### PR TITLE
Fix table printing to handle unicode

### DIFF
--- a/globus_cli/helpers/printing.py
+++ b/globus_cli/helpers/printing.py
@@ -49,17 +49,23 @@ def print_table(iterable, headers_and_keys, print_headers=True):
     # the same order as the headers_and_keys array
     # use a special function to handle empty iterable
     def get_max_colwidth(kf):
-        lengths = [len(str(kf(i))) for i in iterable]
+        def _safelen(x):
+            try:
+                return len(x)
+            except TypeError:
+                return len(str(x))
+        lengths = [_safelen(kf(i)) for i in iterable]
         if not lengths:
             return 0
         else:
             return max(lengths)
+
     widths = [get_max_colwidth(kf) for kf in keyfuncs]
     # handle the case in which the column header is the widest thing
     widths = [max(w, len(h)) for w, h in zip(widths, headers)]
 
     # create a format string based on column widths
-    format_str = ' | '.join('{:' + str(w) + '}' for w in widths)
+    format_str = six.u(' | '.join('{:' + str(w) + '}' for w in widths))
 
     def none_to_null(val):
         if val is None:


### PR DESCRIPTION
This is not sufficient for us to claim broad unicode support, but rather a patch for something I just encountered.

If there is unicode data in a table we want to print for output, we need to handle two things:
  1. `str(value)` is unsafe, so only do it on types that don't support `__len__` natively
  2. The format string must be unicode in order to format unicode data

I couldn't think of a cleaner way of doing this, but maybe there is one?