### PR TITLE
Update to v0.4.2.0; use TransferClient.task_wait

### DIFF
--- a/globus_cli/services/transfer/task/wait.py
+++ b/globus_cli/services/transfer/task/wait.py
@@ -1,14 +1,10 @@
 import click
 import sys
-import time
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import HiddenOption, common_options, task_id_option
 
 from globus_cli.services.transfer.helpers import get_client
-
-
-_POLLING_INTERVAL_MINIMUM = 0.1
 
 
 @click.command('wait', help='Wait for a Task to complete')
@@ -17,11 +13,8 @@ _POLLING_INTERVAL_MINIMUM = 0.1
 @click.option('--timeout', type=int, metavar='N',
               help=('Wait N seconds. If the Task does not terminate by '
                     'then, exit with status 0'))
-@click.option('--polling-interval', default=1, type=float, show_default=True,
-              help=(('Number of seconds between Task status checks. '
-                     'Can be a fraction of a second in decimal notation, '
-                     'but has a minimum of {0}')
-                    .format(_POLLING_INTERVAL_MINIMUM)))
+@click.option('--polling-interval', default=1, type=int, show_default=True,
+              help='Number of seconds between Task status checks.')
 @click.option('--heartbeat', '-H', is_flag=True,
               help=('Every polling interval, print "." to stdout to '
                     'indicate that task wait is till active'))
@@ -30,10 +23,10 @@ def task_wait(meow, heartbeat, polling_interval, timeout, task_id):
     """
     Executor for `globus transfer task wait`
     """
-    if polling_interval < _POLLING_INTERVAL_MINIMUM:
+    if polling_interval < 1:
         raise click.UsageError(
-            '--polling-interval was less than minimum of {0}'
-            .format(_POLLING_INTERVAL_MINIMUM))
+            '--polling-interval={0} was less than minimum of {1}'
+            .format(polling_interval, 1))
 
     client = get_client()
 
@@ -43,24 +36,10 @@ def task_wait(meow, heartbeat, polling_interval, timeout, task_id):
         else:
             return waited_time >= timeout
 
-    # Tasks start out sleepy
-    if meow:
-        safeprint("""\
-   |\      _,,,---,,_
-   /,`.-'`'    -.  ;-;;,_
-  |,4-  ) )-,_..;\ (  `'-'
- '---''(_/--'  `-'\_)""")
-
-    waited_time = 0
-    while not timed_out(waited_time):
-        if heartbeat:
-            safeprint('.', newline=False)
-            sys.stdout.flush()
-
-        task = client.get_task(task_id)
-
-        status = task['status']
-        if status != 'ACTIVE':
+    def check_completed():
+        completed = client.task_wait(task_id, timeout=1,
+                                     polling_interval=polling_interval)
+        if completed:
             if heartbeat:
                 safeprint('')
             # meowing tasks wake up!
@@ -74,9 +53,25 @@ def task_wait(meow, heartbeat, polling_interval, timeout, task_id):
       {_;/   {_//""")
             sys.exit(1)
 
-        waited_time += polling_interval
-        time.sleep(polling_interval)
+        return completed
 
-    # add a trailing newline to heartbeats
+    # Tasks start out sleepy
+    if meow:
+        safeprint("""\
+   |\      _,,,---,,_
+   /,`.-'`'    -.  ;-;;,_
+  |,4-  ) )-,_..;\ (  `'-'
+ '---''(_/--'  `-'\_)""")
+
+    waited_time = 0
+    while (not timed_out(waited_time) and
+            not check_completed()):
+        if heartbeat:
+            safeprint('.', newline=False)
+            sys.stdout.flush()
+
+        waited_time += polling_interval
+
+    # add a trailing newline to heartbeats if we fail
     if heartbeat:
         safeprint('')

--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -18,7 +18,7 @@
 #       2.4.6.1.2   -- no additional point versions
 #       0.1.0.0     -- no special rules for things like this
 #       1.4.6.0     -- differing major version, obviously wrong
-__version__ = "0.4.0.0"
+__version__ = "0.4.2.0"
 
 # app name to send as part of SDK requests
 app_name = 'Globus CLI v{} - Alpha'.format(__version__)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version=version,
     packages=find_packages(),
     install_requires=[
-        'globus-sdk==0.4.0',
+        'globus-sdk==0.4.2',
         'click>=6.6,<7.0',
         'configobj>=5.0.6,<6.0.0',
         'six>=1.0.0,<2.0.0'


### PR DESCRIPTION
For `globus transfer task wait` use TransferClient.task_wait.
Update to SDK v0.4.2 (current), and change version as appropriate.

Maybe I could have kept these changes separate, but I wasn't sure about when we added `task_wait`.
It didn't seem important to make separate commits.