### PR TITLE
Add --map-http-status Flag

### DIFF
--- a/globus_cli/parsing/command_state.py
+++ b/globus_cli/parsing/command_state.py
@@ -17,6 +17,8 @@ class CommandState(object):
         self.output_format = config.get_output_format() or TEXT_FORMAT
         # default is always False
         self.debug = False
+        # by default, empty dict
+        self.http_status_map = {}
 
     def outformat_is_text(self):
         return self.output_format == TEXT_FORMAT
@@ -55,3 +57,50 @@ def debug_option(f):
     return click.option(
         '--debug', is_flag=True, cls=HiddenOption,
         expose_value=False, callback=callback, is_eager=True)(f)
+
+
+def map_http_status_option(f):
+    exit_stat_set = [0, 1] + range(50, 100)
+
+    def per_val_callback(ctx, value):
+        if value is None:
+            return None
+        state = ctx.ensure_object(CommandState)
+        try:
+            # we may be given a comma-delimited list of values
+            # any cases of empty strings are dropped
+            pairs = [x for x in
+                     (y.strip() for y in value.split(','))
+                     if len(x)]
+            # iterate over those pairs, splitting them on `=` signs
+            for http_stat, exit_stat in (pair.split('=') for pair in pairs):
+                # "parse" as ints
+                http_stat, exit_stat = int(http_stat), int(exit_stat)
+                # force into the desired range
+                if exit_stat not in exit_stat_set:
+                    raise ValueError()
+                # map the status
+                state.http_status_map[http_stat] = exit_stat
+        # two conditions can cause ValueError: split didn't give right number
+        # of args, or results weren't int()-able
+        except ValueError:
+            raise click.UsageError(
+                '--map-http-status must have an argument of the form '
+                '"INT=INT,INT=INT,..." and values of exit codes must be in '
+                '0,1,50-99')
+
+    def callback(ctx, param, value):
+        """
+        Wrap the per-value callback -- multiple=True means that the value is
+        always a tuple of given vals.
+        """
+        for v in value:
+            per_val_callback(ctx, v)
+
+    return click.option(
+        '--map-http-status',
+        help=('Map HTTP statuses to any of these exit codes: 0,1,50-99.'
+              'Given by providing both values separated by an "=", as in '
+              '\'--map-http-status "404=0"\' or '
+              '--map-http-status "404=50,403=51"'),
+        expose_value=False, callback=callback, multiple=True)(f)

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -1,7 +1,8 @@
 import click
 
 from globus_cli.version import get_versions
-from globus_cli.parsing.command_state import format_option, debug_option
+from globus_cli.parsing.command_state import (
+    format_option, debug_option, map_http_status_option)
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
 
 
@@ -80,6 +81,10 @@ def common_options(*args, **kwargs):
         # if the format option is being allowed, it needs to be applied to `f`
         if not kwargs.get('no_format_option'):
             f = format_option(f)
+
+        # if the --map-http-status option is being allowed, ...
+        if not kwargs.get('no_map_http_status_option'):
+            f = map_http_status_option(f)
 
         return f
 


### PR DESCRIPTION
I don't think this is the final version of the flag, or the last word on this by any means, but it's a good first cut.
Supports fairly "robust" parsing in the form of multiple instances of the flag and multiple values given to a single instance of the flag (best of both approaches mentioned in #21).

As mentioned in the commit messages, there's a big question about how well the semantics of this will play with auxiliary calls to the services like identity mapping or autoactivation.
Ideally, this would be hooked in more directly on the error or response objects created by the "main" calls of the various CLI commands. However, that will have to wait for a future effort.

Resolves #21 for now