### PR TITLE
Support for new role features in Transfer 5.3

### DIFF
--- a/globus_cli/services/transfer/endpoint/role/create.py
+++ b/globus_cli/services/transfer/endpoint/role/create.py
@@ -20,9 +20,11 @@ from globus_cli.services.transfer.helpers import (
 @click.option('--principal', required=True,
               help=('Entity to set a role on. ID of a Group or Identity, or '
                     'a valid Identity Name, like "go@globusid.org"'))
-@click.option('--role', default='access_manager', show_default=True,
-              type=CaseInsensitiveChoice(('access_manager',)),
-              help='A role to assign. Currently only supports access_manager')
+@click.option('--role', required=True,
+              type=CaseInsensitiveChoice(
+                  ('administrator', 'access_manager', 'activity_manager',
+                   'activity_monitor')),
+              help='A role to assign.')
 def role_create(role, principal, principal_type, endpoint_id):
     """
     Executor for `globus transfer endpoint role show`

--- a/globus_cli/services/transfer/endpoint/search.py
+++ b/globus_cli/services/transfer/endpoint/search.py
@@ -13,9 +13,9 @@ from globus_cli.services.transfer.helpers import (
 @common_options
 @click.option('--filter-scope', default='all', show_default=True,
               type=CaseInsensitiveChoice(
-                  ('all', 'my-endpoints', 'my-gcp-endpoints',
-                   'recently-used', 'in-use', 'shared-by-me',
-                   'shared-with-me')),
+                  ('all', 'administered-by-me', 'my-endpoints',
+                   'my-gcp-endpoints', 'recently-used', 'in-use',
+                   'shared-by-me', 'shared-with-me')),
               help='The set of endpoints to search over.')
 @click.option('--filter-fulltext',
               help='Text filter to apply to the selected set of endpoints')


### PR DESCRIPTION
Adds option support for these new features in the roles expansion in Transfer 5.3:

- the `administered-by-me` endpoint search scope for `globus transfer endpoint search`
- Administrator and activity manager/monitor roles for `globus transfer endpoint role create`. This is a breaking change if a caller was previously depending upon not having to pass `--role=access_manager`, as the `--role` option is now required and has no default.