### PR TITLE
Fix non-batch globus transfer async-delete --path

### DIFF
--- a/globus_cli/services/transfer/async_delete.py
+++ b/globus_cli/services/transfer/async_delete.py
@@ -47,7 +47,7 @@ def async_delete_command(batch, ignore_missing, recursive, path, endpoint_id,
                              recursive=recursive,
                              ignore_missing=ignore_missing)
 
-    if batch is not None:
+    if batch:
         # although this sophisticated structure (like that in async-transfer)
         # isn't strictly necessary, it gives us the ability to add options in
         # the future to these lines with trivial modifications


### PR DESCRIPTION
On the current release, `globus transfer async-delete --path=xxx` does not work, and instead behaves as if the user did `--batch`.

Adjusts the check to be just `if batch` rather than `if batch is not None` since `batch` will be either `True` or `False`, not `None`. This is consistent with the guard check for `batch` at the top of this command's implementation, which is just a truthy/falsey check.