### PR TITLE
Make async-* ops do colon format, show task_id

### DIFF
--- a/globus_cli/services/transfer/async_delete.py
+++ b/globus_cli/services/transfer/async_delete.py
@@ -3,10 +3,10 @@ import click
 from globus_sdk import DeleteData
 
 
-from globus_cli.safeio import safeprint
 from globus_cli.parsing import (
     common_options, endpoint_id_option, submission_id_option)
-from globus_cli.helpers import outformat_is_json, print_json_response
+from globus_cli.helpers import (
+    outformat_is_json, print_json_response, colon_formatted_print)
 
 from globus_cli.services.transfer.helpers import (
     get_client, shlex_process_stdin)
@@ -74,4 +74,5 @@ def async_delete_command(batch, ignore_missing, recursive, path, endpoint_id,
     if outformat_is_json():
         print_json_response(res)
     else:
-        safeprint(res['message'])
+        fields = (('Message', 'message'), ('Task ID', 'task_id'))
+        colon_formatted_print(res, fields)

--- a/globus_cli/services/transfer/async_transfer.py
+++ b/globus_cli/services/transfer/async_transfer.py
@@ -2,10 +2,10 @@ import click
 
 from globus_sdk import TransferData
 
-from globus_cli.safeio import safeprint
 from globus_cli.parsing import (
     CaseInsensitiveChoice, common_options, submission_id_option)
-from globus_cli.helpers import outformat_is_json, print_json_response
+from globus_cli.helpers import (
+    outformat_is_json, print_json_response, colon_formatted_print)
 
 from globus_cli.services.transfer.helpers import (
     get_client, shlex_process_stdin)
@@ -163,4 +163,5 @@ def async_transfer_command(batch, sync_level, recursive, dest_path,
     if outformat_is_json():
         print_json_response(res)
     else:
-        safeprint(res['message'])
+        fields = (('Message', 'message'), ('Task ID', 'task_id'))
+        colon_formatted_print(res, fields)


### PR DESCRIPTION
async-delete and async-transfer were doing raw "message" output.

Instead, use the colon format and show the Task ID for the submitted tasks.
Much better for submitting a task and immediately interacting with it.
Fixes #29