### PR TITLE
[HOLD] Add command aliases as a type of click.Command

### DIFF
--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -2,6 +2,7 @@ from globus_cli.parsing.main_command_decorator import globus_main_func
 
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
 from globus_cli.parsing.hidden_option import HiddenOption
+from globus_cli.parsing.aliases import AliasCommand
 
 from globus_cli.parsing.shared_options import (
     common_options,
@@ -15,6 +16,7 @@ __all__ = [
 
     'CaseInsensitiveChoice',
     'HiddenOption',
+    'AliasCommand',
 
     'common_options',
     # Transfer options

--- a/globus_cli/parsing/aliases.py
+++ b/globus_cli/parsing/aliases.py
@@ -1,0 +1,18 @@
+import click
+
+
+class AliasCommand(click.Command):
+    def __init__(self, alias_name, target_command):
+        self.target_command = target_command
+        super(AliasCommand, self).__init__(
+            name=alias_name,
+            params=target_command.params,
+            help=target_command.help,
+            epilog=target_command.epilog,
+            short_help=target_command.short_help,
+            add_help_option=target_command.add_help_option,
+            callback=target_command.callback,
+            context_settings=target_command.context_settings)
+
+    def invoke(self, ctx):
+        ctx.forward(self.target_command)

--- a/globus_cli/run.py
+++ b/globus_cli/run.py
@@ -1,11 +1,12 @@
-from globus_cli.parsing import globus_main_func
+from globus_cli.parsing import globus_main_func, AliasCommand
 
 from globus_cli.login import login_command
 from globus_cli.list_commands import list_commands
 from globus_cli.config_command import config_command
 
 from globus_cli.services.auth import auth_command
-from globus_cli.services.transfer import transfer_command
+from globus_cli.services.transfer import (
+    transfer_command, endpoint_search, ls_command)
 
 
 @globus_main_func
@@ -18,3 +19,5 @@ main.add_command(transfer_command)
 main.add_command(login_command)
 main.add_command(list_commands)
 main.add_command(config_command)
+main.add_command(AliasCommand('endpoint-search', endpoint_search))
+main.add_command(AliasCommand('endpoint-ls', ls_command))

--- a/globus_cli/services/transfer/__init__.py
+++ b/globus_cli/services/transfer/__init__.py
@@ -1,6 +1,10 @@
 from globus_cli.services.transfer.commands import transfer_command
+from globus_cli.services.transfer.endpoint.commands import endpoint_search
+from globus_cli.services.transfer.ls import ls_command
 
 
 __all__ = [
-    'transfer_command'
+    'transfer_command',
+    'endpoint_search',
+    'ls_command'
 ]


### PR DESCRIPTION
The aliases are constructed in terms of a rename and an existing command object, and assign nearly all of the same attributes to the alias command. The only exception is the name, which is obviously altered in the process.
Importantly, this is a type of `click.Command`, and is not generic enough to safely apply to a `Group` or `MultiCommand` -- the attributes for those types are different, and the passthrough of original command attributes to the new command's constructor will not cover the differences.

The `AliasCommand` importantly inherits the original commands params, so it does not need to blindly forward options as unprocessed values. That saves us from some of the concerns over doing that.

Using this, it was pretty trivial to add
- `globus endpoint-search` -> `globus transfer endpoint search`
- `globus endpoint-ls` -> `globus transfer ls`

Resolves #71
