### PR TITLE
Text output for `globus transfer task show`

### DIFF
--- a/globus_cli/services/transfer/task/show.py
+++ b/globus_cli/services/transfer/task/show.py
@@ -1,9 +1,39 @@
 import click
 
 from globus_cli.parsing import common_options, task_id_option
-from globus_cli.helpers import print_json_response
+from globus_cli.helpers import (
+    outformat_is_json, print_json_response, colon_formatted_print)
 
 from globus_cli.services.transfer.helpers import get_client
+
+
+COMMON_FIELDS = [
+    ('Label', 'label'),
+    ('Task ID', 'task_id'),
+    ('Type', 'type'),
+    ('Directories', 'directories'),
+    ('Files', 'files'),
+    ('Status', 'status'),
+    ('Request Time', 'request_time'),
+]
+
+ACTIVE_FIELDS = [
+    ('Deadline', 'deadline'),
+    ('Details', 'nice_status'),
+]
+
+COMPLETED_FIELDS = [
+    ('Completion Time', 'completion_time'),
+]
+
+DELETE_FIELDS = [
+    ('Endpoint', 'source_endpoint_display_name'),
+]
+
+TRANSFER_FIELDS = [
+    ('Source Endpoint', 'source_endpoint_display_name'),
+    ('Destination Endpoint', 'destination_endpoint_display_name'),
+]
 
 
 @click.command('show', help='Show detailed information about a specific Task')
@@ -17,4 +47,10 @@ def show_task(task_id):
 
     res = client.get_task(task_id)
 
-    print_json_response(res)
+    if outformat_is_json():
+        print_json_response(res)
+    else:
+        fields = COMMON_FIELDS + \
+            (COMPLETED_FIELDS if res['completion_time'] else ACTIVE_FIELDS) + \
+            (DELETE_FIELDS if res['type'] == 'DELETE' else TRANSFER_FIELDS)
+        colon_formatted_print(res, fields)


### PR DESCRIPTION
Adds support for the regular text mode output of a task retrieved via `globus transfer task show`. Fields vary depending on what kind of task it is and whether it is completed or not.

Toward #35.