### PR TITLE
Replace GLOBUS_CLI_DEBUGMODE with --debug

### DIFF
--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -1,3 +1,4 @@
+import logging.config
 import os
 from configobj import ConfigObj
 
@@ -100,3 +101,30 @@ def internal_auth_client():
                               environment=GLOBUS_ENV) or CLIENT_ID
 
     return globus_sdk.NativeAppAuthClient(client_id, app_name=version.app_name)
+
+
+def setup_debug_logging():
+    conf = {
+        'version': 1,
+        'formatters': {
+            'basic': {
+                'format':
+                '[%(levelname)s] %(name)s::%(funcName)s() %(message)s'
+            }
+        },
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'level': 'DEBUG',
+                'formatter': 'basic'
+            }
+        },
+        'loggers': {
+            'globus_sdk': {
+                'level': 'DEBUG',
+                'handlers': ['console']
+            }
+        }
+    }
+
+    logging.config.dictConfig(conf)

--- a/globus_cli/parsing/command_state.py
+++ b/globus_cli/parsing/command_state.py
@@ -2,6 +2,7 @@ import click
 
 from globus_cli import config
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
+from globus_cli.parsing.hidden_option import HiddenOption
 
 
 # Format Enum for output formatting
@@ -14,6 +15,8 @@ class CommandState(object):
     def __init__(self):
         # default is config value, or TEXT if it's not set
         self.output_format = config.get_output_format() or TEXT_FORMAT
+        # default is always False
+        self.debug = False
 
     def outformat_is_text(self):
         return self.output_format == TEXT_FORMAT
@@ -36,3 +39,19 @@ def format_option(f):
         type=CaseInsensitiveChoice([JSON_FORMAT, TEXT_FORMAT]),
         help='Output format for stdout. Defaults to text',
         expose_value=False, callback=callback)(f)
+
+
+def debug_option(f):
+    def callback(ctx, param, value):
+        # copied from click.decorators.version_option
+        # no idea what resilient_parsing means, but...
+        if not value or ctx.resilient_parsing:
+            return
+
+        state = ctx.ensure_object(CommandState)
+        state.debug = True
+        config.setup_debug_logging()
+
+    return click.option(
+        '--debug', is_flag=True, cls=HiddenOption,
+        expose_value=False, callback=callback, is_eager=True)(f)

--- a/globus_cli/parsing/excepthook.py
+++ b/globus_cli/parsing/excepthook.py
@@ -8,12 +8,13 @@ Define an except hook per exception type that we want to treat specially,
 generally types of SDK errors, and dispatch onto tht set of hooks.
 """
 import sys
-import os
 
 import click
 from six import reraise
 
 from globus_sdk import exc
+
+from globus_cli.parsing.command_state import CommandState
 from globus_cli.safeio import safeprint, write_error_info, PrintableErrorField
 
 
@@ -68,7 +69,9 @@ def custom_except_hook(exc_info):
     exception_type, exception, traceback = exc_info
 
     # check if we're in debug mode, and run the real excepthook if we are
-    if os.environ.get('GLOBUS_CLI_DEBUGMODE', None) is not None:
+    ctx = click.get_current_context()
+    state = ctx.ensure_object(CommandState)
+    if state.debug:
         sys.excepthook(exception_type, exception, traceback)
 
     # we're not in debug mode, do custom handling

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.version import get_versions
-from globus_cli.parsing.command_state import format_option
+from globus_cli.parsing.command_state import format_option, debug_option
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
 
 
@@ -74,6 +74,7 @@ def common_options(*args, **kwargs):
         want to dispatch depending on how `common_options` is invoked
         """
         f = version_option(f)
+        f = debug_option(f)
         f = click.help_option('-h', '--help')(f)
 
         # if the format option is being allowed, it needs to be applied to `f`


### PR DESCRIPTION
The `--debug` flag does two things: it sets up debug logging on the SDK, and it sets `CommandState.debug` to `True`.
The excepthook no longer respects the environment variable, leveraging `CommandState.debug` instead.

Resolves #36

Impacts #17 as well -- that should be driven off of `--debug` for the forseeable future.