### PR TITLE
Improve error message for S3 endpoint creation

### DIFF
--- a/globus_cli/services/transfer/endpoint/create.py
+++ b/globus_cli/services/transfer/endpoint/create.py
@@ -35,8 +35,14 @@ def endpoint_create(endpoint_type, display_name, description, organization,
         myproxy_server=myproxy_server, myproxy_dn=myproxy_dn,
         oauth_server=oauth_server)
     if endpoint_type == 's3':
-        raise NotImplementedError(
-            'S3 Endpoints cannot be created through the new CLI yet.')
+        raise click.ClickException(
+            'At this time, S3-backed endpoints can only be created via the '
+            'legacy hosted Globus CLI.\n'
+            '\n'
+            'For more information, see:\n'
+            '- https://docs.globus.org/cli/using-the-cli\n'
+            '- https://docs.globus.org/how-to/amazon-aws-s3-endpoints'
+        )
     elif endpoint_type in ('globus-connect-personal', 'gcp'):
         ep_doc['is_globus_connect'] = True
     elif endpoint_type in ('globus-connect-server', 'gcs'):


### PR DESCRIPTION
With regards to #64...

- we already error on `--endpoint-type=s3`
- the (current) process for setting up an S3 endpoint is relatively involved and requires the legacy CLI
- this it to be replaced with the new S3 DSI at some point soon, so support is unlikely to ever land in Transfer's current REST API

... so, what if we just improve the error message until S3 endpoints can be created natively via the new CLI?

Old:

```
(.venv3) ~/Repos/globus-cli$ globus transfer endpoint create --endpoint-type=s3 --display-name=x
NotImplementedError: S3 Endpoints cannot be created through the new CLI yet.
```

Proposed:

```
(.venv3) ~/Repos/globus-cli$ globus transfer endpoint create --endpoint-type=s3 --display-name=x
Error: At this time, S3-backed endpoints can only be created via the legacy
hosted Globus CLI.

For more information, see:
- https://docs.globus.org/cli/using-the-cli
- https://docs.globus.org/how-to/amazon-aws-s3-endpoints
```