### PR TITLE
Introduce `globus transfer bookmark locate`

### DIFF
--- a/globus_cli/services/transfer/bookmark/commands.py
+++ b/globus_cli/services/transfer/bookmark/commands.py
@@ -7,6 +7,7 @@ from globus_cli.services.transfer.bookmark.create import bookmark_create
 from globus_cli.services.transfer.bookmark.delete import bookmark_delete
 from globus_cli.services.transfer.bookmark.rename import bookmark_rename
 from globus_cli.services.transfer.bookmark.show import bookmark_show
+from globus_cli.services.transfer.bookmark.locate import bookmark_locate
 
 
 @click.group(name='bookmark', help='Manage Endpoint Bookmarks')
@@ -20,3 +21,4 @@ bookmark_command.add_command(bookmark_create)
 bookmark_command.add_command(bookmark_delete)
 bookmark_command.add_command(bookmark_rename)
 bookmark_command.add_command(bookmark_show)
+bookmark_command.add_command(bookmark_locate)

--- a/globus_cli/services/transfer/bookmark/locate.py
+++ b/globus_cli/services/transfer/bookmark/locate.py
@@ -1,0 +1,49 @@
+from uuid import UUID
+
+import click
+
+from globus_sdk.exc import TransferAPIError
+from globus_cli.safeio import safeprint
+from globus_cli.parsing import common_options
+from globus_cli.services.transfer.helpers import get_client
+
+
+@click.command('locate', help='Output <UUID>:<path> of a bookmark; useful in '
+                              'a subshell as input to another command')
+@common_options
+@click.argument('bookmark_id_or_name', required=True)
+def bookmark_locate(bookmark_id_or_name):
+    """
+    Executor for `globus transfer bookmark locate`
+    """
+
+    client = get_client()
+
+    # leading/trailing whitespace doesn't make sense for UUIDs and the Transfer
+    # service outright forbids it for bookmark names, so we can strip it off
+    bookmark_id_or_name = bookmark_id_or_name.strip()
+
+    try:
+        UUID(bookmark_id_or_name)  # raises ValueError if argument not a UUID
+        res = client.get_bookmark(bookmark_id_or_name.lower())
+
+    except (ValueError, TransferAPIError) as ex:
+        if isinstance(ex, TransferAPIError) and ex.code != 'BookmarkNotFound':
+            raise
+
+        # either the user provided a string that isn't a UUID (ValueError) or
+        # the provided UUID doesn't identity a bookmark (TransferAPIError with
+        # code='BookmarkNotFound'); fallback to matching a bookmark by name
+
+        try:
+            # n.b. case matters to the Transfer service for bookmark names, so
+            # two bookmarks can exist whose names vary only by their case
+            res = next(bookmark_row for bookmark_row in client.bookmark_list()
+                       if bookmark_row['name'] == bookmark_id_or_name)
+
+        except StopIteration:
+            safeprint('No bookmark found for "{}"'.format(bookmark_id_or_name),
+                      write_to_stderr=True)
+            click.get_current_context().exit(1)
+
+    print('{}:{}'.format(res['endpoint_id'], res['path']))


### PR DESCRIPTION
This is sort of what I'm thinking for #74.

Notes/questions:

- I arbitrarily did this as a special-case option rather than a `--format` switch (which is an "open question" in #74) only because I think the syntax for subshells is already noisy enough and I think it will be easier to look at when used in practice
- I went ahead and implemented this new command using our new proposed positional argument style instead of requiring the user to type `--bookmark-id`/`--id` or `--name`, so this is one possible pattern for handling that ambiguity, but I'm not wedded to it
- given the use case for this, I really want a non-zero status code for this if it fails, so
  - is `click.get_current_context().exit(1)` best practice from our commands when we willfully want to exit with a non-zero status code?
  - when an uncaught exception happens, e.g. an internal server error from Transfer, a zero status code seems to be returned... why is this?
- do we need to do any special quoting, e.g. for a path that includes spaces? (I *think* the answer is "no", assuming that people quote properly, like `globus transfer ls "$(globus transfer bookmark locate 'My Bookmark')"`)

Closes #74 