### PR TITLE
Implement EndpointPlusPath Type, apply it in all "easy" scenarios, enforce Endpoint IDs being UUIDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - globus --help  # parsing failures
   - globus list-commands  # actually running a command
   - globus auth get-identities 'abc@globus.org' --map-http-status "401=0"  # auth call (noauth)
-  - globus transfer ls --endpoint-id 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' --map-http-status "400=0"  # transfer call (noauth)
+  - globus transfer ls 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' --map-http-status "400=0"  # transfer call (noauth)

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -1,12 +1,13 @@
 from globus_cli.parsing.main_command_decorator import globus_main_func
 
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
-from globus_cli.parsing.endpoint_plus_path import EndpointPlusPath
+from globus_cli.parsing.endpoint_plus_path import (
+    EndpointPlusPath, ENDPOINT_PLUS_OPTPATH, ENDPOINT_PLUS_REQPATH)
 from globus_cli.parsing.hidden_option import HiddenOption
 
 from globus_cli.parsing.shared_options import (
     common_options,
-    endpoint_id_option, task_id_option, submission_id_option,
+    endpoint_id_arg, task_id_option, submission_id_option,
     endpoint_create_and_update_opts, role_id_option,
     server_id_option, server_add_and_update_opts)
 
@@ -15,12 +16,12 @@ __all__ = [
     'globus_main_func',
 
     'CaseInsensitiveChoice',
-    'EndpointPlusPath',
+    'EndpointPlusPath', 'ENDPOINT_PLUS_OPTPATH', 'ENDPOINT_PLUS_REQPATH',
     'HiddenOption',
 
     'common_options',
     # Transfer options
-    'endpoint_id_option', 'task_id_option', 'submission_id_option',
+    'endpoint_id_arg', 'task_id_option', 'submission_id_option',
     'endpoint_create_and_update_opts', 'role_id_option',
     'server_id_option', 'server_add_and_update_opts',
 ]

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -1,6 +1,7 @@
 from globus_cli.parsing.main_command_decorator import globus_main_func
 
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
+from globus_cli.parsing.endpoint_plus_path import EndpointPlusPath
 from globus_cli.parsing.hidden_option import HiddenOption
 
 from globus_cli.parsing.shared_options import (
@@ -14,6 +15,7 @@ __all__ = [
     'globus_main_func',
 
     'CaseInsensitiveChoice',
+    'EndpointPlusPath',
     'HiddenOption',
 
     'common_options',

--- a/globus_cli/parsing/endpoint_plus_path.py
+++ b/globus_cli/parsing/endpoint_plus_path.py
@@ -47,7 +47,7 @@ class EndpointPlusPath(click.ParamType):
         # split the value on the first colon, leave the rest intact
         splitval = value.split(':', 1)
         # first element is the endpoint_id
-        endpoint_id = splitval[0]
+        endpoint_id = click.UUID(splitval[0])
 
         # get the second element, defaulting to `None` if there was no colon in
         # the original value
@@ -63,3 +63,7 @@ class EndpointPlusPath(click.ParamType):
             self.fail('The path component is required', param=param)
 
         return (endpoint_id, path)
+
+
+ENDPOINT_PLUS_OPTPATH = EndpointPlusPath(path_required=False)
+ENDPOINT_PLUS_REQPATH = EndpointPlusPath(path_required=True)

--- a/globus_cli/parsing/endpoint_plus_path.py
+++ b/globus_cli/parsing/endpoint_plus_path.py
@@ -1,0 +1,65 @@
+import click
+
+
+class EndpointPlusPath(click.ParamType):
+    """
+    Custom type for "<endpoint_id>:<path>"
+    Supports path being required and path being optional.
+
+    Always produces a Tuple.
+    """
+    name = 'endpoint plus path'
+
+    def __init__(self, *args, **kwargs):
+        # path requirement defaults to True, but can be tweaked by a kwarg
+        self.path_required = kwargs.pop('path_required', True)
+
+        super(EndpointPlusPath, self).__init__(*args, **kwargs)
+
+    def get_metavar(self, param):
+        """
+        Default metavar for this instance of the type.
+        """
+        return self.metavar
+
+    @property
+    def metavar(self):
+        """
+        Metavar as a property, to satisfy the slight brokenness of
+        click.Argument
+        Tracked against Click as an issue:
+        https://github.com/pallets/click/issues/674
+        """
+        if self.path_required:
+            return "ENDPOINT_ID:PATH"
+        else:
+            return "ENDPOINT_ID[:PATH]"
+
+    def convert(self, value, param, ctx):
+        """
+        ParamType.convert() is the actual processing method that takes a
+        provided parameter and parses it.
+        """
+        # passthrough conditions: None or already processed
+        if value is None or isinstance(value, tuple):
+            return value
+
+        # split the value on the first colon, leave the rest intact
+        splitval = value.split(':', 1)
+        # first element is the endpoint_id
+        endpoint_id = splitval[0]
+
+        # get the second element, defaulting to `None` if there was no colon in
+        # the original value
+        try:
+            path = splitval[1]
+        except IndexError:
+            path = None
+        # coerce path="" to path=None
+        # means that we treat "enpdoint_id" and "endpoint_id:" equivalently
+        path = path or None
+
+        if path is None and self.path_required:
+            self.fail('The path component is required', param=param)
+
+        return (endpoint_id, path)

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -99,8 +99,7 @@ def common_options(*args, **kwargs):
     # will probably confuse someone in the future when their arguments are
     # silently discarded
     elif len(args) != 0:
-        raise ValueError(
-            'common_options() cannot take positional args')
+        raise ValueError('common_options() cannot take positional args')
 
     # final case: got 0 or more kwargs, no positionals
     # do the function-which-returns-a-decorator dance to produce a
@@ -111,21 +110,22 @@ def common_options(*args, **kwargs):
         return inner_decorator
 
 
-def endpoint_id_option(*args, **kwargs):
+def endpoint_id_arg(*args, **kwargs):
     """
-    This is the `--endpoint-id` option consumed by many Transfer endpoint
-    related operations. It accepts variable helptext, but can also be applied
-    as a direct decorator.
+    This is the `ENDPOINT_ID` argument consumed by many Transfer endpoint
+    related operations. It accepts alternate metavars for cases when another
+    name is desirable (e.x. `SHARE_ID`, `HOST_ENDPOINT_ID`), but can also be
+    applied as a direct decorator if no specialized metavar is being passed.
 
     Usage:
 
-    >>> @endpoint_id_option
+    >>> @endpoint_id_arg
     >>> def command_func(endpoint_id):
     >>>     ...
 
     or
 
-    >>> @endpoint_id_option(help='ID of the Share')
+    >>> @endpoint_id_arg(metavar='HOST_ENDPOINT_ID')
     >>> def command_func(endpoint_id):
     >>>     ...
     """
@@ -134,8 +134,8 @@ def endpoint_id_option(*args, **kwargs):
         Work of actually decorating a function -- wrapped in here because we
         want to dispatch depending on how this is invoked
         """
-        help = kwargs.get('help', 'ID of the Endpoint')
-        f = click.option('--endpoint-id', required=True, help=help)(f)
+        metavar = kwargs.get('metavar', 'ENDPOINT_ID')
+        f = click.argument('endpoint_id', metavar=metavar, type=click.UUID)(f)
         return f
 
     # special behavior when invoked with only one non-keyword argument: act as
@@ -149,8 +149,7 @@ def endpoint_id_option(*args, **kwargs):
     # will probably confuse someone in the future when their arguments are
     # silently discarded
     elif len(args) != 0:
-        raise ValueError(
-            'endpoint_id_option() cannot take positional args')
+        raise ValueError('endpoint_id_arg() cannot take positional args')
 
     # final case: got 0 or more kwargs, no positionals
     # do the function-which-returns-a-decorator dance to produce a

--- a/globus_cli/services/transfer/async_delete.py
+++ b/globus_cli/services/transfer/async_delete.py
@@ -4,15 +4,13 @@ from globus_sdk import DeleteData
 
 
 from globus_cli.parsing import (
-    common_options, submission_id_option, EndpointPlusPath)
+    common_options, submission_id_option, ENDPOINT_PLUS_OPTPATH)
 from globus_cli.helpers import (
     outformat_is_json, print_json_response, colon_formatted_print)
 
 from globus_cli.services.transfer.helpers import (
     get_client, shlex_process_stdin)
 from globus_cli.services.transfer.activation import autoactivate
-
-path_type = EndpointPlusPath(path_required=False)
 
 
 @click.command('async-delete', short_help='Submit a Delete Task',
@@ -28,8 +26,8 @@ path_type = EndpointPlusPath(path_required=False)
               help=('Accept a batch of paths on stdin (i.e. run in '
                     'batchmode). Uses ENDPOINT_ID as passed on the '
                     'commandline, and includes any commandline PATH given'))
-@click.argument('endpoint_plus_path', metavar=path_type.metavar,
-                type=path_type)
+@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
+                type=ENDPOINT_PLUS_OPTPATH)
 def async_delete_command(batch, ignore_missing, recursive, endpoint_plus_path,
                          label, submission_id):
     """

--- a/globus_cli/services/transfer/async_delete.py
+++ b/globus_cli/services/transfer/async_delete.py
@@ -4,7 +4,7 @@ from globus_sdk import DeleteData
 
 
 from globus_cli.parsing import (
-    common_options, endpoint_id_option, submission_id_option)
+    common_options, submission_id_option, EndpointPlusPath)
 from globus_cli.helpers import (
     outformat_is_json, print_json_response, colon_formatted_print)
 
@@ -12,33 +12,33 @@ from globus_cli.services.transfer.helpers import (
     get_client, shlex_process_stdin)
 from globus_cli.services.transfer.activation import autoactivate
 
+path_type = EndpointPlusPath(path_required=False)
+
 
 @click.command('async-delete', short_help='Submit a Delete Task',
                help=('Delete a file or directory from one Endpoint as an '
                      'asynchronous task.'))
 @common_options
 @submission_id_option
-@endpoint_id_option(help='ID of the Endpoint from which to delete file(s)')
-@click.option('--path', help='Path to the file/dir to delete')
 @click.option('--recursive', is_flag=True, help='Recursively delete dirs')
 @click.option('--label', default=None, help=('Set a label for this task'))
 @click.option('--ignore-missing', is_flag=True,
               help="Don't throw errors if the file or dir is absent")
 @click.option('--batch', is_flag=True,
               help=('Accept a batch of paths on stdin (i.e. run in '
-                    'batchmode). Uses --endpoint-id as passed on the '
-                    'commandline.'))
-def async_delete_command(batch, ignore_missing, recursive, path, endpoint_id,
+                    'batchmode). Uses ENDPOINT_ID as passed on the '
+                    'commandline, and includes any commandline PATH given'))
+@click.argument('endpoint_plus_path', metavar=path_type.metavar,
+                type=path_type)
+def async_delete_command(batch, ignore_missing, recursive, endpoint_plus_path,
                          label, submission_id):
     """
     Executor for `globus transfer async-delete`
     """
+    endpoint_id, path = endpoint_plus_path
     if path is None and (not batch):
         raise click.UsageError(
-            'async-delete requires either --path OR --batch')
-    if path is not None and batch:
-        raise click.UsageError(
-            'async-delete cannot take --batch in addition to --path')
+            'async-delete requires either a PATH OR --batch')
 
     client = get_client()
     autoactivate(client, endpoint_id, if_expires_in=60)
@@ -47,6 +47,9 @@ def async_delete_command(batch, ignore_missing, recursive, path, endpoint_id,
                              label=label,
                              recursive=recursive,
                              ignore_missing=ignore_missing)
+
+    if path:
+        delete_data.add_item(path)
 
     if batch:
         # although this sophisticated structure (like that in async-transfer)
@@ -63,9 +66,6 @@ def async_delete_command(batch, ignore_missing, recursive, path, endpoint_id,
 
         shlex_process_stdin(
             process_batch_line, 'Enter paths to delete, line by line.')
-
-    else:
-        delete_data.add_item(path)
 
     if submission_id is not None:
         delete_data['submission_id'] = submission_id

--- a/globus_cli/services/transfer/async_transfer.py
+++ b/globus_cli/services/transfer/async_transfer.py
@@ -4,7 +4,7 @@ from globus_sdk import TransferData
 
 from globus_cli.parsing import (
     CaseInsensitiveChoice, common_options, submission_id_option,
-    EndpointPlusPath)
+    ENDPOINT_PLUS_OPTPATH)
 from globus_cli.helpers import (
     outformat_is_json, print_json_response, colon_formatted_print)
 
@@ -116,9 +116,9 @@ from globus_cli.services.transfer.activation import autoactivate
                     'Uses SOURCE_ENDPOINT_ID and DEST_ENDPOINT_ID as passed '
                     'on the commandline.'))
 @click.argument('source', metavar='SOURCE_ENDPOINT_ID[:SOURCE_PATH]',
-                type=EndpointPlusPath(path_required=False))
+                type=ENDPOINT_PLUS_OPTPATH)
 @click.argument('destination', metavar='DEST_ENDPOINT_ID[:DEST_PATH]',
-                type=EndpointPlusPath(path_required=False))
+                type=ENDPOINT_PLUS_OPTPATH)
 def async_transfer_command(batch, sync_level, recursive, destination, source,
                            label, preserve_mtime, verify_checksum, encrypt,
                            submission_id):

--- a/globus_cli/services/transfer/async_transfer.py
+++ b/globus_cli/services/transfer/async_transfer.py
@@ -3,7 +3,8 @@ import click
 from globus_sdk import TransferData
 
 from globus_cli.parsing import (
-    CaseInsensitiveChoice, common_options, submission_id_option)
+    CaseInsensitiveChoice, common_options, submission_id_option,
+    EndpointPlusPath)
 from globus_cli.helpers import (
     outformat_is_json, print_json_response, colon_formatted_print)
 
@@ -28,7 +29,7 @@ from globus_cli.services.transfer.activation import autoactivate
     Single-item has behavior similar to `cp` and `cp -r`, across endpoints of
     course.
 
-    It is the behavior you get if you use `--source-path` and `--dest-path`.
+    It is the behavior you get if you use `SOURCE_PATH` and `DEST_PATH`.
 
     ---
 
@@ -62,6 +63,9 @@ from globus_cli.services.transfer.activation import autoactivate
             --batch --sync-level checksum \\
             --source-endpoint "..." --dest-endpoint "..."
 
+    You can use `--batch` in addition to a single SOURCE_PATH, DEST_PATH pair
+    given in the commandline.
+
     \b
     Sync Levels
     ===
@@ -90,16 +94,6 @@ from globus_cli.services.transfer.activation import autoactivate
     """))
 @common_options
 @submission_id_option
-@click.option('--source-endpoint', required=True,
-              help='ID of the Endpoint from which to transfer')
-@click.option('--dest-endpoint', required=True,
-              help='ID of the Endpoint to which to transfer')
-@click.option('--source-path',
-              help=('Path to the file/dir to move on source-endpoint in '
-                    'single-item mode'))
-@click.option('--dest-path',
-              help=('Desired location of the file/dir on dest-endpoint in '
-                    'single-item mode'))
 @click.option('--recursive', is_flag=True,
               help=('source-path and dest-path are both directories, do a '
                     'recursive dir transfer. Ignored in batchmode'))
@@ -119,24 +113,25 @@ from globus_cli.services.transfer.activation import autoactivate
 @click.option('--batch', is_flag=True,
               help=('Accept a batch of source/dest path pairs on stdin (i.e. '
                     'run in batchmode). '
-                    'Uses --source-endpoint and --dest-endpoint as passed on '
-                    'the commandline.'))
-def async_transfer_command(batch, sync_level, recursive, dest_path,
-                           source_path, dest_endpoint, source_endpoint,
+                    'Uses SOURCE_ENDPOINT_ID and DEST_ENDPOINT_ID as passed '
+                    'on the commandline.'))
+@click.argument('source', metavar='SOURCE_ENDPOINT_ID[:SOURCE_PATH]',
+                type=EndpointPlusPath(path_required=False))
+@click.argument('destination', metavar='DEST_ENDPOINT_ID[:DEST_PATH]',
+                type=EndpointPlusPath(path_required=False))
+def async_transfer_command(batch, sync_level, recursive, destination, source,
                            label, preserve_mtime, verify_checksum, encrypt,
                            submission_id):
     """
     Executor for `globus transfer async-transfer`
     """
+    source_endpoint, source_path = source
+    dest_endpoint, dest_path = destination
+
     if (source_path is None or dest_path is None) and (not batch):
         raise click.UsageError(
-            ('async-transfer requires either --source-path and --dest-path OR '
+            ('async-transfer requires either SOURCE_PATH and DEST_PATH or '
              '--batch'))
-    if ((source_path is not None and batch) or
-            (dest_path is not None and batch)):
-        raise click.UsageError(
-            ('async-transfer cannot take --batch in addition to --source-path '
-             'or --dest-path'))
 
     client = get_client()
     transfer_data = TransferData(
@@ -144,6 +139,9 @@ def async_transfer_command(batch, sync_level, recursive, dest_path,
         label=label, sync_level=sync_level, verify_checksum=verify_checksum,
         preserve_timestamp=preserve_mtime, encrypt_data=encrypt)
 
+    if source_path and dest_path:
+        transfer_data.add_item(source_path, dest_path,
+                               recursive=recursive)
     if batch:
         @click.command()
         @click.option('--recursive', is_flag=True)
@@ -161,9 +159,6 @@ def async_transfer_command(batch, sync_level, recursive, dest_path,
             process_batch_line,
             ('Enter transfers, line by line, as\n\n'
              '    [--recursive] source-path dest-path\n'))
-    else:
-        transfer_data.add_item(source_path, dest_path,
-                               recursive=recursive)
 
     if submission_id is not None:
         transfer_data['submission_id'] = submission_id

--- a/globus_cli/services/transfer/bookmark/create.py
+++ b/globus_cli/services/transfer/bookmark/create.py
@@ -21,7 +21,7 @@ def bookmark_create(name, endpoint_plus_path):
     client = get_client()
 
     submit_data = {
-        'endpoint_id': endpoint_id,
+        'endpoint_id': str(endpoint_id),
         'path': path,
         'name': name
     }

--- a/globus_cli/services/transfer/bookmark/create.py
+++ b/globus_cli/services/transfer/bookmark/create.py
@@ -1,24 +1,25 @@
 import click
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options
+from globus_cli.parsing import common_options, EndpointPlusPath
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
 
+path_type = EndpointPlusPath()
+
 
 @click.command('create', help='Create a Bookmark for the current user')
 @common_options
-@click.option('--endpoint-id', required=True,
-              help='ID of the endpoint on which to add a Bookmark')
-@click.option('--path', required=True,
-              help='Path on the endpoint for the Bookmark')
 @click.option('--name', required=True,
               help='Name for the Bookmark')
-def bookmark_create(name, path, endpoint_id):
+@click.argument('endpoint_plus_path', required=True,
+                metavar=path_type.metavar, type=path_type)
+def bookmark_create(name, endpoint_plus_path):
     """
     Executor for `globus transfer bookmark create`
     """
+    endpoint_id, path = endpoint_plus_path
     client = get_client()
 
     submit_data = {

--- a/globus_cli/services/transfer/bookmark/create.py
+++ b/globus_cli/services/transfer/bookmark/create.py
@@ -1,20 +1,18 @@
 import click
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options, EndpointPlusPath
+from globus_cli.parsing import common_options, ENDPOINT_PLUS_REQPATH
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
-
-path_type = EndpointPlusPath()
 
 
 @click.command('create', help='Create a Bookmark for the current user')
 @common_options
 @click.option('--name', required=True,
               help='Name for the Bookmark')
-@click.argument('endpoint_plus_path', required=True,
-                metavar=path_type.metavar, type=path_type)
+@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_REQPATH.metavar,
+                type=ENDPOINT_PLUS_REQPATH)
 def bookmark_create(name, endpoint_plus_path):
     """
     Executor for `globus transfer bookmark create`

--- a/globus_cli/services/transfer/endpoint/acl/add_rule.py
+++ b/globus_cli/services/transfer/endpoint/acl/add_rule.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.parsing import (
-    CaseInsensitiveChoice, common_options, ENDPOINT_PLUS_OPTPATH)
+    CaseInsensitiveChoice, common_options, ENDPOINT_PLUS_REQPATH)
 from globus_cli.helpers import print_json_response
 
 from globus_cli.services.auth import maybe_lookup_identity_id
@@ -23,8 +23,8 @@ from globus_cli.services.transfer.helpers import (
               type=CaseInsensitiveChoice(('identity', 'group', 'anonymous',
                                           'all_authenticated_users')),
               help='Principal type to grant permissions to')
-@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
-                type=ENDPOINT_PLUS_OPTPATH)
+@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_REQPATH.metavar,
+                type=ENDPOINT_PLUS_REQPATH)
 def add_acl_rule(principal_type, principal, permissions, endpoint_plus_path):
     """
     Executor for `globus transfer acl add-rule`

--- a/globus_cli/services/transfer/endpoint/acl/add_rule.py
+++ b/globus_cli/services/transfer/endpoint/acl/add_rule.py
@@ -1,15 +1,13 @@
 import click
 
 from globus_cli.parsing import (
-    CaseInsensitiveChoice, common_options, EndpointPlusPath)
+    CaseInsensitiveChoice, common_options, ENDPOINT_PLUS_OPTPATH)
 from globus_cli.helpers import print_json_response
 
 from globus_cli.services.auth import maybe_lookup_identity_id
 
 from globus_cli.services.transfer.helpers import (
     get_client, assemble_generic_doc)
-
-path_type = EndpointPlusPath(path_required=False)
 
 
 @click.command('add-rule', help='Add an ACL rule')
@@ -25,8 +23,8 @@ path_type = EndpointPlusPath(path_required=False)
               type=CaseInsensitiveChoice(('identity', 'group', 'anonymous',
                                           'all_authenticated_users')),
               help='Principal type to grant permissions to')
-@click.argument('endpoint_plus_path', metavar=path_type.metavar,
-                type=path_type)
+@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
+                type=ENDPOINT_PLUS_OPTPATH)
 def add_acl_rule(principal_type, principal, permissions, endpoint_plus_path):
     """
     Executor for `globus transfer acl add-rule`

--- a/globus_cli/services/transfer/endpoint/acl/add_rule.py
+++ b/globus_cli/services/transfer/endpoint/acl/add_rule.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.parsing import (
-    CaseInsensitiveChoice, common_options, endpoint_id_option)
+    CaseInsensitiveChoice, common_options, EndpointPlusPath)
 from globus_cli.helpers import print_json_response
 
 from globus_cli.services.auth import maybe_lookup_identity_id
@@ -9,10 +9,11 @@ from globus_cli.services.auth import maybe_lookup_identity_id
 from globus_cli.services.transfer.helpers import (
     get_client, assemble_generic_doc)
 
+path_type = EndpointPlusPath(path_required=False)
+
 
 @click.command('add-rule', help='Add an ACL rule')
 @common_options
-@endpoint_id_option
 @click.option('--permissions', required=True,
               type=CaseInsensitiveChoice(('r', 'rw')),
               help='Permissions to add. Read-Only or Read/Write')
@@ -24,12 +25,13 @@ from globus_cli.services.transfer.helpers import (
               type=CaseInsensitiveChoice(('identity', 'group', 'anonymous',
                                           'all_authenticated_users')),
               help='Principal type to grant permissions to')
-@click.option('--path', required=True,
-              help='Path on which the rule grants permissions')
-def add_acl_rule(path, principal_type, principal, permissions, endpoint_id):
+@click.argument('endpoint_plus_path', metavar=path_type.metavar,
+                type=path_type)
+def add_acl_rule(principal_type, principal, permissions, endpoint_plus_path):
     """
     Executor for `globus transfer acl add-rule`
     """
+    endpoint_id, path = endpoint_plus_path
     client = get_client()
 
     if principal_type == 'identity':

--- a/globus_cli/services/transfer/endpoint/acl/del_rule.py
+++ b/globus_cli/services/transfer/endpoint/acl/del_rule.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
@@ -8,7 +8,7 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('del-rule', help='Remove an ACL rule')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 @click.option('--rule-id', required=True, help='ID of the rule to display')
 def del_acl_rule(rule_id, endpoint_id):
     """

--- a/globus_cli/services/transfer/endpoint/acl/list.py
+++ b/globus_cli/services/transfer/endpoint/acl/list.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import (
     outformat_is_json, print_table, print_json_response)
 from globus_cli.services.auth import lookup_identity_name
@@ -9,7 +9,7 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('list', help='List of Access Control List rules on an Endpoint')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 def acl_list(endpoint_id):
     """
     Executor for `globus transfer acl list`

--- a/globus_cli/services/transfer/endpoint/acl/update_rule.py
+++ b/globus_cli/services/transfer/endpoint/acl/update_rule.py
@@ -1,45 +1,26 @@
 import click
 
 from globus_cli.parsing import (
-    CaseInsensitiveChoice, common_options, ENDPOINT_PLUS_OPTPATH)
+    CaseInsensitiveChoice, common_options, endpoint_id_arg)
 from globus_cli.helpers import print_json_response
-
-from globus_cli.services.auth import maybe_lookup_identity_id
 
 from globus_cli.services.transfer.helpers import (
     get_client, assemble_generic_doc)
 
 
 @click.command('update-rule', help='Update an ACL rule')
+@endpoint_id_arg
 @common_options
 @click.option('--rule-id', required=True, help='ID of the rule to modify')
 @click.option('--permissions', required=True,
               type=CaseInsensitiveChoice(('r', 'rw')),
               help='Permissions to add. Read-Only or Read/Write')
-@click.option('--principal', required=True,
-              help=('Principal to grant permissions to. ID of a Group or '
-                    'Identity, or a valid Identity Name, like '
-                    '"go@globusid.org"'))
-@click.option('--principal-type', required=True,
-              type=CaseInsensitiveChoice(('identity', 'group', 'anonymous',
-                                          'all_authenticated_users')),
-              help='Principal type to grant permissions to')
-@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
-                type=ENDPOINT_PLUS_OPTPATH)
-def update_acl_rule(principal_type, principal, permissions, rule_id,
-                    endpoint_plus_path):
+def update_acl_rule(permissions, rule_id, endpoint_id):
     """
     Executor for `globus transfer access update-acl-rule`
     """
-    endpoint_id, path = endpoint_plus_path
     client = get_client()
 
-    rule_data = assemble_generic_doc(
-        'access', permissions=permissions,
-        principal=maybe_lookup_identity_id(principal),
-        principal_type=principal_type, path=path)
-
-    res = client.update_endpoint_acl_rule(endpoint_id, rule_id,
-                                          rule_data)
-
+    rule_data = assemble_generic_doc('access', permissions=permissions)
+    res = client.update_endpoint_acl_rule(endpoint_id, rule_id, rule_data)
     print_json_response(res)

--- a/globus_cli/services/transfer/endpoint/acl/update_rule.py
+++ b/globus_cli/services/transfer/endpoint/acl/update_rule.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.parsing import (
-    CaseInsensitiveChoice, common_options, endpoint_id_option)
+    CaseInsensitiveChoice, common_options, EndpointPlusPath)
 from globus_cli.helpers import print_json_response
 
 from globus_cli.services.auth import maybe_lookup_identity_id
@@ -9,10 +9,11 @@ from globus_cli.services.auth import maybe_lookup_identity_id
 from globus_cli.services.transfer.helpers import (
     get_client, assemble_generic_doc)
 
+path_type = EndpointPlusPath(path_required=False)
+
 
 @click.command('update-rule', help='Update an ACL rule')
 @common_options
-@endpoint_id_option
 @click.option('--rule-id', required=True, help='ID of the rule to modify')
 @click.option('--permissions', required=True,
               type=CaseInsensitiveChoice(('r', 'rw')),
@@ -25,13 +26,14 @@ from globus_cli.services.transfer.helpers import (
               type=CaseInsensitiveChoice(('identity', 'group', 'anonymous',
                                           'all_authenticated_users')),
               help='Principal type to grant permissions to')
-@click.option('--path', required=True,
-              help='Path on which the rule grants permissions')
-def update_acl_rule(path, principal_type, principal, permissions,
-                    rule_id, endpoint_id):
+@click.argument('endpoint_plus_path', metavar=path_type.metavar,
+                type=path_type)
+def update_acl_rule(principal_type, principal, permissions, rule_id,
+                    endpoint_plus_path):
     """
     Executor for `globus transfer access update-acl-rule`
     """
+    endpoint_id, path = endpoint_plus_path
     client = get_client()
 
     rule_data = assemble_generic_doc(

--- a/globus_cli/services/transfer/endpoint/acl/update_rule.py
+++ b/globus_cli/services/transfer/endpoint/acl/update_rule.py
@@ -1,15 +1,13 @@
 import click
 
 from globus_cli.parsing import (
-    CaseInsensitiveChoice, common_options, EndpointPlusPath)
+    CaseInsensitiveChoice, common_options, ENDPOINT_PLUS_OPTPATH)
 from globus_cli.helpers import print_json_response
 
 from globus_cli.services.auth import maybe_lookup_identity_id
 
 from globus_cli.services.transfer.helpers import (
     get_client, assemble_generic_doc)
-
-path_type = EndpointPlusPath(path_required=False)
 
 
 @click.command('update-rule', help='Update an ACL rule')
@@ -26,8 +24,8 @@ path_type = EndpointPlusPath(path_required=False)
               type=CaseInsensitiveChoice(('identity', 'group', 'anonymous',
                                           'all_authenticated_users')),
               help='Principal type to grant permissions to')
-@click.argument('endpoint_plus_path', metavar=path_type.metavar,
-                type=path_type)
+@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
+                type=ENDPOINT_PLUS_OPTPATH)
 def update_acl_rule(principal_type, principal, permissions, rule_id,
                     endpoint_plus_path):
     """

--- a/globus_cli/services/transfer/endpoint/autoactivate.py
+++ b/globus_cli/services/transfer/endpoint/autoactivate.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import print_json_response
 
 from globus_cli.services.transfer.activation import autoactivate
@@ -9,7 +9,7 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('autoactivate', help='Activate an Endpoint via autoactivation')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 def endpoint_autoactivate(endpoint_id):
     """
     Executor for `globus transfer endpoint autoactivate`

--- a/globus_cli/services/transfer/endpoint/deactivate.py
+++ b/globus_cli/services/transfer/endpoint/deactivate.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
@@ -8,7 +8,7 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('deactivate', help='Deactivate an Endpoint')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 def endpoint_deactivate(endpoint_id):
     """
     Executor for `globus transfer endpoint deactivate`

--- a/globus_cli/services/transfer/endpoint/delete.py
+++ b/globus_cli/services/transfer/endpoint/delete.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
@@ -9,7 +9,7 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('delete', help='Delete a given Endpoint')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 def endpoint_delete(endpoint_id):
     """
     Executor for `globus transfer endpoint delete`

--- a/globus_cli/services/transfer/endpoint/my_shared_endpoint_list.py
+++ b/globus_cli/services/transfer/endpoint/my_shared_endpoint_list.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import outformat_is_json
 
 from globus_cli.services.transfer.helpers import (
@@ -11,7 +11,7 @@ from globus_cli.services.transfer.helpers import (
     'my-shared-endpoint-list',
     help='List all Shared Endpoints on an Endpoint by the current user')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 def my_shared_endpoint_list(endpoint_id):
     """
     Executor for `globus transfer endpoint my-shared-endpoint-list`

--- a/globus_cli/services/transfer/endpoint/role/create.py
+++ b/globus_cli/services/transfer/endpoint/role/create.py
@@ -2,7 +2,7 @@ import click
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import (
-    CaseInsensitiveChoice, common_options, endpoint_id_option)
+    CaseInsensitiveChoice, common_options, endpoint_id_arg)
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.auth import maybe_lookup_identity_id
@@ -13,7 +13,7 @@ from globus_cli.services.transfer.helpers import (
 
 @click.command('create', help='Create a Role on an Endpoint')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 @click.option('--principal-type', required=True,
               type=CaseInsensitiveChoice(('identity', 'group')),
               help='Type of entity to set a role on')

--- a/globus_cli/services/transfer/endpoint/role/delete.py
+++ b/globus_cli/services/transfer/endpoint/role/delete.py
@@ -2,7 +2,7 @@ import click
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import (
-    common_options, endpoint_id_option, role_id_option)
+    common_options, endpoint_id_arg, role_id_option)
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
@@ -10,7 +10,7 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('delete', help='Remove a Role from an Endpoint')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 @role_id_option
 def role_delete(role_id, endpoint_id):
     """

--- a/globus_cli/services/transfer/endpoint/role/list.py
+++ b/globus_cli/services/transfer/endpoint/role/list.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import (
     outformat_is_json, print_json_response, print_table)
 
@@ -11,7 +11,7 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('list', help='List of assigned Roles on an Endpoint')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 def role_list(endpoint_id):
     """
     Executor for `globus transfer access endpoint-role-list`

--- a/globus_cli/services/transfer/endpoint/role/show.py
+++ b/globus_cli/services/transfer/endpoint/role/show.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.parsing import (
-    common_options, endpoint_id_option, role_id_option)
+    common_options, endpoint_id_arg, role_id_option)
 from globus_cli.helpers import (
     outformat_is_json, print_json_response, colon_formatted_print)
 
@@ -12,8 +12,8 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('show', help='Show full info for a Role on an Endpoint')
 @common_options
-@endpoint_id_option
 @role_id_option
+@endpoint_id_arg
 def role_show(role_id, endpoint_id):
     """
     Executor for `globus transfer endpoint role show`

--- a/globus_cli/services/transfer/endpoint/server/add.py
+++ b/globus_cli/services/transfer/endpoint/server/add.py
@@ -2,7 +2,7 @@ import click
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import (
-    common_options, endpoint_id_option, server_add_and_update_opts)
+    common_options, endpoint_id_arg, server_add_and_update_opts)
 from globus_cli.helpers import print_json_response, outformat_is_json
 
 from globus_cli.services.transfer.helpers import (
@@ -12,7 +12,7 @@ from globus_cli.services.transfer.helpers import (
 @click.command('add', help='Add a server to an Endpoint')
 @common_options
 @server_add_and_update_opts(add=True)
-@endpoint_id_option
+@endpoint_id_arg
 def server_add(endpoint_id, subject, port, scheme, hostname):
     """
     Executor for `globus transfer endpoint server add`

--- a/globus_cli/services/transfer/endpoint/server/delete.py
+++ b/globus_cli/services/transfer/endpoint/server/delete.py
@@ -2,7 +2,7 @@ import click
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import (
-    common_options, endpoint_id_option, server_id_option)
+    common_options, endpoint_id_arg, server_id_option)
 from globus_cli.helpers import print_json_response, outformat_is_json
 
 from globus_cli.services.transfer.helpers import get_client
@@ -11,7 +11,7 @@ from globus_cli.services.transfer.helpers import get_client
 @click.command('delete', help='Delete a server belonging to an Endpoint')
 @common_options
 @server_id_option
-@endpoint_id_option
+@endpoint_id_arg
 def server_delete(endpoint_id, server_id):
     """
     Executor for `globus transfer endpoint server show`

--- a/globus_cli/services/transfer/endpoint/server/list.py
+++ b/globus_cli/services/transfer/endpoint/server/list.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import print_table, outformat_is_json
 from globus_cli.services.transfer.helpers import (
     get_client, print_json_from_iterator)
@@ -8,7 +8,7 @@ from globus_cli.services.transfer.helpers import (
 
 @click.command('list', help='List all servers belonging to an Endpoint')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 def server_list(endpoint_id):
     """
     Executor for `globus transfer endpoint server list`

--- a/globus_cli/services/transfer/endpoint/server/show.py
+++ b/globus_cli/services/transfer/endpoint/server/show.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.parsing import (
-    common_options, endpoint_id_option, server_id_option)
+    common_options, endpoint_id_arg, server_id_option)
 from globus_cli.helpers import (
     print_json_response, outformat_is_json, colon_formatted_print)
 
@@ -11,7 +11,7 @@ from globus_cli.services.transfer.helpers import get_client
 @click.command('show', help='Show a server belonging to an Endpoint')
 @common_options
 @server_id_option
-@endpoint_id_option
+@endpoint_id_arg
 def server_show(endpoint_id, server_id):
     """
     Executor for `globus transfer endpoint server show`

--- a/globus_cli/services/transfer/endpoint/server/update.py
+++ b/globus_cli/services/transfer/endpoint/server/update.py
@@ -2,7 +2,7 @@ import click
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import (
-    common_options, endpoint_id_option,
+    common_options, endpoint_id_arg,
     server_add_and_update_opts, server_id_option)
 from globus_cli.helpers import print_json_response, outformat_is_json
 
@@ -14,7 +14,7 @@ from globus_cli.services.transfer.helpers import (
 @common_options
 @server_add_and_update_opts()
 @server_id_option
-@endpoint_id_option
+@endpoint_id_arg
 def server_update(endpoint_id, server_id, subject, port, scheme, hostname):
     """
     Executor for `globus transfer endpoint server update`

--- a/globus_cli/services/transfer/endpoint/show.py
+++ b/globus_cli/services/transfer/endpoint/show.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import (
     outformat_is_json, print_json_response, colon_formatted_print)
 
@@ -9,7 +9,7 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('show', help='Display a detailed Endpoint definition')
 @common_options
-@endpoint_id_option
+@endpoint_id_arg
 def endpoint_show(endpoint_id):
     """
     Executor for `globus transfer endpoint show`

--- a/globus_cli/services/transfer/endpoint/update.py
+++ b/globus_cli/services/transfer/endpoint/update.py
@@ -2,7 +2,7 @@ import click
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import (
-    common_options, endpoint_id_option, endpoint_create_and_update_opts)
+    common_options, endpoint_id_arg, endpoint_create_and_update_opts)
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer.helpers import (
@@ -12,7 +12,7 @@ from globus_cli.services.transfer.helpers import (
 @click.command('update', help='Update attributes of an Endpoint')
 @common_options
 @endpoint_create_and_update_opts(create=False)
-@endpoint_id_option
+@endpoint_id_arg
 def endpoint_update(endpoint_id, display_name, description, organization,
                     contact_email, contact_info, info_link, public,
                     default_directory, force_encryption, oauth_server,

--- a/globus_cli/services/transfer/helpers.py
+++ b/globus_cli/services/transfer/helpers.py
@@ -1,3 +1,4 @@
+import uuid
 import json
 import sys
 import shlex
@@ -54,9 +55,11 @@ def endpoint_list_to_text(iterator):
 
 def assemble_generic_doc(datatype, **kwargs):
     doc = {'DATA_TYPE': datatype}
-    for argname in kwargs:
-        if kwargs[argname] is not None:
-            doc[argname] = kwargs[argname]
+    for key, val in kwargs.items():
+        if isinstance(val, uuid.UUID):
+            val = str(val)
+        if val is not None:
+            doc[key] = val
     return doc
 
 

--- a/globus_cli/services/transfer/ls.py
+++ b/globus_cli/services/transfer/ls.py
@@ -8,6 +8,10 @@ from globus_cli.helpers import (
 from globus_cli.services.transfer.helpers import get_client
 from globus_cli.services.transfer.activation import autoactivate
 
+# we need to pull path_type.metavar because Argument.make_metavar()
+# behaves poorly even when a ParamType supplies get_metavar()
+path_type = EndpointPlusPath(path_required=False)
+
 
 class DummyLSIterable(dict):
     """
@@ -71,11 +75,6 @@ def _get_ls_res(client, path, endpoint_id, recursive, depth, show_hidden):
                 result_doc['DATA'].append(nested_item)
 
     return result_doc
-
-
-# we need to pull path_type.metavar because Argument.make_metavar()
-# behaves poorly even when a ParamType supplies get_metavar()
-path_type = EndpointPlusPath(path_required=False)
 
 
 @click.command('ls', help='List the contents of a directory on an Endpoint',

--- a/globus_cli/services/transfer/ls.py
+++ b/globus_cli/services/transfer/ls.py
@@ -1,16 +1,12 @@
 import click
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options, EndpointPlusPath
+from globus_cli.parsing import common_options, ENDPOINT_PLUS_OPTPATH
 from globus_cli.helpers import (
     outformat_is_json, print_json_response, print_table)
 
 from globus_cli.services.transfer.helpers import get_client
 from globus_cli.services.transfer.activation import autoactivate
-
-# we need to pull path_type.metavar because Argument.make_metavar()
-# behaves poorly even when a ParamType supplies get_metavar()
-path_type = EndpointPlusPath(path_required=False)
 
 
 class DummyLSIterable(dict):
@@ -80,8 +76,8 @@ def _get_ls_res(client, path, endpoint_id, recursive, depth, show_hidden):
 @click.command('ls', help='List the contents of a directory on an Endpoint',
                short_help='List Endpoint directory contents')
 @common_options
-@click.argument('endpoint_plus_path', metavar=path_type.metavar,
-                type=path_type)
+@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
+                type=ENDPOINT_PLUS_OPTPATH)
 @click.option('--all', '-a', is_flag=True,
               help=('Show files and directories that start with `.`'))
 @click.option('--long', is_flag=True,

--- a/globus_cli/services/transfer/mkdir.py
+++ b/globus_cli/services/transfer/mkdir.py
@@ -1,22 +1,25 @@
 import click
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options
+from globus_cli.parsing import common_options, EndpointPlusPath
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
 from globus_cli.services.transfer.activation import autoactivate
 
+path_type = EndpointPlusPath()
+
 
 @click.command('mkdir', help='Make a directory on an Endpoint')
 @common_options
-@click.option('--endpoint-id', required=True, help='ID of the Endpoint')
-@click.option('--path', required=True,
-              help='Path on the remote Endpoint to create')
-def mkdir_command(path, endpoint_id):
+@click.argument('endpoint_plus_path', required=True,
+                metavar=path_type.metavar, type=path_type)
+def mkdir_command(endpoint_plus_path):
     """
     Executor for `globus transfer mkdir`
     """
+    endpoint_id, path = endpoint_plus_path
+
     client = get_client()
     autoactivate(client, endpoint_id, if_expires_in=60)
 

--- a/globus_cli/services/transfer/mkdir.py
+++ b/globus_cli/services/transfer/mkdir.py
@@ -1,19 +1,17 @@
 import click
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options, EndpointPlusPath
+from globus_cli.parsing import common_options, ENDPOINT_PLUS_REQPATH
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
 from globus_cli.services.transfer.activation import autoactivate
 
-path_type = EndpointPlusPath()
-
 
 @click.command('mkdir', help='Make a directory on an Endpoint')
 @common_options
-@click.argument('endpoint_plus_path', required=True,
-                metavar=path_type.metavar, type=path_type)
+@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_REQPATH.metavar,
+                type=ENDPOINT_PLUS_REQPATH)
 def mkdir_command(endpoint_plus_path):
     """
     Executor for `globus transfer mkdir`

--- a/globus_cli/services/transfer/rename.py
+++ b/globus_cli/services/transfer/rename.py
@@ -10,10 +10,10 @@ from globus_cli.services.transfer.activation import autoactivate
 
 @click.command('rename', help='Rename a file or directory on an Endpoint')
 @common_options
-@click.argument('source', required=True,
-                metavar='ENDPOINT_ID:SOURCE_PATH', type=EndpointPlusPath())
-@click.argument('destination', required=True,
-                metavar='ENDPOINT_ID:DEST_PATH', type=EndpointPlusPath())
+@click.argument('source', metavar='ENDPOINT_ID:SOURCE_PATH',
+                type=EndpointPlusPath())
+@click.argument('destination', metavar='ENDPOINT_ID:DEST_PATH',
+                type=EndpointPlusPath())
 def rename_command(source, destination):
     """
     Executor for `globus transfer rename`

--- a/globus_cli/services/transfer/rename.py
+++ b/globus_cli/services/transfer/rename.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, EndpointPlusPath
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
@@ -10,20 +10,28 @@ from globus_cli.services.transfer.activation import autoactivate
 
 @click.command('rename', help='Rename a file or directory on an Endpoint')
 @common_options
-@endpoint_id_option
-@click.option('--old-path', required=True,
-              help='Path to the file/dir to rename')
-@click.option('--new-path', required=True,
-              help='Desired location of the file/dir after rename')
-def rename_command(new_path, old_path, endpoint_id):
+@click.argument('source', required=True,
+                metavar='ENDPOINT_ID:SOURCE_PATH', type=EndpointPlusPath())
+@click.argument('destination', required=True,
+                metavar='ENDPOINT_ID:DEST_PATH', type=EndpointPlusPath())
+def rename_command(source, destination):
     """
     Executor for `globus transfer rename`
     """
+    source_ep, source_path = source
+    dest_ep, dest_path = destination
+
+    if source_ep != dest_ep:
+        raise click.UsageError(('rename requires that the source and dest '
+                                'endpoints are the same, {} != {}')
+                               .format(source_ep, dest_ep))
+    endpoint_id = source_ep
+
     client = get_client()
     autoactivate(client, endpoint_id, if_expires_in=60)
 
-    res = client.operation_rename(endpoint_id, oldpath=old_path,
-                                  newpath=new_path)
+    res = client.operation_rename(endpoint_id, oldpath=source_path,
+                                  newpath=dest_path)
 
     if outformat_is_json():
         print_json_response(res)

--- a/globus_cli/services/transfer/rename.py
+++ b/globus_cli/services/transfer/rename.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options, EndpointPlusPath
+from globus_cli.parsing import common_options, ENDPOINT_PLUS_REQPATH
 from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer.helpers import get_client
@@ -11,9 +11,9 @@ from globus_cli.services.transfer.activation import autoactivate
 @click.command('rename', help='Rename a file or directory on an Endpoint')
 @common_options
 @click.argument('source', metavar='ENDPOINT_ID:SOURCE_PATH',
-                type=EndpointPlusPath())
+                type=ENDPOINT_PLUS_REQPATH)
 @click.argument('destination', metavar='ENDPOINT_ID:DEST_PATH',
-                type=EndpointPlusPath())
+                type=ENDPOINT_PLUS_REQPATH)
 def rename_command(source, destination):
     """
     Executor for `globus transfer rename`

--- a/globus_cli/services/transfer/share/create.py
+++ b/globus_cli/services/transfer/share/create.py
@@ -1,6 +1,7 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_create_and_update_opts
+from globus_cli.parsing import (
+    common_options, endpoint_create_and_update_opts, endpoint_id_arg)
 from globus_cli.helpers import print_json_response
 from globus_cli.services.transfer.helpers import (
     get_client, assemble_generic_doc)
@@ -9,15 +10,14 @@ from globus_cli.services.transfer.helpers import (
 @click.command('create', help='Create a new Share, hosted on an Endpoint')
 @common_options
 @endpoint_create_and_update_opts(create=True, shared_ep=True)
-@click.option('--host-endpoint-id', required=True,
-              help='ID of the endpoint on which this Share is hosted')
-def share_create(host_endpoint_id, display_name, description, organization,
+@endpoint_id_arg(metavar='HOST_ENDPOINT_ID')
+def share_create(endpoint_id, display_name, description, organization,
                  contact_email, contact_info, info_link, public):
     """
     Executor for `globus transfer share create`
     """
     ep_doc = assemble_generic_doc(
-        'shared_endpoint', host_endpoint_id=host_endpoint_id,
+        'shared_endpoint', host_endpoint_id=endpoint_id,
         display_name=display_name, description=description,
         organization=organization, contact_email=contact_email,
         contact_info=contact_info, info_link=info_link, public=public)

--- a/globus_cli/services/transfer/share/delete.py
+++ b/globus_cli/services/transfer/share/delete.py
@@ -1,14 +1,14 @@
 import click
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import outformat_is_json, print_json_response
 from globus_cli.services.transfer.helpers import get_client
 
 
 @click.command('delete', help='Delete a given Share')
 @common_options
-@endpoint_id_option(help='ID of the Share')
+@endpoint_id_arg(metavar='SHARE_ID')
 def share_delete(endpoint_id):
     """
     Executor for `globus transfer share delete`

--- a/globus_cli/services/transfer/share/show.py
+++ b/globus_cli/services/transfer/share/show.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_option
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import (
     outformat_is_json, print_json_response, colon_formatted_print)
 from globus_cli.services.transfer.helpers import get_client
@@ -8,7 +8,7 @@ from globus_cli.services.transfer.helpers import get_client
 
 @click.command('show', help='Display a detailed Share definition')
 @common_options
-@endpoint_id_option(help='ID of the Share')
+@endpoint_id_arg(metavar='SHARE_ID')
 def share_show(endpoint_id):
     """
     Executor for `globus transfer endpoint show`

--- a/globus_cli/services/transfer/share/update.py
+++ b/globus_cli/services/transfer/share/update.py
@@ -2,7 +2,7 @@ import click
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import (
-    common_options, endpoint_id_option, endpoint_create_and_update_opts)
+    common_options, endpoint_id_arg, endpoint_create_and_update_opts)
 from globus_cli.helpers import outformat_is_json, print_json_response
 from globus_cli.services.transfer.helpers import (
     get_client, assemble_generic_doc)
@@ -11,7 +11,7 @@ from globus_cli.services.transfer.helpers import (
 @click.command('update', help='Update attributes of a Share')
 @common_options
 @endpoint_create_and_update_opts(create=False, shared_ep=True)
-@endpoint_id_option(help='ID of the Share')
+@endpoint_id_arg(metavar='SHARE_ID')
 def share_update(endpoint_id, display_name, description, organization,
                  contact_email, contact_info, info_link, public):
     """


### PR DESCRIPTION
This is a new `click.ParamType`.
Unfortunately, a little bit of hackery is needed because of a bad behavior (which I call a bug) in `click` ( https://github.com/pallets/click/issues/674 ), so in some locations the parameter type is not used inline, but defined at the top of the file. This is actually fine, but a little annoying.

Also converts all obvious cases of `--endpoint-id` plus `--path` to this type.
Some commands, like shared endpoint creation, could use this type but (for now at least) don't.

I consider this sufficient to conclude #73, and we can work on #72 separately as an addition on top of this.