### PR TITLE
Introduce failing poor man's automated test and fix range() exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ install:
 cache: pip
 script:
   - flake8
+  - globus --help  # poor man's test: detect catastrophic parsing failures

--- a/globus_cli/parsing/command_state.py
+++ b/globus_cli/parsing/command_state.py
@@ -60,7 +60,7 @@ def debug_option(f):
 
 
 def map_http_status_option(f):
-    exit_stat_set = [0, 1] + range(50, 100)
+    exit_stat_set = [0, 1] + list(range(50, 100))
 
     def per_val_callback(ctx, value):
         if value is None:


### PR DESCRIPTION
- runs `globus --help` as part of the script list on Travis so that if we really mess something up such that even the `globus --help` command doesn't work, we will catch it
- listify generator from `range()` in `map_http_status_option()` implementation so that it works on Python 3