### PR TITLE
Save access tokens to config and use if valid

### DIFF
--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -11,13 +11,17 @@ __all__ = [
     # option name constants
     'OUTPUT_FORMAT_OPTNAME',
     'AUTH_RT_OPTNAME',
+    'AUTH_AT_OPTNAME',
+    'AUTH_AT_EXPIRES_OPTNAME',
     'TRANSFER_RT_OPTNAME',
+    'TRANSFER_AT_OPTNAME',
+    'AUTH_AT_EXPIRES_OPTNAME',
 
     'internal_auth_client',
 
     'get_output_format',
-    'get_auth_refresh_token',
-    'get_transfer_refresh_token',
+    'get_auth_tokens',
+    'get_transfer_tokens',
 
     'write_option',
     'lookup_option',
@@ -35,7 +39,11 @@ ENV_CLIENT_ID_OPTNAME = 'cli_client_id'
 # constants for global use
 OUTPUT_FORMAT_OPTNAME = 'output_format'
 AUTH_RT_OPTNAME = 'auth_refresh_token'
+AUTH_AT_OPTNAME = 'auth_access_token'
+AUTH_AT_EXPIRES_OPTNAME = 'auth_access_token_expires'
 TRANSFER_RT_OPTNAME = 'transfer_refresh_token'
+TRANSFER_AT_OPTNAME = 'transfer_access_token'
+TRANSFER_AT_EXPIRES_OPTNAME = 'transfer_access_token_expires'
 
 # get the environment from env var (not exported)
 GLOBUS_ENV = os.environ.get('GLOBUS_SDK_ENVIRONMENT')
@@ -44,7 +52,13 @@ GLOBUS_ENV = os.environ.get('GLOBUS_SDK_ENVIRONMENT')
 # prefix
 if GLOBUS_ENV:
     AUTH_RT_OPTNAME = '{0}_auth_refresh_token'.format(GLOBUS_ENV)
+    AUTH_AT_OPTNAME = '{0}_auth_access_token'.format(GLOBUS_ENV)
+    AUTH_AT_EXPIRES_OPTNAME = '{0}_auth_access_token_expires'.format(
+        GLOBUS_ENV)
     TRANSFER_RT_OPTNAME = '{0}_transfer_refresh_token'.format(GLOBUS_ENV)
+    TRANSFER_AT_OPTNAME = '{0}_transfer_access_token'.format(GLOBUS_ENV)
+    TRANSFER_AT_EXPIRES_OPTNAME = '{0}_transfer_access_token_expires'.format(
+        GLOBUS_ENV)
 
 
 def _get_config_obj(system=False):
@@ -86,12 +100,38 @@ def get_output_format():
     return lookup_option(OUTPUT_FORMAT_OPTNAME)
 
 
-def get_auth_refresh_token():
-    return lookup_option(AUTH_RT_OPTNAME)
+def get_auth_tokens():
+    expires = lookup_option(AUTH_AT_EXPIRES_OPTNAME)
+    if expires is not None:
+        expires = int(expires)
+
+    return {
+        'refresh_token': lookup_option(AUTH_RT_OPTNAME),
+        'access_token': lookup_option(AUTH_AT_OPTNAME),
+        'access_token_expires': expires
+    }
 
 
-def get_transfer_refresh_token():
-    return lookup_option(TRANSFER_RT_OPTNAME)
+def set_auth_access_token(token, expires_at):
+    write_option(AUTH_AT_OPTNAME, token)
+    write_option(AUTH_AT_EXPIRES_OPTNAME, expires_at)
+
+
+def get_transfer_tokens():
+    expires = lookup_option(TRANSFER_AT_EXPIRES_OPTNAME)
+    if expires is not None:
+        expires = int(expires)
+
+    return {
+        'refresh_token': lookup_option(TRANSFER_RT_OPTNAME),
+        'access_token': lookup_option(TRANSFER_AT_OPTNAME),
+        'access_token_expires': expires
+    }
+
+
+def set_transfer_access_token(token, expires_at):
+    write_option(TRANSFER_AT_OPTNAME, token)
+    write_option(TRANSFER_AT_EXPIRES_OPTNAME, expires_at)
 
 
 def internal_auth_client():

--- a/globus_cli/login.py
+++ b/globus_cli/login.py
@@ -4,6 +4,8 @@ from globus_cli.safeio import safeprint
 from globus_cli.parsing import common_options
 from globus_cli.config import (
     AUTH_RT_OPTNAME, TRANSFER_RT_OPTNAME,
+    AUTH_AT_OPTNAME, TRANSFER_AT_OPTNAME,
+    AUTH_AT_EXPIRES_OPTNAME, TRANSFER_AT_EXPIRES_OPTNAME,
     internal_auth_client, write_option)
 
 
@@ -24,7 +26,7 @@ def login_command():
     # prompt
     linkprompt = 'Please login to Globus here'
     safeprint('{0}:\n{1}\n{2}\n{1}\n'
-              .format(linkprompt, '-'*len(linkprompt),
+              .format(linkprompt, '-' * len(linkprompt),
                       ac.oauth2_get_authorize_url()))
 
     # come back with auth code
@@ -33,16 +35,21 @@ def login_command():
 
     # exchange, done!
     tkn = ac.oauth2_exchange_code_for_tokens(auth_code)
+    tkn = tkn.by_resource_server
 
     # extract access tokens from final response
     transfer_at = (
-        tkn.by_resource_server['transfer.api.globus.org']['access_token'])
+        tkn['transfer.api.globus.org']['access_token'])
+    transfer_at_expires = (
+        tkn['transfer.api.globus.org']['expires_at_seconds'])
     transfer_rt = (
-        tkn.by_resource_server['transfer.api.globus.org']['refresh_token'])
+        tkn['transfer.api.globus.org']['refresh_token'])
     auth_at = (
-        tkn.by_resource_server['auth.globus.org']['access_token'])
+        tkn['auth.globus.org']['access_token'])
+    auth_at_expires = (
+        tkn['auth.globus.org']['expires_at_seconds'])
     auth_rt = (
-        tkn.by_resource_server['auth.globus.org']['refresh_token'])
+        tkn['auth.globus.org']['refresh_token'])
 
     # write data to config
     # TODO: remove once we deprecate these fully
@@ -50,4 +57,8 @@ def login_command():
     write_option('auth_token', auth_at, section='general')
     # new values we want to use moving forward
     write_option(TRANSFER_RT_OPTNAME, transfer_rt)
+    write_option(TRANSFER_AT_OPTNAME, transfer_at)
+    write_option(TRANSFER_AT_EXPIRES_OPTNAME, transfer_at_expires)
     write_option(AUTH_RT_OPTNAME, auth_rt)
+    write_option(AUTH_AT_OPTNAME, auth_at)
+    write_option(AUTH_AT_EXPIRES_OPTNAME, auth_at_expires)


### PR DESCRIPTION
Closes #83

* Start saving access_tokens (and their expiration time) in the config file.
* Pass access_tokens into the authorizer to avoid always fetching a new access_token on every CLI command.
* Uses the refresh token authorizer's new `on_refresh` callback to get notified when access_token data should be updated in the config file.

Depends on https://github.com/globus/globus-sdk-python/pull/72