### PR TITLE
Join batchmode paths with commandline paths

### DIFF
--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -1,8 +1,10 @@
 from globus_cli.parsing.main_command_decorator import globus_main_func
 
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
+from globus_cli.parsing.task_path import TaskPath
 from globus_cli.parsing.endpoint_plus_path import (
-    EndpointPlusPath, ENDPOINT_PLUS_OPTPATH, ENDPOINT_PLUS_REQPATH)
+    ENDPOINT_PLUS_OPTPATH, ENDPOINT_PLUS_REQPATH)
+
 from globus_cli.parsing.hidden_option import HiddenOption
 
 from globus_cli.parsing.shared_options import (
@@ -16,7 +18,9 @@ __all__ = [
     'globus_main_func',
 
     'CaseInsensitiveChoice',
-    'EndpointPlusPath', 'ENDPOINT_PLUS_OPTPATH', 'ENDPOINT_PLUS_REQPATH',
+    'ENDPOINT_PLUS_OPTPATH', 'ENDPOINT_PLUS_REQPATH',
+    'TaskPath',
+
     'HiddenOption',
 
     'common_options',

--- a/globus_cli/parsing/task_path.py
+++ b/globus_cli/parsing/task_path.py
@@ -1,0 +1,60 @@
+import os
+import click
+
+
+class TaskPath(click.ParamType):
+    def __init__(self, base_dir=None, coerce_to_dir=False, normalize=True,
+                 require_absolute=False):
+        """
+        Task Paths are paths for passing into Transfer or Delete tasks.
+        They're only slightly more than string types: they can join themselves
+        with a base dir path, and they can coerce themselves to the dir format
+        by appending a trailing slash if it's absent.
+
+        For us to toggle and talk about behaviors as necessary, normalization
+        is an option that defaults to True.
+        Also can enforce that the path is absolute.
+        """
+        self.base_dir = base_dir
+        self.coerce_to_dir = coerce_to_dir
+        self.normalize = normalize
+        self.require_absolute = require_absolute
+
+        # the "real value" of this path holder
+        self.path = None
+        # the original path, as consumed before processing
+        self.orig_path = None
+
+    def convert(self, value, param, ctx):
+        if value is None or (ctx and ctx.resilient_parsing):
+            return
+        if isinstance(value, TaskPath):
+            return value
+
+        self.orig_path = self.path = value
+
+        if self.base_dir:
+            self.path = os.path.join(self.base_dir, self.path)
+        if self.coerce_to_dir and not self.path.endswith('/'):
+            self.path += '/'
+        if self.normalize:
+            self.path = os.path.normpath(self.path)
+
+        if self.require_absolute and not (self.path.startswith('/') or
+                                          self.path.startswith('~')):
+            self.fail('{} is not absolute (abspath required)'
+                      .format(self.path), param=param, ctx=ctx)
+
+        return self
+
+    def __repr__(self):
+        return "TaskPath({})".format(
+            ','.join(
+                "{}={}".format(name, getattr(self, name))
+                for name in
+                ('base_dir', 'coerce_to_dir', 'normalize', 'path',
+                 'orig_path'))
+        )
+
+    def __str__(self):
+        return str(self.path)

--- a/globus_cli/services/transfer/async_transfer.py
+++ b/globus_cli/services/transfer/async_transfer.py
@@ -142,6 +142,12 @@ def async_transfer_command(batch, sync_level, recursive, destination, source,
     source_endpoint, cmd_source_path = source
     dest_endpoint, cmd_dest_path = destination
 
+    if recursive and batch:
+        raise click.UsageError(
+            ('You cannot use --recursive in addition to --batch. '
+             'Instead, use --recursive on lines of --batch input '
+             'which need it'))
+
     if (cmd_source_path is None or cmd_dest_path is None) and (not batch):
         raise click.UsageError(
             ('async-transfer requires either SOURCE_PATH and DEST_PATH or '

--- a/globus_cli/services/transfer/async_transfer.py
+++ b/globus_cli/services/transfer/async_transfer.py
@@ -36,7 +36,7 @@ from globus_cli.services.transfer.activation import autoactivate
     ---
 
     Batchmode is the way in which `async-transfer` can be used to
-    submit a Task which transfers of multiple files or directories, and it is
+    submit a Task which transfers multiple files or directories, and it is
     used to accept paths to transfer on stdin.
 
     Batchmode splits each line on spaces, and treats every line as a file or
@@ -46,7 +46,7 @@ from globus_cli.services.transfer.activation import autoactivate
 
     \b
     Lines are of the form
-    [--recursive] SOURCE_PATH [DEST_PATH]
+    [--recursive] SOURCE_PATH DEST_PATH
 
     Skips empty lines and allows comments beginning with "#".
 
@@ -56,25 +56,22 @@ from globus_cli.services.transfer.activation import autoactivate
         # file 1, simple
         ~/dir1/sourcepath1 /abspath/destpath1
 
+    \b
         # file 2, with spaces in dest path
         # paths without / or ~ are relative to the default_directory of the
         # endpoint they are on
         dir2/sourcepath2   "path with spaces/dest2"
 
+    \b
         # dir 1, requires --recursive option
         --recursive ~/srcdir1/ /somepath/destdir1
 
-        # if dest path is omitted, the source path is copied
-        # the lines below are therefore equivalent to
-        #   --recursive ~/srcdir1/ ~/srcdir1/
-        #   file_to_copy file_to_copy
-        --recursive ~/srcdir1/
-        file_to_copy
     \b
         $ cat dat | globus transfer async-transfer \\
             --batch --sync-level checksum \\
             "$SOURCE_ENDPOINT_ID" "$DEST_ENDPOINT_ID"
 
+    \b
     You can use `--batch` with a commandline SOURCE_PATH and/or DEST_PATH.
     In that case, these paths will be used as dir prefixes to any paths in the
     batch input.
@@ -112,7 +109,7 @@ from globus_cli.services.transfer.activation import autoactivate
                     "data instead"))
 @click.option('--recursive', is_flag=True,
               help=('SOURCE_PATH and DEST_PATH are both directories, do a '
-                    'recursive dir transfer. Ignored in batchmode'))
+                    'recursive dir transfer'))
 @click.option('--label', default=None, help=('Set a label for this task.'))
 @click.option('--sync-level', default=None, show_default=True,
               type=CaseInsensitiveChoice(
@@ -160,23 +157,19 @@ def async_transfer_command(batch, sync_level, recursive, destination, source,
         @click.command()
         @click.option('--recursive', is_flag=True)
         @click.argument('source_path', type=TaskPath(base_dir=cmd_source_path))
-        @click.argument('dest_path', type=TaskPath(base_dir=cmd_dest_path),
-                        required=False)
+        @click.argument('dest_path', type=TaskPath(base_dir=cmd_dest_path))
         def process_batch_line(dest_path, source_path, recursive):
             """
             Parse a line of batch input and turn it into a transfer submission
             item.
             """
-            if not dest_path:
-                dest_path = str(TaskPath(base_dir=cmd_dest_path)
-                                .convert(source_path.orig_path, None, None))
             transfer_data.add_item(str(source_path), str(dest_path),
                                    recursive=recursive)
 
         shlex_process_stdin(
             process_batch_line,
             ('Enter transfers, line by line, as\n\n'
-             '    [--recursive] SOURCE_PATH [DEST_PATH]\n'))
+             '    [--recursive] SOURCE_PATH DEST_PATH\n'))
     else:
         transfer_data.add_item(cmd_source_path, cmd_dest_path,
                                recursive=recursive)


### PR DESCRIPTION
Per #89, slapping the commandline paths into the document body as just another pair is potentially confusing and not very good semantically.
To be more useful, join paths as given on the commandline to all of the batch inputs, letting the commandline paths be used to specify a prefix.

Implemented with a new custom ParamType for consuming/converting paths relative to a base dir.
That type has some unused features from my experiments with it which I'm leaving in, in case we want to use them in the future.

This leads logically towards an interesting potential use case for `globus transfer ls | globus transfer async-delete ...`
That's also interesting for `async-transfer`, but requires the annoying extra step of `| awk '{print $1 " " $1}'`. Thinking further about that, why not let `dest_path` be optional during transfer submission, and we'll just copy the source path, potentially joined with a commandline dest path?
This changeset includes that modification, as it actually has some minor implications for the ParamType definition.

With this improvement, it's possible to pipe and `ls` through a grep and ultimately to transfer submission. Things only get messy when you have a pipeline producing a mix of files and dirs for transfer -- in that case, a sophisticated manipulation with `awk` or similar is once again required.
Consider, however
```shell
$ globus transfer ls "$ENDPOINT_ID:/mypath" | grep '.*\.txt' | \
    globus transfer async-transfer "$ENDPOINT_ID:/mypath" "$OTHER_ENDPOINT:mypath_txts/"
```
in simple cases like this, accepting single-column input for batchmode proves very useful. (Yes, that example can be messed up by spaces in the path, but this isn't the place for building quoting tools).


Resolves #89