### PR TITLE
Add whoami command to show logged-in user

### DIFF
--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -16,6 +16,10 @@ __all__ = [
     'TRANSFER_RT_OPTNAME',
     'TRANSFER_AT_OPTNAME',
     'AUTH_AT_EXPIRES_OPTNAME',
+    'WHOAMI_ID_OPTNAME',
+    'WHOAMI_USERNAME_OPTNAME',
+    'WHOAMI_EMAIL_OPTNAME',
+    'WHOAMI_NAME_OPTNAME',
 
     'internal_auth_client',
 
@@ -44,6 +48,10 @@ AUTH_AT_EXPIRES_OPTNAME = 'auth_access_token_expires'
 TRANSFER_RT_OPTNAME = 'transfer_refresh_token'
 TRANSFER_AT_OPTNAME = 'transfer_access_token'
 TRANSFER_AT_EXPIRES_OPTNAME = 'transfer_access_token_expires'
+WHOAMI_ID_OPTNAME = 'whoami_identity_id'
+WHOAMI_USERNAME_OPTNAME = 'whoami_identity_username'
+WHOAMI_EMAIL_OPTNAME = 'whoami_identity_email'
+WHOAMI_NAME_OPTNAME = 'whoami_identity_display_name'
 
 # get the environment from env var (not exported)
 GLOBUS_ENV = os.environ.get('GLOBUS_SDK_ENVIRONMENT')
@@ -59,6 +67,10 @@ if GLOBUS_ENV:
     TRANSFER_AT_OPTNAME = '{0}_transfer_access_token'.format(GLOBUS_ENV)
     TRANSFER_AT_EXPIRES_OPTNAME = '{0}_transfer_access_token_expires'.format(
         GLOBUS_ENV)
+    WHOAMI_ID_OPTNAME = '{0}_whoami_identity_id'.format(GLOBUS_ENV)
+    WHOAMI_USERNAME_OPTNAME = '{0}_whoami_identity_username'.format(GLOBUS_ENV)
+    WHOAMI_EMAIL_OPTNAME = '{0}_whoami_identity_email'.format(GLOBUS_ENV)
+    WHOAMI_NAME_OPTNAME = '{0}_whoami_identity_display_name'.format(GLOBUS_ENV)
 
 
 def _get_config_obj(system=False):

--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -21,6 +21,8 @@ __all__ = [
     'WHOAMI_EMAIL_OPTNAME',
     'WHOAMI_NAME_OPTNAME',
 
+    'GLOBUS_ENV',
+
     'internal_auth_client',
 
     'get_output_format',

--- a/globus_cli/run.py
+++ b/globus_cli/run.py
@@ -3,6 +3,7 @@ from globus_cli.parsing import globus_main_func
 from globus_cli.login import login_command
 from globus_cli.list_commands import list_commands
 from globus_cli.config_command import config_command
+from globus_cli.whoami import whoami_command
 
 from globus_cli.services.auth import auth_command
 from globus_cli.services.transfer import transfer_command
@@ -18,3 +19,4 @@ main.add_command(transfer_command)
 main.add_command(login_command)
 main.add_command(list_commands)
 main.add_command(config_command)
+main.add_command(whoami_command)

--- a/globus_cli/whoami.py
+++ b/globus_cli/whoami.py
@@ -1,0 +1,36 @@
+import click
+
+from globus_cli.safeio import safeprint
+from globus_cli.parsing import common_options
+from globus_cli.config import (
+    WHOAMI_ID_OPTNAME, WHOAMI_USERNAME_OPTNAME,
+    WHOAMI_EMAIL_OPTNAME, WHOAMI_NAME_OPTNAME,
+    GLOBUS_ENV, lookup_option)
+
+
+@click.command('whoami',
+               help=('Show the currently logged-in identity.'))
+@common_options(no_format_option=True, no_map_http_status_option=True)
+@click.option('--verbose', '-v', is_flag=True, default=False)
+def whoami_command(verbose):
+    """
+    Executor for `globus whoami`
+    """
+
+    username = lookup_option(WHOAMI_USERNAME_OPTNAME,
+                             environment=GLOBUS_ENV)
+    if not username:
+        safeprint('No login information available. Please try '
+                  'logging in again.')
+        return
+
+    safeprint('Logged in as: {}'.format(username))
+
+    if verbose:
+        name = lookup_option(WHOAMI_NAME_OPTNAME, environment=GLOBUS_ENV)
+        identity_id = lookup_option(WHOAMI_ID_OPTNAME, environment=GLOBUS_ENV)
+        email = lookup_option(WHOAMI_EMAIL_OPTNAME, environment=GLOBUS_ENV)
+
+        safeprint('Name: {}'.format(name))
+        safeprint('Id: {}'.format(identity_id))
+        safeprint('Email: {}'.format(email))


### PR DESCRIPTION
* Adds a `globus whoami` command to show the currently logged-in user (i.e., the identity-context for the CLI's current set of tokens)

Examples:
```
(venv) jasons-mbp:globus-cli jtw$ globus whoami
No login information available. Please try logging in again.
```

```
(venv) jasons-mbp:globus-cli jtw$ globus whoami
Logged in as: jaswilli@globusid.org
```

```
(venv) jasons-mbp:globus-cli jtw$ globus whoami --verbose
Logged in as: jaswilli@globusid.org
Name: Jason Williams
Id: a492bd6e-d274-11e5-994a-0f250392c65f
Email: jaswilli@uchicago.edu
```

Closes #44