### PR TITLE
Add initial version of logout command

### DIFF
--- a/globus_cli/commands/login.py
+++ b/globus_cli/commands/login.py
@@ -19,7 +19,7 @@ from globus_cli.config import (
                help=('Get credentials for the Globus CLI. '
                      'Necessary before any Globus CLI commands which require '
                      'authentication will work'))
-@common_options
+@common_options(no_format_option=True, no_map_http_status_option=True)
 def login_command():
     # build the NativeApp client object
     native_client = internal_auth_client()

--- a/globus_cli/commands/logout.py
+++ b/globus_cli/commands/logout.py
@@ -1,0 +1,43 @@
+import click
+
+from globus_cli.safeio import safeprint
+from globus_cli.parsing import common_options
+from globus_cli.config import (
+    AUTH_RT_OPTNAME, TRANSFER_RT_OPTNAME,
+    AUTH_AT_OPTNAME, TRANSFER_AT_OPTNAME,
+    AUTH_AT_EXPIRES_OPTNAME, TRANSFER_AT_EXPIRES_OPTNAME,
+    WHOAMI_ID_OPTNAME, WHOAMI_USERNAME_OPTNAME,
+    WHOAMI_EMAIL_OPTNAME, WHOAMI_NAME_OPTNAME,
+    internal_auth_client, remove_option, lookup_option)
+
+
+@click.command('logout',
+               short_help=('Logout of Globus, revoking credentials for '
+                           'the Globus CLI'),
+               help=('Remove credentials for the Globus CLI. '
+                     'Effectively stops any use of your CLI credentials as '
+                     'well'))
+@common_options
+def logout_command():
+    # build the NativeApp client object
+    native_client = internal_auth_client()
+
+    # prompt
+    confirmed = click.confirm("Are you sure you'd like to logout?")
+    if not confirmed:
+        return
+
+    safeprint('Logging out of Globus as {}'
+              .format(lookup_option(WHOAMI_USERNAME_OPTNAME)))
+
+    # remove tokens from config and revoke them
+    for token_opt in (TRANSFER_RT_OPTNAME, TRANSFER_AT_OPTNAME,
+                      TRANSFER_AT_EXPIRES_OPTNAME,
+                      AUTH_RT_OPTNAME, AUTH_AT_OPTNAME,
+                      AUTH_AT_EXPIRES_OPTNAME):
+        token = remove_option(token_opt)
+        if token:
+            native_client.oauth2_revoke_token(token)
+    for whoami_opt in (WHOAMI_ID_OPTNAME, WHOAMI_USERNAME_OPTNAME,
+                       WHOAMI_EMAIL_OPTNAME, WHOAMI_NAME_OPTNAME):
+        remove_option(whoami_opt)

--- a/globus_cli/commands/logout.py
+++ b/globus_cli/commands/logout.py
@@ -12,6 +12,27 @@ from globus_cli.config import (
     internal_auth_client, remove_option, lookup_option)
 
 
+_RESCIND_HELP = """\
+Rescinding Consents
+-------------------
+The logout command only revokes tokens that it can see in its storage.
+If you are concerned that logout may have failed to revoke a token,
+you may want to manually rescind the Globus CLI consent on the
+Manage Consents Page:
+    https://auth.globus.org/consents
+
+"""
+
+
+_LOGOUT_EPILOG = """\
+\nYou are now successfully logged out of the Globus CLI.
+Before attempting any further CLI commands, you will have to login again using
+
+  globus login
+
+"""
+
+
 @click.command('logout',
                short_help='Logout of the Globus CLI',
                help=('Logout of the Globus CLI. '
@@ -40,20 +61,23 @@ def logout_command(yes):
     if not username:
         _confirm(("Your username is not set. You may not be logged in. "
                   "Would you like to try to logout anyway?"), default=True)
-    safeprint('Logging out of Globus{}'.format(' as ' + username
-                                               if username else ''))
+    safeprint('Logging out of Globus{}\n'.format(' as ' + username
+                                                 if username else ''))
 
     # build the NativeApp client object
     native_client = internal_auth_client()
 
     # remove tokens from config and revoke them
+    # also, track whether or not we should print the rescind help
+    print_rescind_help = False
     for token_opt in (TRANSFER_RT_OPTNAME, TRANSFER_AT_OPTNAME,
-                      TRANSFER_AT_EXPIRES_OPTNAME,
-                      AUTH_RT_OPTNAME, AUTH_AT_OPTNAME,
-                      AUTH_AT_EXPIRES_OPTNAME):
+                      AUTH_RT_OPTNAME, AUTH_AT_OPTNAME):
         # first lookup the token -- if not found we'll continue
         token = lookup_option(token_opt)
         if not token:
+            safeprint(('Warning: Found no token named "{}"! '
+                       'Recommend rescinding consent').format(token_opt))
+            print_rescind_help = True
             continue
         # token was found, so try to revoke it
         try:
@@ -68,7 +92,21 @@ def logout_command(yes):
         # finally, we revoked, so it's safe to remove the token
         remove_option(token_opt)
 
+    # remove expiration times, just for cleanliness
+    for expires_opt in (TRANSFER_AT_EXPIRES_OPTNAME,
+                        AUTH_AT_EXPIRES_OPTNAME):
+        remove_option(expires_opt)
+
     # remove whoami data
     for whoami_opt in (WHOAMI_ID_OPTNAME, WHOAMI_USERNAME_OPTNAME,
                        WHOAMI_EMAIL_OPTNAME, WHOAMI_NAME_OPTNAME):
         remove_option(whoami_opt)
+
+    safeprint(_LOGOUT_EPILOG)
+
+    # if some token wasn't found in the config, it means its possible that the
+    # config file was removed without logout
+    # in that case, the user should rescind the CLI consent to invalidate any
+    # potentially leaked refresh tokens, so print the help on that
+    if print_rescind_help:
+        safeprint(_RESCIND_HELP)

--- a/globus_cli/commands/logout.py
+++ b/globus_cli/commands/logout.py
@@ -1,4 +1,5 @@
 import click
+import globus_sdk
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import common_options
@@ -12,32 +13,62 @@ from globus_cli.config import (
 
 
 @click.command('logout',
-               short_help=('Logout of Globus, revoking credentials for '
-                           'the Globus CLI'),
-               help=('Remove credentials for the Globus CLI. '
-                     'Effectively stops any use of your CLI credentials as '
-                     'well'))
-@common_options
-def logout_command():
-    # build the NativeApp client object
-    native_client = internal_auth_client()
+               short_help='Logout of the Globus CLI',
+               help=('Logout of the Globus CLI. '
+                     'Removes your Globus tokens from local storage, '
+                     'and revokes them so that they cannot be used anymore'))
+@common_options(no_format_option=True, no_map_http_status_option=True)
+@click.option('--yes', help='Automatically say "Yes" to all prompts',
+              is_flag=True, default=False)
+def logout_command(yes):
+    def _confirm(prompt, default=False):
+        """
+        Handy confirmation prompt that respects --yes and exits if confirmation
+        fails.
+        """
+        if yes:
+            return
+        confirmed = click.confirm(prompt, default=default)
+        if not confirmed:
+            click.get_current_context().exit(1)
 
     # prompt
-    confirmed = click.confirm("Are you sure you'd like to logout?")
-    if not confirmed:
-        return
+    _confirm("Are you sure you'd like to logout?")
 
-    safeprint('Logging out of Globus as {}'
-              .format(lookup_option(WHOAMI_USERNAME_OPTNAME)))
+    # check for username -- if not set, probably not logged in
+    username = lookup_option(WHOAMI_USERNAME_OPTNAME)
+    if not username:
+        _confirm(("Your username is not set. You may not be logged in. "
+                  "Would you like to try to logout anyway?"), default=True)
+    safeprint('Logging out of Globus{}'.format(' as ' + username
+                                               if username else ''))
+
+    # build the NativeApp client object
+    native_client = internal_auth_client()
 
     # remove tokens from config and revoke them
     for token_opt in (TRANSFER_RT_OPTNAME, TRANSFER_AT_OPTNAME,
                       TRANSFER_AT_EXPIRES_OPTNAME,
                       AUTH_RT_OPTNAME, AUTH_AT_OPTNAME,
                       AUTH_AT_EXPIRES_OPTNAME):
-        token = remove_option(token_opt)
-        if token:
+        # first lookup the token -- if not found we'll continue
+        token = lookup_option(token_opt)
+        if not token:
+            continue
+        # token was found, so try to revoke it
+        try:
             native_client.oauth2_revoke_token(token)
+        # if we network error, revocation failed -- print message and abort so
+        # that we can revoke later when the network is working
+        except globus_sdk.NetworkError:
+            safeprint(('Failed to reach Globus to revoke tokens. '
+                       'Because we cannot revoke these tokens, cancelling '
+                       'logout'))
+            click.get_current_context().exit(1)
+        # finally, we revoked, so it's safe to remove the token
+        remove_option(token_opt)
+
+    # remove whoami data
     for whoami_opt in (WHOAMI_ID_OPTNAME, WHOAMI_USERNAME_OPTNAME,
                        WHOAMI_EMAIL_OPTNAME, WHOAMI_NAME_OPTNAME):
         remove_option(whoami_opt)

--- a/globus_cli/commands/logout.py
+++ b/globus_cli/commands/logout.py
@@ -54,7 +54,7 @@ def logout_command(yes):
             click.get_current_context().exit(1)
 
     # prompt
-    _confirm("Are you sure you'd like to logout?")
+    _confirm("Are you sure you want to logout?")
 
     # check for username -- if not set, probably not logged in
     username = lookup_option(WHOAMI_USERNAME_OPTNAME)

--- a/globus_cli/commands/logout.py
+++ b/globus_cli/commands/logout.py
@@ -19,6 +19,7 @@ The logout command only revokes tokens that it can see in its storage.
 If you are concerned that logout may have failed to revoke a token,
 you may want to manually rescind the Globus CLI consent on the
 Manage Consents Page:
+
     https://auth.globus.org/consents
 
 """
@@ -39,28 +40,14 @@ Before attempting any further CLI commands, you will have to login again using
                      'Removes your Globus tokens from local storage, '
                      'and revokes them so that they cannot be used anymore'))
 @common_options(no_format_option=True, no_map_http_status_option=True)
-@click.option('--yes', help='Automatically say "Yes" to all prompts',
-              is_flag=True, default=False)
-def logout_command(yes):
-    def _confirm(prompt, default=False):
-        """
-        Handy confirmation prompt that respects --yes and exits if confirmation
-        fails.
-        """
-        if yes:
-            return
-        confirmed = click.confirm(prompt, default=default)
-        if not confirmed:
-            click.get_current_context().exit(1)
-
-    # prompt
-    _confirm("Are you sure you want to logout?")
-
+@click.confirmation_option(prompt='Are you sure you want to logout?',
+                           help='Automatically say "yes" to all prompts')
+def logout_command():
     # check for username -- if not set, probably not logged in
     username = lookup_option(WHOAMI_USERNAME_OPTNAME)
     if not username:
-        _confirm(("Your username is not set. You may not be logged in. "
-                  "Would you like to try to logout anyway?"), default=True)
+        safeprint(("Your username is not set. You may not be logged in. "
+                   "Attempting logout anyway...\n"))
     safeprint('Logging out of Globus{}\n'.format(' as ' + username
                                                  if username else ''))
 

--- a/globus_cli/commands/main.py
+++ b/globus_cli/commands/main.py
@@ -4,6 +4,7 @@ from globus_cli.commands.list_commands import list_commands
 from globus_cli.commands.config import config_command
 
 from globus_cli.commands.login import login_command
+from globus_cli.commands.logout import logout_command
 from globus_cli.commands.whoami import whoami_command
 
 from globus_cli.commands.get_identities import get_identities_command
@@ -27,6 +28,7 @@ main.add_command(list_commands)
 main.add_command(config_command)
 
 main.add_command(login_command)
+main.add_command(logout_command)
 main.add_command(whoami_command)
 
 main.add_command(get_identities_command)

--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -95,11 +95,14 @@ def remove_option(option, section='cli', system=False):
     conf = get_config_obj(system=system)
     section = conf[section]
 
-    opt_val = section[option]
+    try:
+        opt_val = section[option]
 
-    # remove value and flush to disk
-    del section[option]
-    conf.write()
+        # remove value and flush to disk
+        del section[option]
+        conf.write()
+    except KeyError:
+        opt_val = None
 
     # return the just-deleted value
     return opt_val

--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -93,7 +93,12 @@ def lookup_option(option, section='cli', environment=None):
 
 def remove_option(option, section='cli', system=False):
     conf = get_config_obj(system=system)
-    section = conf[section]
+
+    # if there's no section for the option we're removing, just return None
+    try:
+        section = conf[section]
+    except KeyError:
+        return None
 
     try:
         opt_val = section[option]

--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -31,6 +31,7 @@ __all__ = [
 
     'get_config_obj',
     'write_option',
+    'remove_option',
     'lookup_option',
 ]
 
@@ -88,6 +89,20 @@ def get_config_obj(system=False):
 def lookup_option(option, section='cli', environment=None):
     p = globus_sdk.config._get_parser()
     return p.get(option, section=section, environment=environment)
+
+
+def remove_option(option, section='cli', system=False):
+    conf = get_config_obj(system=system)
+    section = conf[section]
+
+    opt_val = section[option]
+
+    # remove value and flush to disk
+    del section[option]
+    conf.write()
+
+    # return the just-deleted value
+    return opt_val
 
 
 def write_option(option, value, section='cli', system=False):

--- a/globus_cli/parsing/command_state.py
+++ b/globus_cli/parsing/command_state.py
@@ -101,7 +101,7 @@ def map_http_status_option(f):
 
     return click.option(
         '--map-http-status',
-        help=('Map HTTP statuses to any of these exit codes: 0,1,50-99.'
+        help=('Map HTTP statuses to any of these exit codes: 0,1,50-99. '
               'Given by providing both values separated by an "=", as in '
               '\'--map-http-status "404=0"\' or '
               '--map-http-status "404=50,403=51"'),


### PR DESCRIPTION
Revokes all tokens, and deletes them from config. Further attempts to
use the tokens naturally fail.
As an unfortunate aside, we can't do much to direct users into the
consents page right now. Maybe print some epilog help about how to go
there and remove the consent? It's a dead entity, but we can't clean it
up at all.

Resolves #38