### PR TITLE
Update `--version` to properly handle no network

### DIFF
--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -1,43 +1,10 @@
 import click
 
-from globus_cli.version import get_versions
 from globus_cli.parsing.command_state import (
     format_option, debug_option, map_http_status_option)
+from globus_cli.parsing.version_option import version_option
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
 from globus_cli.parsing.detect_and_decorate import detect_and_decorate
-
-
-def version_option(f):
-    """
-    Largely a custom clone of click.version_option -- almost identical, but
-    makes more assumptions and prints our special output.
-    """
-    def callback(ctx, param, value):
-        # copied from click.decorators.version_option
-        # no idea what resilient_parsing means, but...
-        if not value or ctx.resilient_parsing:
-            return
-
-        latest, current = get_versions()
-        click.echo(('Installed Version: {0}\n'
-                    'Latest Version:    {1}\n'
-                    '\n{2}').format(
-                        current, latest,
-                        'You are running the latest version of the Globus CLI'
-                        if current == latest else
-                        ('You should update your version of the Globus CLI\n'
-                         'Update instructions: '
-                         'https://globus.github.io/globus-cli/'
-                         '#updating-and-removing')
-                        if current < latest else
-                        'You are running a preview version of the Globus CLI'
-            )
-        )
-        ctx.exit()
-
-    return click.option('--version', help='Show the version and exit.',
-                        is_flag=True, expose_value=False, is_eager=True,
-                        callback=callback)(f)
 
 
 def common_options(*args, **kwargs):

--- a/globus_cli/parsing/version_option.py
+++ b/globus_cli/parsing/version_option.py
@@ -1,0 +1,44 @@
+import click
+
+from globus_cli.safeio import safeprint
+from globus_cli.version import get_versions
+
+
+def version_option(f):
+    """
+    Largely a custom clone of click.version_option -- almost identical, but
+    makes more assumptions and prints our special output.
+    """
+    def callback(ctx, param, value):
+        # copied from click.decorators.version_option
+        # no idea what resilient_parsing means, but...
+        if not value or ctx.resilient_parsing:
+            return
+
+        latest, current = get_versions()
+        if latest is None:
+            safeprint(('Installed Version: {0}\n'
+                       'Failed to lookup latest version.')
+                      .format(current))
+        else:
+            safeprint(
+                ('Installed Version: {0}\n'
+                 'Latest Version:    {1}\n'
+                 '\n{2}').format(
+                    current, latest,
+                    'You are running the latest version of the Globus CLI'
+                    if current == latest else
+                    ('You should update your version of the Globus CLI\n'
+                     'Update instructions: '
+                     'https://globus.github.io/globus-cli/'
+                     '#updating-and-removing')
+                     if current < latest else
+                     'You are running a preview version of the Globus CLI'
+                )
+            )
+
+        ctx.exit(0)
+
+    return click.option('--version', help='Show the version and exit.',
+                        is_flag=True, expose_value=False, is_eager=True,
+                        callback=callback)(f)

--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -38,7 +38,11 @@ def get_versions():
     # `requests` isn't required -- otherwise, setuptools will fail to run
     # because requests isn't installed yet.
     import requests
-    version_data = requests.get(
-        'https://pypi.python.org/pypi/globus-cli/json').json()
-    latest = max(LooseVersion(v) for v in version_data['releases'])
-    return latest, LooseVersion(__version__)
+    try:
+        version_data = requests.get(
+            'https://pypi.python.org/pypi/globus-cli/json').json()
+        latest = max(LooseVersion(v) for v in version_data['releases'])
+        return latest, LooseVersion(__version__)
+    # if the fetch from pypi fails
+    except requests.RequestException:
+        return None, LooseVersion(__version__)


### PR DESCRIPTION
With no network connection, crashfailing on `--version` is pretty bad behavior. Catch the `RequestException` and just show the current version.

Also moves the version option out of the ever-growing `shared_options` module.