### PR TITLE
Add success confirmation output for `globus login`

### DIFF
--- a/globus_cli/commands/login.py
+++ b/globus_cli/commands/login.py
@@ -13,6 +13,23 @@ from globus_cli.config import (
     internal_auth_client, write_option)
 
 
+_LOGIN_EPILOG = ("""\
+
+SUCCESS
+You have logged in to the Globus CLI as {}
+
+A set of valid tokens for accessing Globus have been saved for you in
+~/.globus.cfg and are valid indefinitely unless revoked.
+
+
+You can always check your current identity with
+  globus whoami
+
+Logout and invalidate these credentials at any time with
+  globus logout
+""")
+
+
 @click.command('login',
                short_help=('Login to Globus to get credentials for '
                            'the Globus CLI'),
@@ -81,3 +98,5 @@ def login_command():
     write_option(WHOAMI_USERNAME_OPTNAME, identity['username'])
     write_option(WHOAMI_EMAIL_OPTNAME, identity['email'])
     write_option(WHOAMI_NAME_OPTNAME, identity['name'])
+
+    safeprint(_LOGIN_EPILOG.format(identity['username']))

--- a/globus_cli/commands/login.py
+++ b/globus_cli/commands/login.py
@@ -15,17 +15,13 @@ from globus_cli.config import (
 
 _LOGIN_EPILOG = ("""\
 
-SUCCESS
-You have logged in to the Globus CLI as {}
-
-A set of valid tokens for accessing Globus have been saved for you in
-~/.globus.cfg and are valid indefinitely unless revoked.
+You have successfully logged in to the Globus CLI as {}
 
 
 You can always check your current identity with
   globus whoami
 
-Logout and invalidate these credentials at any time with
+Logout of the Globus CLI with
   globus logout
 """)
 


### PR DESCRIPTION
Depends on #120 -- don't merge before that.
Makes it clear that login worked, and that you can check your status with `whoami` or logout with `logout`.
Resolves #52

@stumartin as an example of the output in this new version, here's what I get:
```
$ globus login
Please login to Globus here:
---------------------------
https://auth.globus.org/v2/oauth2/authorize?code_challenge=<redacted>
---------------------------

Enter the resulting Authorization Code here: <redacted>

SUCCESS
You have logged in to the Globus CLI as sirosen@globusid.org

A set of valid tokens for accessing Globus have been saved for you in
~/.globus.cfg and are valid indefinitely unless revoked.


You can always check your current identity with
  globus whoami

Logout and invalidate these credentials at any time with
  globus logout

```
Can you confirm that this resolves the issue as you see it?