### PR TITLE
Show principal_type in acl list for unusual types

### DIFF
--- a/globus_cli/commands/endpoint/permission/list.py
+++ b/globus_cli/commands/endpoint/permission/list.py
@@ -28,6 +28,8 @@ def list_command(endpoint_id):
             elif rule['principal_type'] == 'group':
                 return ('https://www.globus.org/app/groups/{}'
                         ).format(principal)
+            else:
+                principal = rule['principal_type']
             return principal
 
         print_table(rules, [('Rule ID', 'id'), ('Permissions', 'permissions'),


### PR DESCRIPTION
For anonymous and all_authenticated_users we want to show the type, not the value, in the acl listing. (The values for these are always "").
Luckily, the other values in this column fit strict formats that preclude any matches with these strings, so the result is unambiguous.

Resolves #114