### PR TITLE
Add `permission show` command

### DIFF
--- a/globus_cli/commands/endpoint/permission/commands.py
+++ b/globus_cli/commands/endpoint/permission/commands.py
@@ -4,6 +4,7 @@ from globus_cli.parsing import common_options
 
 from globus_cli.commands.endpoint.permission.list import list_command
 from globus_cli.commands.endpoint.permission.create import create_command
+from globus_cli.commands.endpoint.permission.show import show_command
 from globus_cli.commands.endpoint.permission.update import update_command
 from globus_cli.commands.endpoint.permission.delete import delete_command
 
@@ -17,5 +18,6 @@ def permission_command():
 
 permission_command.add_command(list_command)
 permission_command.add_command(create_command)
+permission_command.add_command(show_command)
 permission_command.add_command(update_command)
 permission_command.add_command(delete_command)

--- a/globus_cli/commands/endpoint/permission/show.py
+++ b/globus_cli/commands/endpoint/permission/show.py
@@ -1,0 +1,37 @@
+import click
+
+from globus_cli.parsing import common_options, endpoint_id_arg
+from globus_cli.helpers import (
+    outformat_is_json, print_json_response, colon_formatted_print)
+from globus_cli.services.auth import lookup_identity_name
+from globus_cli.services.transfer import get_client
+
+
+def _shared_with_keyfunc(rule):
+    if rule['principal_type'] == 'identity':
+        return lookup_identity_name(rule['principal'])
+    elif rule['principal_type'] == 'group':
+        return ('https://www.globus.org/app/groups/{}'
+                .format(rule['principal']))
+    else:
+        return rule['principal_type']
+
+
+@click.command('show', help='Show a Permission on an Endpoint')
+@common_options
+@endpoint_id_arg
+@click.argument('rule_id')
+def show_command(endpoint_id, rule_id):
+    """
+    Executor for `globus endpoint permission show`
+    """
+    client = get_client()
+
+    rule = client.get_endpoint_acl_rule(endpoint_id, rule_id)
+
+    if outformat_is_json():
+        print_json_response(rule)
+    else:
+        fields = (('Rule ID', 'id'), ('Permissions', 'permissions'),
+                  ('Shared With', _shared_with_keyfunc), ('Path', 'path'))
+        colon_formatted_print(rule, fields)

--- a/globus_cli/helpers/printing.py
+++ b/globus_cli/helpers/printing.py
@@ -8,10 +8,31 @@ def print_json_response(res):
     safeprint(json.dumps(res.data, indent=2))
 
 
+def _key_to_keyfunc(k):
+    """
+    We allow for 'keys' which are functions that map columns onto value
+    types -- they may do formatting or inspect multiple values on the
+    object. In order to support this, wrap string keys in a simple function
+    that does the natural lookup operation, but return any functions we
+    receive as they are.
+    """
+    # if the key is a string, then the "keyfunc" is just a basic lookup
+    # operation -- return that
+    if isinstance(k, six.string_types):
+        def lookup(x):
+            return x[k]
+        return lookup
+    # otherwise, the key must be a function which is executed on the item
+    # to produce a value -- return it verbatim
+    return k
+
+
 def colon_formatted_print(data, named_fields):
     maxlen = max(len(n) for n, f in named_fields) + 1
     for name, field in named_fields:
-        safeprint('{} {}'.format((name + ':').ljust(maxlen), data[field]))
+        field_keyfunc = _key_to_keyfunc(field)
+        safeprint('{} {}'.format((name + ':').ljust(maxlen),
+                                 field_keyfunc(data)))
 
 
 def print_table(iterable, headers_and_keys, print_headers=True):
@@ -24,26 +45,8 @@ def print_table(iterable, headers_and_keys, print_headers=True):
     headers = [h for (h, k) in headers_and_keys]
     keys = [k for (h, k) in headers_and_keys]
 
-    def key_to_keyfunc(k):
-        """
-        We allow for 'keys' which are functions that map columns onto value
-        types -- they may do formatting or inspect multiple values on the
-        object. In order to support this, wrap string keys in a simple function
-        that does the natural lookup operation, but return any functions we
-        receive as they are.
-        """
-        # if the key is a string, then the "keyfunc" is just a basic lookup
-        # operation -- return that
-        if isinstance(k, six.string_types):
-            def lookup(x):
-                return x[k]
-            return lookup
-        # otherwise, the key must be a function which is executed on the item
-        # to produce a value -- return it verbatim
-        return k
-
     # convert all keys to keyfuncs
-    keyfuncs = [key_to_keyfunc(key) for key in keys]
+    keyfuncs = [_key_to_keyfunc(key) for key in keys]
 
     # use the iterable to find the max width of an element for each column, in
     # the same order as the headers_and_keys array


### PR DESCRIPTION
To get this working, it was necessary to give colon_formatted_print the same keyfunction capabilites as table printing, so there's a bit of a refactor in the printing helpers.
Adds `permission show` very similar to `permission list`, especially with the fix for #114 in place.

Resolves #110