### PR TITLE
Add department and keywords to endpoint fields

### DIFF
--- a/globus_cli/commands/endpoint/create.py
+++ b/globus_cli/commands/endpoint/create.py
@@ -16,9 +16,9 @@ from globus_cli.services.transfer import get_client, assemble_generic_doc
               flag_value='personal', default=True, show_default=True,
               help='This endpoint is a Globus Connect Personal endpoint')
 def endpoint_create(endpoint_type, display_name, description, organization,
-                    contact_email, contact_info, info_link, public,
-                    default_directory, force_encryption, oauth_server,
-                    myproxy_server, myproxy_dn):
+                    department, keywords, contact_email, contact_info,
+                    info_link, public, default_directory, force_encryption,
+                    oauth_server, myproxy_server, myproxy_dn):
     """
     Executor for `globus endpoint create`
     """
@@ -27,7 +27,8 @@ def endpoint_create(endpoint_type, display_name, description, organization,
         # omit this key if not personal, but include as True if personal
         is_globus_connect=(endpoint_type == 'personal' or None),
         display_name=display_name, description=description,
-        organization=organization, contact_email=contact_email,
+        organization=organization, department=department,
+        keywords=keywords, contact_email=contact_email,
         contact_info=contact_info, info_link=info_link,
         force_encryption=force_encryption, public=public,
         default_directory=default_directory,

--- a/globus_cli/commands/endpoint/share.py
+++ b/globus_cli/commands/endpoint/share.py
@@ -13,8 +13,8 @@ from globus_cli.services.transfer import (
                 type=ENDPOINT_PLUS_REQPATH)
 @endpoint_create_and_update_params(create=True, shared_ep=True)
 def endpoint_create_share(endpoint_plus_path, display_name, description,
-                          organization, contact_email, contact_info,
-                          info_link):
+                          department, keywords, organization, contact_email,
+                          contact_info, info_link):
     """
     Executor for `globus share create`
     """
@@ -24,8 +24,9 @@ def endpoint_create_share(endpoint_plus_path, display_name, description,
         'shared_endpoint',
         host_endpoint=endpoint_id, host_path=host_path,
         display_name=display_name, description=description,
-        organization=organization, contact_email=contact_email,
-        contact_info=contact_info, info_link=info_link, public=True)
+        department=department, keywords=keywords, organization=organization,
+        contact_email=contact_email, contact_info=contact_info,
+        info_link=info_link, public=True)
 
     client = get_client()
     autoactivate(client, endpoint_id, if_expires_in=60)

--- a/globus_cli/commands/endpoint/show.py
+++ b/globus_cli/commands/endpoint/show.py
@@ -23,5 +23,6 @@ def endpoint_show(endpoint_id):
     else:
         fields = (('Display Name', 'display_name'), ('ID', 'id'),
                   ('Owner', 'owner_string'), ('Activated', 'activated'),
-                  ('Shareable', 'shareable'))
+                  ('Shareable', 'shareable'),
+                  ('Department', 'department'), ('Keywords', 'keywords'))
         colon_formatted_print(res, fields)

--- a/globus_cli/commands/endpoint/update.py
+++ b/globus_cli/commands/endpoint/update.py
@@ -13,9 +13,9 @@ from globus_cli.services.transfer import get_client, assemble_generic_doc
 @endpoint_id_arg
 @endpoint_create_and_update_params(create=False)
 def endpoint_update(endpoint_id, display_name, description, organization,
-                    contact_email, contact_info, info_link, public,
-                    default_directory, force_encryption, oauth_server,
-                    myproxy_server, myproxy_dn):
+                    department, keywords, contact_email, contact_info,
+                    info_link, public, default_directory, force_encryption,
+                    oauth_server, myproxy_server, myproxy_dn):
     """
     Executor for `globus endpoint update`
     """
@@ -24,12 +24,11 @@ def endpoint_update(endpoint_id, display_name, description, organization,
     ep_doc = assemble_generic_doc(
         'endpoint',
         display_name=display_name, description=description,
-        organization=organization, contact_email=contact_email,
-        contact_info=contact_info, info_link=info_link,
-        force_encryption=force_encryption, public=public,
-        default_directory=default_directory,
-        myproxy_server=myproxy_server, myproxy_dn=myproxy_dn,
-        oauth_server=oauth_server)
+        organization=organization, department=department, keywords=keywords,
+        contact_email=contact_email, contact_info=contact_info,
+        info_link=info_link, force_encryption=force_encryption, public=public,
+        default_directory=default_directory, myproxy_server=myproxy_server,
+        myproxy_dn=myproxy_dn, oauth_server=oauth_server)
 
     res = client.update_endpoint(endpoint_id, ep_doc)
 

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -123,26 +123,27 @@ def endpoint_create_and_update_params(*args, **kwargs):
     Usage:
 
     >>> @endpoint_create_and_update_params
-    >>> def command_func(display_name, description, organization,
-    >>>                  contact_email, contact_info, info_link, public,
-    >>>                  default_directory, force_encryption, oauth_server,
-    >>>                  myproxy_server, myproxy_dn):
+    >>> def command_func(display_name, description, organization, department,
+    >>>                  keywords, contact_email, contact_info, info_link,
+    >>>                  public, default_directory, force_encryption,
+    >>>                  oauth_server, myproxy_server, myproxy_dn):
     >>>     ...
 
     or
 
     >>> @endpoint_create_and_update_params(create=False)
-    >>> def command_func(display_name, description, organization,
-    >>>                  contact_email, contact_info, info_link, public,
-    >>>                  default_directory, force_encryption, oauth_server,
-    >>>                  myproxy_server, myproxy_dn):
+    >>> def command_func(display_name, description, organization, department,
+    >>>                  keywords, contact_email, contact_info, info_link,
+    >>>                  public, default_directory, force_encryption,
+    >>>                  oauth_server, myproxy_server, myproxy_dn):
     >>>     ...
 
     or
 
     >>> @endpoint_create_and_update_params(shared_ep=True)
-    >>> def command_func(display_name, description, organization,
-    >>>                  contact_email, contact_info, info_link, public):
+    >>> def command_func(display_name, description, organization, department,
+    >>>                  keywords, contact_email, contact_info, info_link,
+    >>>                  public):
     >>>     ...
     """
     def apply_non_shared_params(f):
@@ -199,6 +200,15 @@ def endpoint_create_and_update_params(*args, **kwargs):
             '--description',
             help=(update_help_prefix +
                   'Description for the {0}'.format(ep_or_share)))(f)
+        f = click.option(
+            '--department',
+            help=(update_help_prefix +
+                  'Department which operates the {0}'.format(ep_or_share)))(f)
+        f = click.option(
+            '--keywords',
+            help=(update_help_prefix +
+                  'Keywords to help searches for the {0}'
+                  .format(ep_or_share)))(f)
         if create:
             f = click.argument('display_name')(f)
         else:


### PR DESCRIPTION
Add these for endpoint show, create, update, and share commands.
It's not really clear how to describe "Department" as a general property of endpoints (because it's weird that it is one), but the helptext will do for now.

Resolves #107