### PR TITLE
The privacy of an endpoint defaults to notset on updates

### DIFF
--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -135,7 +135,7 @@ def endpoint_create_and_update_params(*args, **kwargs):
             help=('Only available on Globus Connect Server. '
                   'Set the default directory'))(f)
         f = click.option(
-            '--public/--private', 'public',
+            '--public/--private', 'public', default=None,
             help='Set the Endpoint to be public or private')(f)
 
         return f


### PR DESCRIPTION
Making the default None instead of a T/F value means that it won't get passed to the API accidentally in update scenarios where we don't want to be changing this.

Fixes #127