### PR TITLE
Use separated fgrep calls for dry-run submission

### DIFF
--- a/basic_tests.sh
+++ b/basic_tests.sh
@@ -14,10 +14,17 @@ globus get-identities 'abc@globus.org' --map-http-status "401=0"
 globus ls 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' --map-http-status "400=0"
 
 # transfer batchmode dry-run
-echo -e "abc /def\n/xyz p/q/r" | \
+submission_doc=$(
     globus transfer --batch --dry-run \
         --submission-id '89330878-9ffe-11e6-b61b-8c705ad34f60' \
         'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
-        'ddb59af0-6d04-11e5-ba46-22000b92c6ec:base/' | \
-    tr '\n' ' ' | \
-    egrep '"destination_path": "/def".*"source_path": "abc".*"destination_path": "base/p/q/r".*"source_path": "/xyz"'
+        'ddb59af0-6d04-11e5-ba46-22000b92c6ec:base/' \
+    << EOF
+        abc /def
+        /xyz p/q/r
+EOF
+)
+fgrep '"source_path": "abc"' <<< $submission_doc
+fgrep '"destination_path": "/def"' <<< $submission_doc
+fgrep '"source_path": "/xyz"' <<< $submission_doc
+fgrep '"destination_path": "base/p/q/r"' <<< $submission_doc


### PR DESCRIPTION
Because the dict key order in Python is not deterministic, this test was sporadically failing. Instead of using one big regular expression, break it into four individual calls to `fgrep` so that the non-deterministic order of the keys doesn't matter.

If you want to fix this by using the `sort_keys=True` flag on `json.dumps()`, feel free to close this.