### PR TITLE
Human text output for `create` commands lacking it

### DIFF
--- a/globus_cli/commands/endpoint/permission/create.py
+++ b/globus_cli/commands/endpoint/permission/create.py
@@ -3,7 +3,8 @@ import click
 from globus_cli.parsing import (
     CaseInsensitiveChoice, common_options, ENDPOINT_PLUS_REQPATH,
     security_principal_opts)
-from globus_cli.helpers import print_json_response
+from globus_cli.helpers import (
+    outformat_is_json, print_json_response, colon_formatted_print)
 
 from globus_cli.services.auth import maybe_lookup_identity_id
 
@@ -41,4 +42,8 @@ def create_command(principal, permissions, endpoint_plus_path):
 
     res = client.add_endpoint_acl_rule(endpoint_id, rule_data)
 
-    print_json_response(res)
+    if outformat_is_json():
+        print_json_response(res)
+    else:
+        colon_formatted_print(res, [('Message', 'message'),
+                                    ('Rule ID', 'access_id')])

--- a/globus_cli/commands/endpoint/share.py
+++ b/globus_cli/commands/endpoint/share.py
@@ -2,7 +2,8 @@ import click
 
 from globus_cli.parsing import (
     common_options, endpoint_create_and_update_params, ENDPOINT_PLUS_REQPATH)
-from globus_cli.helpers import print_json_response
+from globus_cli.helpers import (
+    outformat_is_json, print_json_response, colon_formatted_print)
 from globus_cli.services.transfer import (
     autoactivate, get_client, assemble_generic_doc)
 
@@ -31,4 +32,9 @@ def endpoint_create_share(endpoint_plus_path, display_name, description,
     client = get_client()
     autoactivate(client, endpoint_id, if_expires_in=60)
     res = client.create_shared_endpoint(ep_doc)
-    print_json_response(res)
+
+    if outformat_is_json():
+        print_json_response(res)
+    else:
+        colon_formatted_print(res, [('Message', 'message'),
+                                    ('Endpoint ID', 'id')])


### PR DESCRIPTION
Adds this for `endpoint create`, `endpoint share`, and `endpoint permission create`. Most of these just output the Transfer message and relevant record ID.

The only interesting one is `endpoint create --globus-connect-personal`, which will output the setup key too.

Toward #35.