### PR TITLE
Better handling for `globus endpoint server list` when the user asks about an endpoint that isn't a GCS endpoint

### DIFF
--- a/globus_cli/commands/endpoint/server/list.py
+++ b/globus_cli/commands/endpoint/server/list.py
@@ -6,7 +6,8 @@ from globus_cli.safeio import safeprint
 from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.helpers import (colon_formatted_print, print_table,
                                 outformat_is_json)
-from globus_cli.services.transfer import get_client, print_json_from_iterator
+from globus_cli.services.transfer import (display_name_or_cname,
+                                          get_client, print_json_from_iterator)
 
 
 @click.command('list', help='List all servers belonging to an Endpoint')
@@ -22,14 +23,14 @@ def server_list(endpoint_id):
 
     if endpoint['host_endpoint_id']:  # not GCS -- this is a share endpoint
         raise click.UsageError(dedent("""\
-            {id} ({display_name}) is a share and does not have servers.
+            {id} ({0}) is a share and does not have servers.
 
             To see details of the share, use
                 globus endpoint show {id}
 
             To list the servers on the share's host endpoint, use
                 globus endpoint server list {host_endpoint_id}
-        """).format(**endpoint.data))
+        """).format(display_name_or_cname(endpoint), **endpoint.data))
 
     if endpoint['s3_url']:  # not GCS -- this is an S3 endpoint
         if outformat_is_json():

--- a/globus_cli/commands/endpoint/server/list.py
+++ b/globus_cli/commands/endpoint/server/list.py
@@ -45,4 +45,7 @@ def server_list(endpoint_id):
     if outformat_is_json():
         print_json_from_iterator(server_iterator)
     else:
-        print_table(server_iterator, [('ID', 'id'), ('URI', 'uri')])
+        print_table(server_iterator, [
+            ('ID', 'id'),
+            ('URI', lambda s: s['uri'] or "none (Globus Connect Personal)"),
+        ])

--- a/globus_cli/commands/endpoint/server/list.py
+++ b/globus_cli/commands/endpoint/server/list.py
@@ -14,6 +14,20 @@ def server_list(endpoint_id):
     """
     client = get_client()
 
+    endpoint = client.get_endpoint(endpoint_id)
+
+    if endpoint['host_endpoint_id']:  # not GCS -- this is a share endpoint
+        raise click.UsageError(
+            "{id} ({display_name}) is a share and does not have servers.\n"
+            "\n"
+            "To see details of the share, use\n"
+            "    globus endpoint show {id}\n"
+            "\n"
+            "To list the servers on the share's host endpoint, use\n"
+            "    globus endpoint server list {host_endpoint_id}".
+            format(**endpoint.data)
+        )
+
     server_iterator = client.endpoint_server_list(endpoint_id)
 
     if outformat_is_json():

--- a/globus_cli/commands/endpoint/server/list.py
+++ b/globus_cli/commands/endpoint/server/list.py
@@ -1,4 +1,5 @@
 import json
+from textwrap import dedent
 import click
 
 from globus_cli.safeio import safeprint
@@ -20,16 +21,15 @@ def server_list(endpoint_id):
     endpoint = client.get_endpoint(endpoint_id)
 
     if endpoint['host_endpoint_id']:  # not GCS -- this is a share endpoint
-        raise click.UsageError(
-            "{id} ({display_name}) is a share and does not have servers.\n"
-            "\n"
-            "To see details of the share, use\n"
-            "    globus endpoint show {id}\n"
-            "\n"
-            "To list the servers on the share's host endpoint, use\n"
-            "    globus endpoint server list {host_endpoint_id}".
-            format(**endpoint.data)
-        )
+        raise click.UsageError(dedent("""\
+            {id} ({display_name}) is a share and does not have servers.
+
+            To see details of the share, use
+                globus endpoint show {id}
+
+            To list the servers on the share's host endpoint, use
+                globus endpoint server list {host_endpoint_id}
+        """).format(**endpoint.data))
 
     if endpoint['s3_url']:  # not GCS -- this is an S3 endpoint
         if outformat_is_json():

--- a/globus_cli/commands/endpoint/server/list.py
+++ b/globus_cli/commands/endpoint/server/list.py
@@ -1,7 +1,10 @@
+import json
 import click
 
+from globus_cli.safeio import safeprint
 from globus_cli.parsing import common_options, endpoint_id_arg
-from globus_cli.helpers import print_table, outformat_is_json
+from globus_cli.helpers import (colon_formatted_print, print_table,
+                                outformat_is_json)
 from globus_cli.services.transfer import get_client, print_json_from_iterator
 
 
@@ -28,6 +31,14 @@ def server_list(endpoint_id):
             format(**endpoint.data)
         )
 
+    if endpoint['s3_url']:  # not GCS -- this is an S3 endpoint
+        if outformat_is_json():
+            safeprint(json.dumps({'s3_uri': endpoint['s3_url']}, indent=2))
+        else:
+            colon_formatted_print(endpoint, [("S3 URL", 's3_url')])
+        return
+
+    # regular GCS host endpoint; use Transfer's server list API
     server_iterator = client.endpoint_server_list(endpoint_id)
 
     if outformat_is_json():

--- a/globus_cli/commands/endpoint/server/list.py
+++ b/globus_cli/commands/endpoint/server/list.py
@@ -33,7 +33,7 @@ def server_list(endpoint_id):
 
     if endpoint['s3_url']:  # not GCS -- this is an S3 endpoint
         if outformat_is_json():
-            safeprint(json.dumps({'s3_uri': endpoint['s3_url']}, indent=2))
+            safeprint(json.dumps({'s3_url': endpoint['s3_url']}, indent=2))
         else:
             colon_formatted_print(endpoint, [("S3 URL", 's3_url')])
         return

--- a/globus_cli/commands/endpoint/server/show.py
+++ b/globus_cli/commands/endpoint/server/show.py
@@ -21,6 +21,12 @@ def server_show(endpoint_id, server_id):
 
     if outformat_is_json():
         print_json_response(server_doc)
+
+    elif not server_doc['uri']:  # GCP endpoint server
+        fields = (('ID', 'id'), ('Is Connected', 'is_connected'),
+                  ('Is Paused (macOS only)', 'is_paused'))
+        colon_formatted_print(server_doc, fields)
+
     else:
         def advertised_port_summary(server):
             def get_range_summary(start, end):


### PR DESCRIPTION
Per #136, listing servers on a share worked, but was misleading, as other commands wouldn't work. In this case, print a usage message about how to lookup information about the share or how to list the servers on the host.

Sort of related to that, listing servers on an S3 endpoint didn't raise an error but instead would just succeed and list an empty set. In this case, we can print the S3 URL instead. I could also raise an error if people prefer that.

Fixes #136.