### PR TITLE
Make `globus version` a command, hide the opt form

### DIFF
--- a/globus_cli/commands/main.py
+++ b/globus_cli/commands/main.py
@@ -1,6 +1,7 @@
 from globus_cli.parsing import globus_main_func
 
 from globus_cli.commands.list_commands import list_commands
+from globus_cli.commands.version import version_command
 from globus_cli.commands.config import config_command
 
 from globus_cli.commands.login import login_command
@@ -25,6 +26,7 @@ def main():
 
 
 main.add_command(list_commands)
+main.add_command(version_command)
 main.add_command(config_command)
 
 main.add_command(login_command)

--- a/globus_cli/commands/version.py
+++ b/globus_cli/commands/version.py
@@ -1,0 +1,13 @@
+import click
+
+from globus_cli.parsing import common_options
+from globus_cli.helpers import print_version
+
+
+@click.command('version', help='Show the version and exit')
+@common_options(no_format_option=True, no_map_http_status_option=True)
+def version_command():
+    """
+    Executor for `globus version`
+    """
+    print_version()

--- a/globus_cli/helpers/__init__.py
+++ b/globus_cli/helpers/__init__.py
@@ -1,10 +1,13 @@
 from globus_cli.helpers.printing import (
     print_json_response, colon_formatted_print, print_table)
 from globus_cli.helpers.options import outformat_is_json, outformat_is_text
+from globus_cli.helpers.version import print_version
 
 
 __all__ = [
     'print_json_response', 'colon_formatted_print', 'print_table',
+
+    'print_version',
 
     'outformat_is_json', 'outformat_is_text'
 ]

--- a/globus_cli/helpers/version.py
+++ b/globus_cli/helpers/version.py
@@ -1,0 +1,33 @@
+from globus_cli.safeio import safeprint
+from globus_cli.version import get_versions
+
+
+def print_version():
+    """
+    Print out the current version, and at least try to fetch the latest from
+    PyPi to print alongside it.
+
+    It may seem odd that this isn't in globus_cli.version , but it's done this
+    way to separate concerns over printing the version from looking it up.
+    """
+    latest, current = get_versions()
+    if latest is None:
+        safeprint(('Installed Version: {0}\n'
+                   'Failed to lookup latest version.')
+                  .format(current))
+    else:
+        safeprint(
+            ('Installed Version: {0}\n'
+             'Latest Version:    {1}\n'
+             '\n{2}').format(
+                current, latest,
+                'You are running the latest version of the Globus CLI'
+                if current == latest else
+                ('You should update your version of the Globus CLI\n'
+                 'Update instructions: '
+                 'https://globus.github.io/globus-cli/'
+                 '#updating-and-removing')
+                 if current < latest else
+                 'You are running a preview version of the Globus CLI'
+            )
+        )

--- a/globus_cli/parsing/version_option.py
+++ b/globus_cli/parsing/version_option.py
@@ -1,13 +1,13 @@
 import click
 
-from globus_cli.safeio import safeprint
-from globus_cli.version import get_versions
+from globus_cli.helpers import print_version
+from globus_cli.parsing.hidden_option import HiddenOption
 
 
 def version_option(f):
     """
     Largely a custom clone of click.version_option -- almost identical, but
-    makes more assumptions and prints our special output.
+    prints our special output.
     """
     def callback(ctx, param, value):
         # copied from click.decorators.version_option
@@ -15,30 +15,8 @@ def version_option(f):
         if not value or ctx.resilient_parsing:
             return
 
-        latest, current = get_versions()
-        if latest is None:
-            safeprint(('Installed Version: {0}\n'
-                       'Failed to lookup latest version.')
-                      .format(current))
-        else:
-            safeprint(
-                ('Installed Version: {0}\n'
-                 'Latest Version:    {1}\n'
-                 '\n{2}').format(
-                    current, latest,
-                    'You are running the latest version of the Globus CLI'
-                    if current == latest else
-                    ('You should update your version of the Globus CLI\n'
-                     'Update instructions: '
-                     'https://globus.github.io/globus-cli/'
-                     '#updating-and-removing')
-                     if current < latest else
-                     'You are running a preview version of the Globus CLI'
-                )
-            )
-
+        print_version()
         ctx.exit(0)
 
-    return click.option('--version', help='Show the version and exit.',
-                        is_flag=True, expose_value=False, is_eager=True,
-                        callback=callback)(f)
+    return click.option('--version', is_flag=True, expose_value=False,
+                        is_eager=True, callback=callback, cls=HiddenOption)(f)


### PR DESCRIPTION
`globus version` is a command, which prints the version.
`--version` is a hidden option on all commands, which also prints the version.

Resolves #165