### PR TITLE
Add successful transfer option to task detail

### DIFF
--- a/globus_cli/commands/task/show.py
+++ b/globus_cli/commands/task/show.py
@@ -2,9 +2,9 @@ import click
 
 from globus_cli.parsing import common_options, task_id_arg
 from globus_cli.helpers import (
-    outformat_is_json, print_json_response, colon_formatted_print)
+    outformat_is_json, print_json_response, colon_formatted_print, print_table)
 
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import get_client, print_json_from_iterator
 
 
 COMMON_FIELDS = [
@@ -35,16 +35,22 @@ TRANSFER_FIELDS = [
     ('Destination Endpoint', 'destination_endpoint_display_name'),
 ]
 
+SUCCESSFULL_TRANSFER_FIELDS = [
+    ('Source', 'source_path'),
+    ('Destination', 'destination_path')
+]
 
-@click.command('show', help='Show detailed information about a specific Task')
-@common_options
-@task_id_arg
-def show_task(task_id):
-    """
-    Executor for `globus task show`
-    """
-    client = get_client()
 
+def print_successful_transfers(client, task_id):
+    res = client.task_successful_transfers(task_id, num_results=None)
+
+    if outformat_is_json():
+        print_json_from_iterator(res)
+    else:
+        print_table(res, SUCCESSFULL_TRANSFER_FIELDS)
+
+
+def print_task_detail(client, task_id):
     res = client.get_task(task_id)
 
     if outformat_is_json():
@@ -54,3 +60,20 @@ def show_task(task_id):
             (COMPLETED_FIELDS if res['completion_time'] else ACTIVE_FIELDS) + \
             (DELETE_FIELDS if res['type'] == 'DELETE' else TRANSFER_FIELDS)
         colon_formatted_print(res, fields)
+
+
+@click.command('show', help='Show detailed information about a specific Task')
+@common_options
+@task_id_arg
+@click.option('--successful-transfers', '-t', is_flag=True, default=False,
+              help='Show files that were transferred as result of this task.')
+def show_task(successful_transfers, task_id):
+    """
+    Executor for `globus task show`
+    """
+    client = get_client()
+
+    if successful_transfers:
+        print_successful_transfers(client, task_id)
+    else:
+        print_task_detail(client, task_id)


### PR DESCRIPTION
* Adds an option to `task show` to list files that were successfully transferred as a part of the specified task. Available as `-t` or `--successful_transfers`.

Example:
```
 jason-mbp:globus-cli jtw$ globus task show 77c88088-f4bb-11e6-ba62-22000b9a448b -t
Source                               | Destination                                                   
------------------------------------ | --------------------------------------------------------------
/portal/catalog/dataset_atl/1951.csv | /~/Atlanta%20International%20Airport%20Climate%20Data/1951.csv
/portal/catalog/dataset_atl/1952.csv | /~/Atlanta%20International%20Airport%20Climate%20Data/1952.csv
```

or as JSON:
```
jason-mbp:globus-cli jtw$ globus task show 77c88088-f4bb-11e6-ba62-22000b9a448b -t -F json
{
  "DATA": [
    {
      "source_path": "/portal/catalog/dataset_atl/1951.csv",
      "destination_path": "/~/Atlanta%20International%20Airport%20Climate%20Data/1951.csv",
      "DATA_TYPE": "successful_transfer"
    },
    {
      "source_path": "/portal/catalog/dataset_atl/1952.csv",
      "destination_path": "/~/Atlanta%20International%20Airport%20Climate%20Data/1952.csv",
      "DATA_TYPE": "successful_transfer"
    }
]
```
Closes #62
