### PR TITLE
get-identities: remove explicit `usernames` and `identities` options

### DIFF
--- a/globus_cli/commands/get_identities.py
+++ b/globus_cli/commands/get_identities.py
@@ -3,15 +3,14 @@ import uuid
 
 import click
 
+from globus_sdk import GlobusResponse
+
 from globus_cli.parsing import common_options, HiddenOption
 from globus_cli.helpers import (
     print_json_response, outformat_is_json, print_table)
 
 from globus_cli.services.auth import get_auth_client
 
-
-_USERNAMES_STYLE = 'usernames'
-_IDS_STYLE = 'identities'
 
 _HIDDEN_TRANSFER_STYLE = 'globus-transfer'
 
@@ -21,19 +20,12 @@ def _b32_decode(v):
     v = v[2:]
     assert len(v) == 26, "u_{0} is the wrong length".format(v)
     # append padding and uppercase so that b32decode will work
-    v = v.upper() + 6*'='
+    v = v.upper() + (6 * '=')
     return str(uuid.UUID(bytes=base64.b32decode(v)))
 
 
 @click.command('get-identities', help='Lookup Globus Auth Identities')
 @common_options
-@click.option('--usernames', 'lookup_style', default=True,
-              help=('Values are Usernames to lookup in Globus Auth. '
-                    'This is the default behavior'),
-              flag_value=_USERNAMES_STYLE)
-@click.option('--identities', 'lookup_style',
-              help='Values are Identity IDs to lookup in Globus Auth',
-              flag_value=_IDS_STYLE)
 @click.option('--globus-transfer-decode', 'lookup_style', cls=HiddenOption,
               flag_value=_HIDDEN_TRANSFER_STYLE)
 @click.argument('values', required=True, nargs=-1)
@@ -43,17 +35,26 @@ def get_identities_command(values, lookup_style):
     """
     client = get_auth_client()
 
-    params = {}
-
     # set commandline params if passed
-    if lookup_style == _USERNAMES_STYLE:
-        params['usernames'] = ','.join(values)
-    elif lookup_style == _IDS_STYLE:
-        params['ids'] = ','.join(values)
-    elif lookup_style == _HIDDEN_TRANSFER_STYLE:
-        params['ids'] = ','.join(_b32_decode(v) for v in values)
+    if lookup_style == _HIDDEN_TRANSFER_STYLE:
+        res = client.get_identities(
+            ids=','.join(_b32_decode(v) for v in values))
+    else:
+        params = dict(ids=[], usernames=[])
+        for val in values:
+            try:
+                uuid.UUID(val)
+                params['ids'].append(val)
+            except ValueError:
+                params['usernames'].append(val)
 
-    res = client.get_identities(**params)
+        results = []
+        for k, v in params.items():
+            if not v:
+                continue
+            results = results + \
+                client.get_identities(**{k: ','.join(v)}).data['identities']
+        res = GlobusResponse({'identities': results})
 
     if outformat_is_json():
         print_json_response(res)


### PR DESCRIPTION
* Determine whether a given input is an identity id (uuid) or a username, no need to use `--usernames` or `--identities` options.
* Mixed id and username input supported.

Example:
```
globus get-identities b0497184-d274-11e5-bf33-130e800f88c2 sirosen@globusid.org a492bd6e-d274-11e5-994a-0f250392c65f
ID                                   | Username              | Full Name      | Organization          | Email Address        
------------------------------------ | --------------------- | -------------- | --------------------- | ---------------------
ae332d86-d274-11e5-b885-b31714a110e9 | sirosen@globusid.org  | Stephen Rosen  | Globus Team           | sirosen@globus.org   
a492bd6e-d274-11e5-994a-0f250392c65f | jaswilli@globusid.org | Jason Williams | Globus                | jaswilli@uchicago.edu
b0497184-d274-11e5-bf33-130e800f88c2 | tuecke@globusid.org   | Steve Tuecke   | University of Chicago | tuecke@uchicago.edu 
```

Closes #179
