### PR TITLE
Fix `globus whoami` to allow JSON output

### DIFF
--- a/globus_cli/commands/whoami.py
+++ b/globus_cli/commands/whoami.py
@@ -1,8 +1,10 @@
 import click
+from globus_sdk import GlobusResponse
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import common_options
-from globus_cli.helpers import colon_formatted_print
+from globus_cli.helpers import (
+    print_json_response, outformat_is_json, colon_formatted_print)
 from globus_cli.config import (
     WHOAMI_ID_OPTNAME, WHOAMI_USERNAME_OPTNAME,
     WHOAMI_EMAIL_OPTNAME, WHOAMI_NAME_OPTNAME,
@@ -11,7 +13,7 @@ from globus_cli.config import (
 
 @click.command('whoami',
                help=('Show the currently logged-in identity.'))
-@common_options(no_format_option=True, no_map_http_status_option=True)
+@common_options(no_map_http_status_option=True)
 @click.option('--verbose', '-v', is_flag=True, default=False)
 def whoami_command(verbose):
     """
@@ -22,10 +24,10 @@ def whoami_command(verbose):
                              environment=GLOBUS_ENV)
     if not username:
         safeprint('No login information available. Please try '
-                  'logging in again.')
-        return
+                  'logging in again.', write_to_stderr=True)
+        click.get_current_context().exit(1)
 
-    if verbose:
+    if verbose or outformat_is_json():
         fields = tuple((x, x) for x in ('Username', 'Name', 'ID', 'Email'))
         user_doc = {
             'Username': username,
@@ -34,6 +36,9 @@ def whoami_command(verbose):
             'Email': lookup_option(WHOAMI_EMAIL_OPTNAME,
                                    environment=GLOBUS_ENV)
         }
-        colon_formatted_print(user_doc, fields)
+        if outformat_is_json():
+            print_json_response(GlobusResponse(user_doc))
+        else:
+            colon_formatted_print(user_doc, fields)
     else:
         safeprint(username)


### PR DESCRIPTION
Simply put, JSON implies verbose, and the verbose document gets wrapped in a GlobusResponse to be dumped to stdout.
Convert the "you are not logged in" message from being stdout + exit(0) to behaving like an error message, going to stderr + exit(1). That way, we have good behavior for `-F json` on that error.

Closes #206

Example:
```shell
$ globus whoami -F json
{
  "Username": "sirosen@globusid.org", 
  "Name": "Stephen Rosen", 
  "Email": "sirosen@globus.org", 
  "ID": "ae332d86-d274-11e5-b885-b31714a110e9"
}
```