### PR TITLE
Add textmode output to the ACL delete command

### DIFF
--- a/globus_cli/commands/endpoint/permission/delete.py
+++ b/globus_cli/commands/endpoint/permission/delete.py
@@ -1,7 +1,8 @@
 import click
 
+from globus_cli.safeio import safeprint
 from globus_cli.parsing import common_options, endpoint_id_arg
-from globus_cli.helpers import print_json_response
+from globus_cli.helpers import print_json_response, outformat_is_json
 
 from globus_cli.services.transfer import get_client
 
@@ -19,4 +20,7 @@ def delete_command(endpoint_id, rule_id):
 
     res = client.delete_endpoint_acl_rule(endpoint_id, rule_id)
 
-    print_json_response(res)
+    if outformat_is_json():
+        print_json_response(res)
+    else:
+        safeprint(res['message'])


### PR DESCRIPTION
Just takes the message field on the response and sends it to stdout.
Closes #185 

Example:
```shell
$ globus endpoint permission list b3ec642e-9fe5-11e6-b0df-22000b92c261
Rule ID                              | Permissions | Shared With             | Path
------------------------------------ | ----------- | ----------------------- | ----
a030a74c-9fef-11e6-b0e1-22000b92c261 | r           | sirosen2@globusid.org   | /   
d48c1d1e-9fe5-11e6-b0df-22000b92c261 | r           | all_authenticated_users | /   
d0d3b628-9fe5-11e6-b0df-22000b92c261 | r           | anonymous               | /   
NULL                                 | rw          | sirosen@globusid.org    | / 
$ globus endpoint permission delete b3ec642e-9fe5-11e6-b0df-22000b92c261 d48c1d1e-9fe5-11e6-b0df-22000b92c261
Access rule 'd48c1d1e-9fe5-11e6-b0df-22000b92c261' deleted successfully
```