### PR TITLE
Fix the "no_args_is_help" behavior of command groups to fire even if options (but no subcommand) are given

### DIFF
--- a/globus_cli/commands/bookmark/commands.py
+++ b/globus_cli/commands/bookmark/commands.py
@@ -1,6 +1,4 @@
-import click
-
-from globus_cli.parsing import common_options
+from globus_cli.parsing import globus_group, common_options
 
 from globus_cli.commands.bookmark.list import bookmark_list
 from globus_cli.commands.bookmark.create import bookmark_create
@@ -10,7 +8,7 @@ from globus_cli.commands.bookmark.show import bookmark_show
 from globus_cli.commands.bookmark.locate import bookmark_locate
 
 
-@click.group(name='bookmark', help='Manage Endpoint Bookmarks')
+@globus_group(name='bookmark', help='Manage Endpoint Bookmarks')
 @common_options
 def bookmark_command():
     pass

--- a/globus_cli/commands/bookmark/commands.py
+++ b/globus_cli/commands/bookmark/commands.py
@@ -1,4 +1,4 @@
-from globus_cli.parsing import globus_group, common_options
+from globus_cli.parsing import globus_group
 
 from globus_cli.commands.bookmark.list import bookmark_list
 from globus_cli.commands.bookmark.create import bookmark_create
@@ -9,7 +9,6 @@ from globus_cli.commands.bookmark.locate import bookmark_locate
 
 
 @globus_group(name='bookmark', help='Manage Endpoint Bookmarks')
-@common_options
 def bookmark_command():
     pass
 

--- a/globus_cli/commands/config/commands.py
+++ b/globus_cli/commands/config/commands.py
@@ -1,6 +1,4 @@
-import click
-
-from globus_cli.parsing import common_options
+from globus_cli.parsing import globus_group, common_options
 
 from globus_cli.commands.config.edit import edit_command
 from globus_cli.commands.config.init import init_command
@@ -9,7 +7,7 @@ from globus_cli.commands.config.set import set_command
 from globus_cli.commands.config.show import show_command
 
 
-@click.group('config', short_help=(
+@globus_group('config', short_help=(
     'Modify, view, and manage your Globus CLI config.'), help=("""\
     Modify, view, and manage your Globus CLI config.
 

--- a/globus_cli/commands/config/commands.py
+++ b/globus_cli/commands/config/commands.py
@@ -1,4 +1,4 @@
-from globus_cli.parsing import globus_group, common_options
+from globus_cli.parsing import globus_group
 
 from globus_cli.commands.config.edit import edit_command
 from globus_cli.commands.config.init import init_command
@@ -27,7 +27,6 @@ from globus_cli.commands.config.show import show_command
         $ globus config show general.auth_token
     to show the same value more explicitly.
     """))
-@common_options
 def config_command():
     pass
 

--- a/globus_cli/commands/endpoint/commands.py
+++ b/globus_cli/commands/endpoint/commands.py
@@ -1,6 +1,4 @@
-import click
-
-from globus_cli.parsing import common_options
+from globus_cli.parsing import globus_group, common_options
 
 from globus_cli.commands.endpoint.permission import permission_command
 from globus_cli.commands.endpoint.role import role_command
@@ -18,7 +16,7 @@ from globus_cli.commands.endpoint.my_shared_endpoint_list import (
     my_shared_endpoint_list)
 
 
-@click.group(name='endpoint', help='Manage Globus Endpoint definitions')
+@globus_group(name='endpoint', help='Manage Globus Endpoint definitions')
 @common_options
 def endpoint_command():
     pass

--- a/globus_cli/commands/endpoint/commands.py
+++ b/globus_cli/commands/endpoint/commands.py
@@ -1,4 +1,4 @@
-from globus_cli.parsing import globus_group, common_options
+from globus_cli.parsing import globus_group
 
 from globus_cli.commands.endpoint.permission import permission_command
 from globus_cli.commands.endpoint.role import role_command
@@ -17,7 +17,6 @@ from globus_cli.commands.endpoint.my_shared_endpoint_list import (
 
 
 @globus_group(name='endpoint', help='Manage Globus Endpoint definitions')
-@common_options
 def endpoint_command():
     pass
 

--- a/globus_cli/commands/endpoint/permission/commands.py
+++ b/globus_cli/commands/endpoint/permission/commands.py
@@ -1,4 +1,4 @@
-from globus_cli.parsing import globus_group, common_options
+from globus_cli.parsing import globus_group
 
 from globus_cli.commands.endpoint.permission.list import list_command
 from globus_cli.commands.endpoint.permission.create import create_command
@@ -9,7 +9,6 @@ from globus_cli.commands.endpoint.permission.delete import delete_command
 
 @globus_group(name='permission', help=('Manage Endpoint Permissions '
                                        '(Access Control Lists)'))
-@common_options
 def permission_command():
     pass
 

--- a/globus_cli/commands/endpoint/permission/commands.py
+++ b/globus_cli/commands/endpoint/permission/commands.py
@@ -1,6 +1,4 @@
-import click
-
-from globus_cli.parsing import common_options
+from globus_cli.parsing import globus_group, common_options
 
 from globus_cli.commands.endpoint.permission.list import list_command
 from globus_cli.commands.endpoint.permission.create import create_command
@@ -9,8 +7,8 @@ from globus_cli.commands.endpoint.permission.update import update_command
 from globus_cli.commands.endpoint.permission.delete import delete_command
 
 
-@click.group(name='permission', help=('Manage Endpoint Permissions '
-                                      '(Access Control Lists)'))
+@globus_group(name='permission', help=('Manage Endpoint Permissions '
+                                       '(Access Control Lists)'))
 @common_options
 def permission_command():
     pass

--- a/globus_cli/commands/endpoint/role/commands.py
+++ b/globus_cli/commands/endpoint/role/commands.py
@@ -1,4 +1,4 @@
-from globus_cli.parsing import globus_group, common_options
+from globus_cli.parsing import globus_group
 
 from globus_cli.commands.endpoint.role.list import role_list
 from globus_cli.commands.endpoint.role.show import role_show
@@ -7,7 +7,6 @@ from globus_cli.commands.endpoint.role.delete import role_delete
 
 
 @globus_group(name='role', help='Manage endpoint roles')
-@common_options
 def role_command():
     pass
 

--- a/globus_cli/commands/endpoint/role/commands.py
+++ b/globus_cli/commands/endpoint/role/commands.py
@@ -1,6 +1,4 @@
-import click
-
-from globus_cli.parsing import common_options
+from globus_cli.parsing import globus_group, common_options
 
 from globus_cli.commands.endpoint.role.list import role_list
 from globus_cli.commands.endpoint.role.show import role_show
@@ -8,7 +6,7 @@ from globus_cli.commands.endpoint.role.create import role_create
 from globus_cli.commands.endpoint.role.delete import role_delete
 
 
-@click.group(name='role', help='Manage endpoint roles')
+@globus_group(name='role', help='Manage endpoint roles')
 @common_options
 def role_command():
     pass

--- a/globus_cli/commands/endpoint/server/commands.py
+++ b/globus_cli/commands/endpoint/server/commands.py
@@ -1,6 +1,4 @@
-import click
-
-from globus_cli.parsing import common_options
+from globus_cli.parsing import globus_group, common_options
 
 from globus_cli.commands.endpoint.server.list import server_list
 from globus_cli.commands.endpoint.server.show import server_show
@@ -9,11 +7,12 @@ from globus_cli.commands.endpoint.server.update import server_update
 from globus_cli.commands.endpoint.server.delete import server_delete
 
 
-@click.group(name='server', short_help='Manage servers for a Globus Endpoint',
-             help=('Manage the servers which back a Globus Endpoint. '
-                   'This typically refers to a Globus Connect Server endpoint '
-                   'running on multiple servers. Each GridFTP server is '
-                   'registered as a server backing the endpoint.'))
+@globus_group(
+    name='server', short_help='Manage servers for a Globus Endpoint',
+    help=('Manage the servers which back a Globus Endpoint. '
+          'This typically refers to a Globus Connect Server endpoint '
+          'running on multiple servers. Each GridFTP server is '
+          'registered as a server backing the endpoint.'))
 @common_options
 def server_command():
     pass

--- a/globus_cli/commands/endpoint/server/commands.py
+++ b/globus_cli/commands/endpoint/server/commands.py
@@ -1,4 +1,4 @@
-from globus_cli.parsing import globus_group, common_options
+from globus_cli.parsing import globus_group
 
 from globus_cli.commands.endpoint.server.list import server_list
 from globus_cli.commands.endpoint.server.show import server_show
@@ -13,7 +13,6 @@ from globus_cli.commands.endpoint.server.delete import server_delete
           'This typically refers to a Globus Connect Server endpoint '
           'running on multiple servers. Each GridFTP server is '
           'registered as a server backing the endpoint.'))
-@common_options
 def server_command():
     pass
 

--- a/globus_cli/commands/task/commands.py
+++ b/globus_cli/commands/task/commands.py
@@ -1,4 +1,4 @@
-from globus_cli.parsing import globus_group, common_options
+from globus_cli.parsing import globus_group
 
 from globus_cli.commands.task.list import task_list
 from globus_cli.commands.task.show import show_task
@@ -14,7 +14,6 @@ from globus_cli.commands.task.generate_submission_id import (
 
 
 @globus_group(name='task', help='Manage asynchronous Tasks')
-@common_options
 def task_command():
     pass
 

--- a/globus_cli/commands/task/commands.py
+++ b/globus_cli/commands/task/commands.py
@@ -1,6 +1,4 @@
-import click
-
-from globus_cli.parsing import common_options
+from globus_cli.parsing import globus_group, common_options
 
 from globus_cli.commands.task.list import task_list
 from globus_cli.commands.task.show import show_task
@@ -15,7 +13,7 @@ from globus_cli.commands.task.generate_submission_id import (
     generate_submission_id)
 
 
-@click.group(name='task', help='Manage asynchronous Tasks')
+@globus_group(name='task', help='Manage asynchronous Tasks')
 @common_options
 def task_command():
     pass

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -1,3 +1,4 @@
+from globus_cli.parsing.custom_group import globus_group
 from globus_cli.parsing.main_command_decorator import globus_main_func
 
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
@@ -18,6 +19,7 @@ from globus_cli.parsing.process_stdin import shlex_process_stdin
 
 
 __all__ = [
+    'globus_group',
     'globus_main_func',
 
     'CaseInsensitiveChoice',

--- a/globus_cli/parsing/custom_group.py
+++ b/globus_cli/parsing/custom_group.py
@@ -1,0 +1,42 @@
+import click
+
+from globus_cli.safeio import safeprint
+
+
+class GlobusCommandGroup(click.Group):
+    """
+    This is a click.Group with any customizations which we deem necessary
+    *everywhere*.
+
+    In particular, at present it provides a better form of handling for
+    no_args_is_help. If that flag is set, helptext will be triggered not only
+    off of cases where there are no arguments at all, but also cases where
+    there are options, but no subcommand (positional arg) is given.
+    """
+    def invoke(self, ctx):
+        # if no subcommand was given (but, potentially, flags were passed),
+        # ctx.protected_args will be empty
+        # improves upon the built-in detection given on click.Group by
+        # no_args_is_help , since that treats options (without a subcommand) as
+        # being arguments and blows up with a "Missing command" failure
+        # for reference to the original version (as of 2017-02-26):
+        # https://github.com/pallets/click/blob/02ea9ee7e864581258b4902d6e6c1264b0226b9f/click/core.py#L1039-L1052
+        if self.no_args_is_help and not ctx.protected_args:
+            safeprint(ctx.get_help())
+            ctx.exit()
+        return super(GlobusCommandGroup, self).invoke(ctx)
+
+
+def globus_group(*args, **kwargs):
+    """
+    Wrapper over click.group which sets GlobusCommandGroup as the Class
+
+    Caution!
+    Don't get snake-bitten by this. `globus_group` is a decorator which MUST
+    take arguments. It is not wrapped in our common detect-and-decorate pattern
+    to allow it to be used bare -- that wouldn't work (unnamed groups? weird
+    stuff)
+    """
+    def inner_decorator(f):
+        return click.group(*args, cls=GlobusCommandGroup, **kwargs)(f)
+    return inner_decorator

--- a/globus_cli/parsing/custom_group.py
+++ b/globus_cli/parsing/custom_group.py
@@ -1,6 +1,7 @@
 import click
 
 from globus_cli.safeio import safeprint
+from globus_cli.parsing.shared_options import common_options
 
 
 class GlobusCommandGroup(click.Group):
@@ -38,5 +39,7 @@ def globus_group(*args, **kwargs):
     stuff)
     """
     def inner_decorator(f):
-        return click.group(*args, cls=GlobusCommandGroup, **kwargs)(f)
+        f = click.group(*args, cls=GlobusCommandGroup, **kwargs)(f)
+        f = common_options(f)
+        return f
     return inner_decorator

--- a/globus_cli/parsing/main_command_decorator.py
+++ b/globus_cli/parsing/main_command_decorator.py
@@ -9,12 +9,13 @@ and all other components will be hidden internals.
 import sys
 import click
 
+from globus_cli.parsing.custom_group import GlobusCommandGroup
 from globus_cli.parsing.shell_completion import shell_complete_option
 from globus_cli.parsing.excepthook import custom_except_hook
 from globus_cli.parsing.shared_options import common_options
 
 
-class TopLevelGroup(click.Group):
+class TopLevelGroup(GlobusCommandGroup):
     """
     This is a custom command type which is basically a click.Group, but is
     designed specifically for the top level command.


### PR DESCRIPTION
This is primarily driven by a desire to fix #174 , but it also resolves that bug as it applies to various subcommands as well.

At each level of our command heirarchy, we have group commands (e.g. `globus endpoint`), which do not have meaningful invocation of their own.
When `no_args_is_help=True` on a `click.Group`, that means that invoking that group command prints help text if no arguments are given at all.

That _sounds right_, but interestingly the parsing stages are such that the logic runs before options and positional arguments are distinguished. The result is that `globus -F json` and the like register as "having arguments" and the help printing doesn't happen.
As the attempt to invoke a subcommand rolls in, and there isn't a positional to process, we get a "Missing command" error.

To fix, add a custom subclass of `click.Group` which checks for the absence of any positional args at the invocation stage and prints help text if `no_args_is_help=True`. If `no_args_is_help=False`, the logic won't fire, so we still could create future groups whose invocation without a subcommand is meaningful.

Closes #174