### PR TITLE
Add endpoint create and update options requested in issue 63

### DIFF
--- a/globus_cli/commands/endpoint/create.py
+++ b/globus_cli/commands/endpoint/create.py
@@ -29,10 +29,43 @@ GCP_FIELDS = [
 def endpoint_create(endpoint_type, display_name, description, organization,
                     department, keywords, contact_email, contact_info,
                     info_link, public, default_directory, force_encryption,
-                    oauth_server, myproxy_server, myproxy_dn):
+                    oauth_server, myproxy_server, myproxy_dn, network_use,
+                    custom_concurrency, custom_parallelism, location_automatic,
+                    location, disable_verify):
     """
     Executor for `globus endpoint create`
     """
+    # require custom_concurrency and custom_parallelism for custom network_use
+    if network_use == "custom" and (not custom_concurrency or
+                                    not custom_parallelism):
+        raise click.UsageError(
+            "custom network_use level requires --custom-concurrency and "
+            "--custom-parallelism to be set")
+
+    # set max and preferred concurrency and parallelism based on args
+    if custom_concurrency:
+        max_concurrency, preferred_concurrency = custom_concurrency
+    else:
+        max_concurrency = None
+        preferred_concurrency = None
+    if custom_parallelism:
+        max_parallelism, preferred_parallelism = custom_parallelism
+    else:
+        max_parallelism = None
+        preferred_parallelism = None
+
+    # location cannot be automatic and user defined
+    if location_automatic and location:
+        raise click.UsageError(
+            "cannot combine --location and --location-automatic")
+
+    # set location based on args
+    if location_automatic:
+        location = "Automatic"
+    elif location:
+        location = "{},{}".format(location[0], location[1])
+    else:
+        location = None
 
     # omit the `is_globus_connect` key if not GCP, otherwise include as `True`
     is_globus_connect = endpoint_type == 'personal' or None
@@ -46,7 +79,12 @@ def endpoint_create(endpoint_type, display_name, description, organization,
         force_encryption=force_encryption, public=public,
         default_directory=default_directory,
         myproxy_server=myproxy_server, myproxy_dn=myproxy_dn,
-        oauth_server=oauth_server)
+        oauth_server=oauth_server, network_use=network_use,
+        max_concurrency=max_concurrency,
+        preferred_concurrency=preferred_concurrency,
+        max_parallelism=max_parallelism,
+        preferred_parallelism=preferred_parallelism,
+        disable_verify=disable_verify, location=location)
 
     client = get_client()
     res = client.create_endpoint(ep_doc)

--- a/globus_cli/commands/endpoint/update.py
+++ b/globus_cli/commands/endpoint/update.py
@@ -15,11 +15,43 @@ from globus_cli.services.transfer import get_client, assemble_generic_doc
 def endpoint_update(endpoint_id, display_name, description, organization,
                     department, keywords, contact_email, contact_info,
                     info_link, public, default_directory, force_encryption,
-                    oauth_server, myproxy_server, myproxy_dn):
+                    oauth_server, myproxy_server, myproxy_dn, network_use,
+                    custom_concurrency, custom_parallelism, location_automatic,
+                    location, disable_verify):
     """
     Executor for `globus endpoint update`
     """
-    client = get_client()
+    # require custom_concurrency and custom_parallelism for custom network_use
+    if network_use == "custom" and (not custom_concurrency or
+                                    not custom_parallelism):
+        raise click.UsageError(
+            "custom network_use level requires --custom-concurrency and "
+            "--custom-parallelism to be set")
+
+    # set max and preferred concurrency and parallelism based on args
+    if custom_concurrency:
+        max_concurrency, preferred_concurrency = custom_concurrency
+    else:
+        max_concurrency = None
+        preferred_concurrency = None
+    if custom_parallelism:
+        max_parallelism, preferred_parallelism = custom_parallelism
+    else:
+        max_parallelism = None
+        preferred_parallelism = None
+
+    # location cannot be automatic and user defined
+    if location_automatic and location:
+        raise click.UsageError(
+            "cannot combine --location and --location-automatic")
+
+    # set location based on args
+    if location_automatic:
+        location = "Automatic"
+    elif location:
+        location = "{},{}".format(location[0], location[1])
+    else:
+        location = None
 
     ep_doc = assemble_generic_doc(
         'endpoint',
@@ -28,8 +60,14 @@ def endpoint_update(endpoint_id, display_name, description, organization,
         contact_email=contact_email, contact_info=contact_info,
         info_link=info_link, force_encryption=force_encryption, public=public,
         default_directory=default_directory, myproxy_server=myproxy_server,
-        myproxy_dn=myproxy_dn, oauth_server=oauth_server)
+        myproxy_dn=myproxy_dn, oauth_server=oauth_server,
+        network_use=network_use, max_concurrency=max_concurrency,
+        preferred_concurrency=preferred_concurrency,
+        max_parallelism=max_parallelism,
+        preferred_parallelism=preferred_parallelism,
+        disable_verify=disable_verify, location=location)
 
+    client = get_client()
     res = client.update_endpoint(endpoint_id, ep_doc)
 
     if outformat_is_json():

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -11,8 +11,9 @@ from globus_cli.parsing.hidden_option import HiddenOption
 from globus_cli.parsing.shared_options import (
     common_options,
     endpoint_id_arg, task_id_arg, submission_id_option,
-    endpoint_create_and_update_params, role_id_arg,
-    server_id_arg, server_add_and_update_opts,
+    endpoint_create_and_update_params,
+    endpoint_create_and_update_validate_params,
+    role_id_arg, server_id_arg, server_add_and_update_opts,
     security_principal_opts)
 
 from globus_cli.parsing.process_stdin import shlex_process_stdin
@@ -31,8 +32,9 @@ __all__ = [
     'common_options',
     # Transfer options
     'endpoint_id_arg', 'task_id_arg', 'submission_id_option',
-    'endpoint_create_and_update_params', 'role_id_arg',
-    'server_id_arg', 'server_add_and_update_opts',
+    'endpoint_create_and_update_params',
+    'endpoint_create_and_update_validate_params',
+    'role_id_arg', 'server_id_arg', 'server_add_and_update_opts',
     'security_principal_opts',
 
     'shlex_process_stdin',

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -90,19 +90,24 @@ def endpoint_create_and_update_params(*args, **kwargs):
     Usage:
 
     >>> @endpoint_create_and_update_params
-    >>> def command_func(display_name, description, organization, department,
-    >>>                  keywords, contact_email, contact_info, info_link,
-    >>>                  public, default_directory, force_encryption,
-    >>>                  oauth_server, myproxy_server, myproxy_dn):
+    >>> def endpoint_create(endpoint_id, display_name, description,
+    >>>                     organization, department, keywords, contact_email,
+    >>>                     contact_info, info_link, public, default_directory,
+    >>>                     force_encryption, oauth_server, myproxy_server,
+    >>>                     myproxy_dn, network_use, custom_concurrency,
+    >>>                     custom_parallelism, location_automatic, location,
+    >>>                     disable_verify):
     >>>     ...
-
     or
 
     >>> @endpoint_create_and_update_params(create=False)
-    >>> def command_func(display_name, description, organization, department,
-    >>>                  keywords, contact_email, contact_info, info_link,
-    >>>                  public, default_directory, force_encryption,
-    >>>                  oauth_server, myproxy_server, myproxy_dn):
+    >>> def endpoint_update(endpoint_id, display_name, description,
+    >>>                     organization, department, keywords, contact_email,
+    >>>                     contact_info, info_link, public, default_directory,
+    >>>                     force_encryption, oauth_server, myproxy_server,
+    >>>                     myproxy_dn, network_use, custom_concurrency,
+    >>>                     custom_parallelism, location_automatic, location,
+    >>>                     disable_verify):
     >>>     ...
 
     or
@@ -133,6 +138,29 @@ def endpoint_create_and_update_params(*args, **kwargs):
         f = click.option(
             '--public/--private', 'public', default=None,
             help='Set the Endpoint to be public or private')(f)
+        f = click.option(
+            "--network-use", default=None,
+            type=click.Choice(["normal", "minimal", "aggressive", "custom"]),
+            help=("Set the endpoint's network use level. If using custom, "
+                  "--custom-concurrency and --custom-parallelism must be used"
+                  "(Managed endpoints only)"))(f)
+        f = click.option(
+            "--custom-concurrency", nargs=2, type=int,
+            help=("Set the endpoint's max and preferred concurrency "
+                  "(Managed endpoints only)"))(f)
+        f = click.option(
+            "--custom-parallelism", nargs=2, type=int,
+            help=("Set the endpoint's max and preferred parallelism "
+                  "(Managed endpoints only) (Non S3 endpoints only)"))(f)
+        f = click.option(
+            "--location-automatic", is_flag=True,
+            help="Set the endpoint to automatically get its location")(f)
+        f = click.option(
+            "--location", nargs=2, type=float, default=None,
+            help="Set the endpoint's latitude and longitude")(f)
+        f = click.option(
+            "--disable-verify", is_flag=True,
+            help="Set the endpoint to not use checksum verification")(f)
 
         return f
 


### PR DESCRIPTION
As requested in #63, I added network_use, location, and disable-verify options to endpoint create and update

I chose not to add subscription_id yet, as the API says it is currently only set manually by us, and I felt having it show up as an option that did nothing might be confusing. I can add it with help text explaining, or add it then comment it out if either of those are better options.

Since the API says a network_use value of custom requires max and preferred concurrency and parallelism to be set, I added --custom-concurrency and --custom-parallelism options that both take two ints. However it looks like these might be silently ignored for non managed endpoints?

To simplify user input I made location take two floats for latitude and longitude, and added a mutually exclusive --location-automatic option

I did manual testing of these options, but I was wondering how I should start making tests to confirm that my changes do what I think they do?