### PR TITLE
Add --limit and filtering options to task list

### DIFF
--- a/globus_cli/commands/task/list.py
+++ b/globus_cli/commands/task/list.py
@@ -6,16 +6,141 @@ from globus_cli.helpers import outformat_is_json, print_table
 from globus_cli.services.transfer import print_json_from_iterator, get_client
 
 
+class ISOTimeType(click.ParamType):
+    """
+    Enforces time inputs to be in either YYYY-MM-DD or YYYY-MM-DD HH:MM:SS
+    And that each value is a valid int that falls in the correct range
+    """
+
+    name = "ISO TIME"
+
+    def convert(self, value, param, ctx):
+        try:
+            if len(value) not in [10, 19]:
+                raise ValueError
+
+            year = int(value[:4])
+            if year <= 0:
+                self.fail("Invalid year {}".format(year))
+            month = int(value[5:7])
+            if month not in range(1, 13):
+                self.fail("Month {} must be in range 1-12.".format(month))
+            day = int(value[8:10])
+            if day not in range(1, 32):
+                self.fail("Day {} must be in range 1-31.".format(day))
+
+            if len(value) == 19:
+                hour = int(value[11:13])
+                if hour not in range(24):
+                    self.fail("Hour {} must be in range 0-23.".format(hour))
+                minute = int(value[14:16])
+                if minute not in range(60):
+                    self.fail(
+                        "Minute {} must be in range 0-59.".format(minute))
+                second = int(value[17:19])
+                if second not in range(61):
+                    self.fail(
+                        "Second {} must be in range 0-60.".format(second))
+
+            return value
+        except (ValueError, IndexError):
+            self.fail(
+                "Time must be in format YYYY-MM-DD or YYYY-MM-DD HH:MM:SS")
+
+
 @click.command('list', help='List Tasks for the current user')
 @common_options
-def task_list():
+@click.option(
+    "--limit", default=10, show_default=True, help="Limit number of results.")
+@click.option(
+    "--filter-task-id", multiple=True, type=click.UUID,
+    help="task UUID to filter by. This option can be used multiple times.")
+@click.option(
+    "--filter-type", type=click.Choice(["TRANSFER", "DELETE"]),
+    help="Filter results to only TRANSFER or DELETE tasks.")
+@click.option(
+    "--filter-status", multiple=True,
+    type=click.Choice(["ACTIVE", "INACTIVE", "FAILED", "SUCCEEDED"]),
+    help=("Task status to filter results by. "
+          "This option can be used multiple times."))
+@click.option(
+    "--filter-label", multiple=True,
+    help=("Filter results to task whose label matches pattern. "
+          "This option can be used multiple times."))
+@click.option(
+    "--filter-not-label", multiple=True,
+    help=("Filter not results whose label matches pattern. "
+          "This option can be used multiple times."))
+@click.option(
+    "--inexact / --exact", default=True,
+    help=("Allows / disallows --filter-label and --filter-not-label to use"
+          "* as a wild-card character and ignore case"))
+@click.option(
+    "--filter-requested-after", type=ISOTimeType(),
+    help="Filter results to tasks that were requested after given time.")
+@click.option(
+    "--filter-requested-before", type=ISOTimeType(),
+    help="Filter results to tasks that were requested before given time.")
+@click.option(
+    "--filter-completed-after", type=ISOTimeType(),
+    help="Filter results to tasks that were completed after given time.")
+@click.option(
+    "--filter-completed-before", type=ISOTimeType(),
+    help="Filter results to tasks that were completed before given time.")
+def task_list(limit, filter_task_id, filter_status, filter_type,
+              filter_label, filter_not_label, inexact,
+              filter_requested_after, filter_requested_before,
+              filter_completed_after, filter_completed_before):
     """
     Executor for `globus task-list`
     """
-    client = get_client()
 
-    task_iterator = client.task_list(num_results=10,
-                                     filter='type:TRANSFER,DELETE')
+    # make filter string
+    filter_string = ""
+
+    if filter_task_id:
+        filter_string += "task_id:"
+        for item in filter_task_id:
+            filter_string += "{},".format(item)
+        filter_string = filter_string[:-1] + "/"  # replace trailing , with /
+
+    if filter_type:
+        filter_string += "type:{}/".format(filter_type)
+    else:
+        filter_string += "type:TRANSFER,DELETE/"
+
+    if filter_status:
+        filter_string += "status:"
+        for item in filter_status:
+            filter_string += "{},".format(item)
+        filter_string = filter_string[:-1] + "/"  # replace trailing , with /
+
+    if filter_label or filter_not_label:
+        filter_string += "label:"
+        for item in filter_label:
+            if inexact:
+                filter_string += "~{},".format(item)
+            else:
+                filter_string += "={},".format(item)
+        for item in filter_not_label:
+            if inexact:
+                filter_string += "!~{},".format(item)
+            else:
+                filter_string += "!{},".format(item)
+        filter_string = filter_string[:-1] + "/"  # replace trailing , with /
+
+    if filter_requested_after or filter_requested_before:
+        filter_string += "request_time:{},{}/".format(
+            (filter_requested_after or ""), (filter_requested_before or ""))
+
+    if filter_completed_after or filter_completed_before:
+        filter_string += "completion_time:{},{}/".format(
+            (filter_completed_after or ""), (filter_completed_before or ""))
+
+    client = get_client()
+    task_iterator = client.task_list(
+        num_results=limit,
+        filter=filter_string[:-1])  # ignore trailing /
 
     if outformat_is_json():
         print_json_from_iterator(task_iterator)

--- a/globus_cli/commands/task/list.py
+++ b/globus_cli/commands/task/list.py
@@ -1,51 +1,10 @@
 import click
+import six
 
-from globus_cli.parsing import common_options
+from globus_cli.parsing import common_options, ISOTimeType
 from globus_cli.helpers import outformat_is_json, print_table
 
 from globus_cli.services.transfer import print_json_from_iterator, get_client
-
-
-class ISOTimeType(click.ParamType):
-    """
-    Enforces time inputs to be in either YYYY-MM-DD or YYYY-MM-DD HH:MM:SS
-    And that each value is a valid int that falls in the correct range
-    """
-
-    name = "ISO TIME"
-
-    def convert(self, value, param, ctx):
-        try:
-            if len(value) not in [10, 19]:
-                raise ValueError
-
-            year = int(value[:4])
-            if year <= 0:
-                self.fail("Invalid year {}".format(year))
-            month = int(value[5:7])
-            if month not in range(1, 13):
-                self.fail("Month {} must be in range 1-12.".format(month))
-            day = int(value[8:10])
-            if day not in range(1, 32):
-                self.fail("Day {} must be in range 1-31.".format(day))
-
-            if len(value) == 19:
-                hour = int(value[11:13])
-                if hour not in range(24):
-                    self.fail("Hour {} must be in range 0-23.".format(hour))
-                minute = int(value[14:16])
-                if minute not in range(60):
-                    self.fail(
-                        "Minute {} must be in range 0-59.".format(minute))
-                second = int(value[17:19])
-                if second not in range(61):
-                    self.fail(
-                        "Second {} must be in range 0-60.".format(second))
-
-            return value
-        except (ValueError, IndexError):
-            self.fail(
-                "Time must be in format YYYY-MM-DD or YYYY-MM-DD HH:MM:SS")
 
 
 @click.command('list', help='List Tasks for the current user')
@@ -95,47 +54,36 @@ def task_list(limit, filter_task_id, filter_status, filter_type,
     Executor for `globus task-list`
     """
 
+    def _process_filterval(prefix, value, default=None):
+        if value:
+            if isinstance(value, six.string_types):
+                return "{}:{}/".format(prefix, value)
+            return "{}:{}/".format(prefix, ",".join(str(x) for x in value))
+        else:
+            return default or ""
+
     # make filter string
     filter_string = ""
+    filter_string += _process_filterval("task_id", filter_task_id)
+    filter_string += _process_filterval("status", filter_status)
+    filter_string += _process_filterval("type", filter_type,
+                                        default="type:TRANSFER,DELETE/")
 
-    if filter_task_id:
-        filter_string += "task_id:"
-        for item in filter_task_id:
-            filter_string += "{},".format(item)
-        filter_string = filter_string[:-1] + "/"  # replace trailing , with /
-
-    if filter_type:
-        filter_string += "type:{}/".format(filter_type)
+    # combine data into one list for easier processing
+    if inexact:
+        label_data = (["~" + s for s in filter_label] +
+                      ["!~" + s for s in filter_not_label])
     else:
-        filter_string += "type:TRANSFER,DELETE/"
+        label_data = (["=" + s for s in filter_label] +
+                      ["!" + s for s in filter_not_label])
+    filter_string += _process_filterval("label", label_data)
 
-    if filter_status:
-        filter_string += "status:"
-        for item in filter_status:
-            filter_string += "{},".format(item)
-        filter_string = filter_string[:-1] + "/"  # replace trailing , with /
-
-    if filter_label or filter_not_label:
-        filter_string += "label:"
-        for item in filter_label:
-            if inexact:
-                filter_string += "~{},".format(item)
-            else:
-                filter_string += "={},".format(item)
-        for item in filter_not_label:
-            if inexact:
-                filter_string += "!~{},".format(item)
-            else:
-                filter_string += "!{},".format(item)
-        filter_string = filter_string[:-1] + "/"  # replace trailing , with /
-
-    if filter_requested_after or filter_requested_before:
-        filter_string += "request_time:{},{}/".format(
-            (filter_requested_after or ""), (filter_requested_before or ""))
-
-    if filter_completed_after or filter_completed_before:
-        filter_string += "completion_time:{},{}/".format(
-            (filter_completed_after or ""), (filter_completed_before or ""))
+    filter_string += _process_filterval(
+        "request_time", [(filter_requested_after or ""),
+                         (filter_requested_before or "")])
+    filter_string += _process_filterval(
+        "completion_time", [(filter_completed_after or ""),
+                            (filter_completed_before or "")])
 
     client = get_client()
     task_iterator = client.task_list(

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -7,6 +7,7 @@ from globus_cli.parsing.endpoint_plus_path import (
     ENDPOINT_PLUS_OPTPATH, ENDPOINT_PLUS_REQPATH)
 
 from globus_cli.parsing.hidden_option import HiddenOption
+from globus_cli.parsing.iso_time import ISOTimeType
 
 from globus_cli.parsing.shared_options import (
     common_options,
@@ -27,6 +28,7 @@ __all__ = [
     'TaskPath',
 
     'HiddenOption',
+    'ISOTimeType',
 
     'common_options',
     # Transfer options

--- a/globus_cli/parsing/iso_time.py
+++ b/globus_cli/parsing/iso_time.py
@@ -1,0 +1,24 @@
+import click
+import time
+
+
+class ISOTimeType(click.ParamType):
+    """
+    Enforces time inputs to be in either YYYY-MM-DD or YYYY-MM-DD HH:MM:SS
+    And that each value is a valid int that falls in the correct range
+    """
+
+    name = "ISO_TIME"
+
+    def convert(self, value, param, ctx):
+        try:
+            time.strptime(value, "%Y-%m-%d %H:%M:%S")
+            return value
+        except ValueError:
+            try:
+                time.strptime(value, "%Y-%m-%d")
+                return value
+            except ValueError:
+                self.fail(
+                    ("Time {} is not in ISO format of 'YYYY-MM-DD' or "
+                     "'YYYY-MM-DD HH:MM:SS'".format(value)))


### PR DESCRIPTION
Adds options to task list requested in #57

I felt it was easier on the user to split filtering up into several options rather than have them try to figure out how to make a filter string and then figure out what the API errors they were getting back meant.

I'm not ecstatic with the multi option method of passing more than one filter of the same kind, but it lets me use a click.Choice type for telling the user what values are allowed, and I think more typing is a lesser evil to unclear options?