### PR TITLE
endpoint activate

### DIFF
--- a/globus_cli/commands/config/init.py
+++ b/globus_cli/commands/config/init.py
@@ -4,7 +4,8 @@ import click
 
 from globus_cli.safeio import safeprint
 from globus_cli.parsing import CaseInsensitiveChoice, common_options
-from globus_cli.config import write_option, OUTPUT_FORMAT_OPTNAME
+from globus_cli.config import (
+    write_option, OUTPUT_FORMAT_OPTNAME, MYPROXY_USERNAME_OPTNAME)
 
 
 @click.command('init',
@@ -14,7 +15,9 @@ from globus_cli.config import write_option, OUTPUT_FORMAT_OPTNAME
 @click.option('--default-output-format',
               help='The default format for the CLI to use when printing.',
               type=CaseInsensitiveChoice(['json', 'text']))
-def init_command(default_output_format):
+@click.option("--default-myproxy-username",
+              help="The default username to use when activating via myproxy.")
+def init_command(default_output_format, default_myproxy_username):
     """
     Executor for `globus config init`
     """
@@ -35,7 +38,15 @@ def init_command(default_output_format):
         if default_output_format not in ('json', 'text'):
             default_output_format = None
 
+    if not default_myproxy_username:
+        safeprint(textwrap.fill("ENTER to skip."))
+        default_myproxy_username = click.prompt(
+            "Default myproxy username (cli.default_myproxy_username)",
+            default="", show_default=False
+            ).strip()
+
     # write to disk
     safeprint('\n\nWriting updated config to {0}'
               .format(os.path.expanduser('~/.globus.cfg')))
     write_option(OUTPUT_FORMAT_OPTNAME, default_output_format)
+    write_option(MYPROXY_USERNAME_OPTNAME, default_myproxy_username)

--- a/globus_cli/commands/endpoint/activate.py
+++ b/globus_cli/commands/endpoint/activate.py
@@ -1,0 +1,116 @@
+import click
+import webbrowser
+
+from globus_cli.safeio import safeprint
+from globus_cli.parsing import common_options, endpoint_id_arg
+from globus_cli.helpers import outformat_is_json, print_json_response
+from globus_cli.config import lookup_option, MYPROXY_USERNAME_OPTNAME
+from globus_cli.services.transfer import get_client
+from globus_cli.helpers import is_remote_session
+
+
+@click.command("activate",
+               short_help="Activate an endpoint",
+               help="""
+    Activate an endpoint using Autoactivation, Myproxy, or Web activation.
+    Note that since Web and Myproxy activation are mutually exclusive,
+    --myproxy-username --myproxy-password and --web are mutually exclusive.
+
+    \b
+    Autoactivation will be attempted if no options are given.
+
+    \b
+    To use Myproxy activation give both --myproxy-username and
+    --myproxy-password. If a default myproxy username has been configured with
+    "globus config init" or "globus config set cli.default_myproxy_username"
+    only --myproxy-password is required. Note that this is not
+    "OAuth for MyProxy" activation which requires Web activation.
+
+    \b
+    To use Web activation use the --web option. The CLI will try to open your
+    default browser to the endpoint's activation page, but if a remote CLI
+    session is detected, or the --no-browser option is given, a url will
+    be printed for you to manually follow and activate the endpoint.""")
+@common_options
+@endpoint_id_arg
+@click.option(
+    "--myproxy-username", "-U",
+    help=("Your username on the endpoint for Myproxy activation. Note, this "
+          "is not necessarily your globus username. Mutually exclusive with "
+          "--web. Requires --myproxy-password. Overrides any myproxy-username "
+          "in config."))
+@click.option(
+    "--myproxy-password", "-P",
+    help=("Your password on the endpoint for Myproxy activation. Note, this "
+          "should not be your globus password. Mutually exclusive with "
+          "--web. Requires --myproxy-username or cli.default_myproxy_username "
+          "to be set in config."))
+@click.option("--web", is_flag=True, default=False,
+              help=("Use web activation. Mutually exclusive with "
+                    "--myproxy-username and --myproxy-password"))
+@click.option("--no-browser", is_flag=True, default=False,
+              help=("If using --web, Give a url to manually follow instead of "
+                    "opening your default web browser. Implied if on a "
+                    "remote session."))
+def endpoint_activate(endpoint_id, myproxy_username, myproxy_password,
+                      web, no_browser):
+    """
+    Executor for `globus endpoint activate`
+    """
+    default_myproxy_username = lookup_option(MYPROXY_USERNAME_OPTNAME)
+    client = get_client()
+
+    # validate options
+    if web and (myproxy_password or myproxy_username):
+        raise click.UsageError(
+            "--web is mutually exclusive with "
+            "--myproxy-password and --myproxy-username")
+    if myproxy_password and not (myproxy_username or default_myproxy_username):
+        raise click.UsageError(
+            "--myproxy-password requires either --myproxy-username or "
+            "cli.default_myproxy_username to be set in config")
+    if no_browser and not web:
+        raise click.UsageError("--no-browser requires --web")
+
+    # myproxy activation
+    if myproxy_password:
+
+        no_server_msg = ("This endpoint has no myproxy server "
+                         "and so cannot be activated through myproxy")
+        requirements_data = client.endpoint_get_activation_requirements(
+            endpoint_id).data
+
+        if not len(requirements_data["DATA"]):
+            raise click.ClickException(no_server_msg)
+
+        for data in requirements_data["DATA"]:
+            if data["name"] == "passphrase":
+                data["value"] = myproxy_password
+            if data["name"] == "username":
+                data["value"] = myproxy_username or default_myproxy_username
+            if data["name"] == "hostname" and data["value"] is None:
+                raise click.ClickException(no_server_msg)
+
+        res = client.endpoint_activate(endpoint_id, requirements_data)
+
+    # web activation
+    elif web:
+        url = ("https://www.globus.org/app/"
+               "endpoints/{}/activate".format(endpoint_id))
+        if no_browser or is_remote_session():
+            res = {"message": "Web activation url: {}".format(url),
+                   "url": url}
+        else:
+            webbrowser.open(url, new=1)
+            res = {"message": "Browser opened to web activation page",
+                   "url": url}
+
+    # autoactivation
+    else:
+        res = client.endpoint_autoactivate(endpoint_id)
+
+    # output
+    if outformat_is_json():
+        print_json_response(res)
+    else:
+        safeprint(res["message"])

--- a/globus_cli/commands/endpoint/activate.py
+++ b/globus_cli/commands/endpoint/activate.py
@@ -2,7 +2,7 @@ import click
 import webbrowser
 
 from globus_cli.safeio import safeprint
-from globus_cli.parsing import common_options, endpoint_id_arg
+from globus_cli.parsing import common_options, endpoint_id_arg, HiddenOption
 from globus_cli.helpers import outformat_is_json, print_json_response
 from globus_cli.config import lookup_option, MYPROXY_USERNAME_OPTNAME
 from globus_cli.services.transfer import get_client
@@ -13,47 +13,56 @@ from globus_cli.helpers import is_remote_session
                short_help="Activate an endpoint",
                help="""
     Activate an endpoint using Autoactivation, Myproxy, or Web activation.
-    Note that since Web and Myproxy activation are mutually exclusive,
-    --myproxy-username --myproxy-password and --web are mutually exclusive.
+    Note that --web and --myproxy activation are mutually exclusive options.
 
     \b
-    Autoactivation will be attempted if no options are given.
+    Autoactivation will always be attempted unless the --no-autoactivate
+    option is given. If autoactivation succeeds any other activation options
+    will be ignored as the endpoint has already been successfully activated.
 
     \b
-    To use Myproxy activation give both --myproxy-username and
-    --myproxy-password. If a default myproxy username has been configured with
-    "globus config init" or "globus config set cli.default_myproxy_username"
-    only --myproxy-password is required. Note that this is not
-    "OAuth for MyProxy" activation which requires Web activation.
+    To use Web activation use the --web option.
+    The CLI will try to open your default browser to the endpoint's activation
+    page, but if a remote CLI session is detected, or the --no-browser option
+    is given, a url will be printed for you to manually follow and activate
+    the endpoint.
 
     \b
-    To use Web activation use the --web option. The CLI will try to open your
-    default browser to the endpoint's activation page, but if a remote CLI
-    session is detected, or the --no-browser option is given, a url will
-    be printed for you to manually follow and activate the endpoint.""")
+    To use Myproxy activation give the --myproxy option.
+    Myproxy activation requires your username and password for the myproxy
+    server the endpoint is using for authentication. e.g. for default
+    Globus Connect Server endpoints this will be your login credentials for the
+    server the endpoint is hosted on.
+
+    You can enter your username when prompted, give your username with the
+    --myproxy-username option, or set a default myproxy username in config with
+    "globus config init" or "globus config set cli.default_myproxy_username".
+
+    For security it is recommended that you only enter your password when
+    prompted to hide your inputs and keep your password out of your
+    command history, but you may pass your password with the hidden
+    --myproxy-password or -P options.""")
 @common_options
 @endpoint_id_arg
-@click.option(
-    "--myproxy-username", "-U",
-    help=("Your username on the endpoint for Myproxy activation. Note, this "
-          "is not necessarily your globus username. Mutually exclusive with "
-          "--web. Requires --myproxy-password. Overrides any myproxy-username "
-          "in config."))
-@click.option(
-    "--myproxy-password", "-P",
-    help=("Your password on the endpoint for Myproxy activation. Note, this "
-          "should not be your globus password. Mutually exclusive with "
-          "--web. Requires --myproxy-username or cli.default_myproxy_username "
-          "to be set in config."))
 @click.option("--web", is_flag=True, default=False,
-              help=("Use web activation. Mutually exclusive with "
-                    "--myproxy-username and --myproxy-password"))
+              help="Use web activation. Mutually exclusive with --myproxy.")
 @click.option("--no-browser", is_flag=True, default=False,
               help=("If using --web, Give a url to manually follow instead of "
                     "opening your default web browser. Implied if on a "
                     "remote session."))
-def endpoint_activate(endpoint_id, myproxy_username, myproxy_password,
-                      web, no_browser):
+@click.option("--myproxy", is_flag=True, default=False,
+              help="Use myproxy activation. Mutually exclusive with --web")
+@click.option("--myproxy-username", "-U",
+              help=("Give a username to use with --myproxy "
+                    "Overrides any default myproxy username set in config."))
+@click.option("--myproxy-password", "-P", cls=HiddenOption)
+@click.option("--no-autoactivate", is_flag=True, default=False,
+              help=("Don't attempt to autoactivate endpoint before using "
+                    "--web or --myproxy activation."))
+@click.option("--force", is_flag=True, default=False,
+              help="Force activation even if endpoint is already activated.")
+def endpoint_activate(endpoint_id, myproxy, myproxy_username, myproxy_password,
+                      web, no_browser, no_autoactivate, force):
     """
     Executor for `globus endpoint activate`
     """
@@ -61,22 +70,61 @@ def endpoint_activate(endpoint_id, myproxy_username, myproxy_password,
     client = get_client()
 
     # validate options
-    if web and (myproxy_password or myproxy_username):
+    if web and myproxy:
+        raise click.UsageError("--web is mutually exclusive with --myproxy.")
+    if no_autoactivate and not (myproxy or web):
         raise click.UsageError(
-            "--web is mutually exclusive with "
-            "--myproxy-password and --myproxy-username")
-    if myproxy_password and not (myproxy_username or default_myproxy_username):
-        raise click.UsageError(
-            "--myproxy-password requires either --myproxy-username or "
-            "cli.default_myproxy_username to be set in config")
+            "--no-autoactivate requires --web or --myproxy.")
+    if myproxy_username and not myproxy:
+        raise click.UsageError("--myproxy-username requires --myproxy.")
+    if myproxy_password and not myproxy:
+        raise click.UsageError("--myproxy-password requires --myproxy.")
     if no_browser and not web:
-        raise click.UsageError("--no-browser requires --web")
+        raise click.UsageError("--no-browser requires --web.")
+
+    # check if endpoint is already activated unless --force
+    if not force:
+        res = client.endpoint_autoactivate(endpoint_id, if_expires_in=60)
+
+        if "AlreadyActivated" == res["code"]:
+            if outformat_is_json():
+                print_json_response(res)
+            else:
+                safeprint(("Endpoint is already activated. Activation "
+                           "expires at {}".format(res["expire_time"])))
+            return
+
+    # attempt autoactivation unless --no-autoactivate
+    if not no_autoactivate:
+
+        res = client.endpoint_autoactivate(endpoint_id)
+
+        if "AutoActivated" in res["code"]:
+            if outformat_is_json():
+                print_json_response(res)
+            else:
+                safeprint("Autoactivation succeeded with message: {}".format(
+                    res["message"]))
+            return
+
+        # override potentially confusing autoactivation failure response
+        else:
+            res = {"message": ("Auto-activation failed, please "
+                               "use another activation method")}
 
     # myproxy activation
-    if myproxy_password:
+    if myproxy:
+
+        # get username and password
+        if not (myproxy_username or default_myproxy_username):
+            myproxy_username = click.prompt("Myproxy username")
+        if not myproxy_password:
+            myproxy_password = click.prompt(
+                "Myproxy password", hide_input=True)
 
         no_server_msg = ("This endpoint has no myproxy server "
                          "and so cannot be activated through myproxy")
+
         requirements_data = client.endpoint_get_activation_requirements(
             endpoint_id).data
 
@@ -104,10 +152,6 @@ def endpoint_activate(endpoint_id, myproxy_username, myproxy_password,
             webbrowser.open(url, new=1)
             res = {"message": "Browser opened to web activation page",
                    "url": url}
-
-    # autoactivation
-    else:
-        res = client.endpoint_autoactivate(endpoint_id)
 
     # output
     if outformat_is_json():

--- a/globus_cli/commands/endpoint/commands.py
+++ b/globus_cli/commands/endpoint/commands.py
@@ -4,6 +4,7 @@ from globus_cli.commands.endpoint.permission import permission_command
 from globus_cli.commands.endpoint.role import role_command
 from globus_cli.commands.endpoint.server import server_command
 
+from globus_cli.commands.endpoint.activate import endpoint_activate
 from globus_cli.commands.endpoint.search import endpoint_search
 from globus_cli.commands.endpoint.show import endpoint_show
 from globus_cli.commands.endpoint.create import endpoint_create
@@ -34,6 +35,7 @@ endpoint_command.add_command(endpoint_create_share)
 endpoint_command.add_command(endpoint_update)
 endpoint_command.add_command(endpoint_delete)
 
+endpoint_command.add_command(endpoint_activate)
 endpoint_command.add_command(endpoint_is_activated)
 endpoint_command.add_command(endpoint_deactivate)
 

--- a/globus_cli/commands/endpoint/deactivate.py
+++ b/globus_cli/commands/endpoint/deactivate.py
@@ -1,7 +1,8 @@
 import click
 
+from globus_cli.safeio import safeprint
 from globus_cli.parsing import common_options, endpoint_id_arg
-from globus_cli.helpers import print_json_response
+from globus_cli.helpers import outformat_is_json, print_json_response
 
 from globus_cli.services.transfer import get_client
 
@@ -15,4 +16,8 @@ def endpoint_deactivate(endpoint_id):
     """
     client = get_client()
     res = client.endpoint_deactivate(endpoint_id)
-    print_json_response(res)
+
+    if outformat_is_json():
+        print_json_response(res)
+    else:
+        safeprint(res["message"])

--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -9,6 +9,7 @@ from globus_cli import version
 __all__ = [
     # option name constants
     'OUTPUT_FORMAT_OPTNAME',
+    'MYPROXY_USERNAME_OPTNAME',
     'AUTH_RT_OPTNAME',
     'AUTH_AT_OPTNAME',
     'AUTH_AT_EXPIRES_OPTNAME',
@@ -45,6 +46,7 @@ ENV_CLIENT_ID_OPTNAME = 'cli_client_id'
 
 # constants for global use
 OUTPUT_FORMAT_OPTNAME = 'output_format'
+MYPROXY_USERNAME_OPTNAME = 'default_myproxy_username'
 AUTH_RT_OPTNAME = 'auth_refresh_token'
 AUTH_AT_OPTNAME = 'auth_access_token'
 AUTH_AT_EXPIRES_OPTNAME = 'auth_access_token_expires'


### PR DESCRIPTION
First pass at addressing issue #242 

Upon manual testing on GCS everything appears to be working, but we've run into the "how to automate tests with passwords" issue again.

I went ahead and added web activation since that's far easier to do than myproxy anyways.

I wasn't sure if we should always attempt autoactivation or not. It could make a user's life easier, but also cause confusion if a user was expecting manual activation. Maybe always attempting autoactivation unless a --no-autoactivate flag is passed would fix this problem?

I considered making the password a hidden prompt input akin to the click.password_option, but felt this might make it seem like we are being more secure with these passwords than we really are. If a false sense of security (along with the disclaimer about how myproxy activation handles passwords I assume we have somewhere) is okay I can add this.