### PR TITLE
Support for JMESPath expressions via --jmespath

### DIFF
--- a/globus_cli/helpers/__init__.py
+++ b/globus_cli/helpers/__init__.py
@@ -1,5 +1,6 @@
 from globus_cli.helpers.options import (
-    outformat_is_json, outformat_is_text, verbosity, is_verbose)
+    outformat_is_json, outformat_is_text, verbosity, is_verbose,
+    get_jmespath_expression)
 from globus_cli.helpers.version import print_version
 from globus_cli.helpers.local_server import (
     start_local_server, is_remote_session, LocalServerError)
@@ -9,6 +10,7 @@ __all__ = [
     'print_version',
 
     'outformat_is_json', 'outformat_is_text',
+    'get_jmespath_expression',
 
     "verbosity", "is_verbose",
 

--- a/globus_cli/helpers/options.py
+++ b/globus_cli/helpers/options.py
@@ -21,6 +21,15 @@ def outformat_is_text():
     return state.outformat_is_text()
 
 
+def get_jmespath_expression():
+    """
+    Only safe to call within a click context.
+    """
+    ctx = click.get_current_context()
+    state = ctx.ensure_object(CommandState)
+    return state.jmespath_expr
+
+
 def verbosity():
     """
     Only safe to call within a click context.

--- a/globus_cli/parsing/command_state.py
+++ b/globus_cli/parsing/command_state.py
@@ -1,5 +1,6 @@
 import warnings
 import click
+import jmespath
 
 from globus_cli import config
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
@@ -16,6 +17,8 @@ class CommandState(object):
     def __init__(self):
         # default is config value, or TEXT if it's not set
         self.output_format = config.get_output_format() or TEXT_FORMAT
+        # a jmespath expression to process on the json output
+        self.jmespath_expr = None
         # default is always False
         self.debug = False
         # default is 0
@@ -36,17 +39,35 @@ class CommandState(object):
 def format_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(CommandState)
-        # need to do an OR check here because this is invoked with value=None
-        # everywhere that the `-F`/`--format` option is omitted (each level of
-        # the command tree)
-        state.output_format = (value or state.output_format).lower()
+        # only set a new format if there is no stored jmespath expression
+        # otherwise, it must remain JSON
+        if state.jmespath_expr is None:
+            # need to do an OR check here because this is invoked with
+            # value=None everywhere that the `-F`/`--format` option is
+            # omitted (each level of the command tree)
+            state.output_format = (value or state.output_format).lower()
         return state.output_format
 
-    return click.option(
+    def jmespath_callback(ctx, param, value):
+        if value is None:
+            return
+        state = ctx.ensure_object(CommandState)
+        state.output_format = 'json'
+        state.jmespath_expr = jmespath.compile(value)
+        return state.jmespath_expr
+
+    f = click.option(
         '-F', '--format',
         type=CaseInsensitiveChoice([JSON_FORMAT, TEXT_FORMAT]),
         help='Output format for stdout. Defaults to text',
         expose_value=False, callback=callback)(f)
+    f = click.option(
+        "--jmespath",
+        help=("A JMESPath expression to apply to json output. "
+              "Takes precedence over any specified '--format' and forces "
+              "the format to be json processed by this expression"),
+        expose_value=False, callback=jmespath_callback)(f)
+    return f
 
 
 def debug_option(f):

--- a/globus_cli/parsing/command_state.py
+++ b/globus_cli/parsing/command_state.py
@@ -62,7 +62,7 @@ def format_option(f):
         help='Output format for stdout. Defaults to text',
         expose_value=False, callback=callback)(f)
     f = click.option(
-        "--jmespath",
+        "--jmespath", "--jq",
         help=("A JMESPath expression to apply to json output. "
               "Takes precedence over any specified '--format' and forces "
               "the format to be json processed by this expression"),

--- a/globus_cli/safeio/output_formatter.py
+++ b/globus_cli/safeio/output_formatter.py
@@ -4,7 +4,7 @@ import six
 from globus_sdk import GlobusResponse
 
 from globus_cli.safeio import safeprint
-from globus_cli.helpers import outformat_is_json
+from globus_cli.helpers import outformat_is_json, get_jmespath_expression
 
 # make sure this is a tuple
 # if it's a list, pylint will freak out
@@ -50,10 +50,17 @@ def _key_to_keyfunc(k):
 
 
 def print_json_response(res):
+    jmespath_expr = get_jmespath_expression()
+
+    def _print(data):
+        if jmespath_expr is not None:
+            data = jmespath_expr.search(data)
+        safeprint(json.dumps(data, indent=2))
+
     if isinstance(res, GlobusResponse):
-        safeprint(json.dumps(res.data, indent=2))
+        _print(res.data)
     elif isinstance(res, dict):
-        safeprint(json.dumps(res, indent=2))
+        _print(res)
     else:
         safeprint(res)
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     install_requires=[
         'globus-sdk==0.6.0',
         'click>=6.6,<7.0',
+        'jmespath==0.9.2',
         'configobj>=5.0.6,<6.0.0',
         'requests>=2.0.0,<3.0.0',
         'six>=1.0.0,<2.0.0'

--- a/tests/integration/test_jmespath_output.py
+++ b/tests/integration/test_jmespath_output.py
@@ -55,6 +55,11 @@ class JMESPathTests(CliTestCase):
                                assert_exit_code=2)
         self.assertIn('Error: --jmespath option requires an argument', output)
 
+        # and the error says `--jq` if you use the `--jq` form
+        output = self.run_line("globus endpoint search 'Tutorial' --jq",
+                               assert_exit_code=2)
+        self.assertIn('Error: --jq option requires an argument', output)
+
     def test_jmespath_invalid_expression_error(self):
         """
         Intentionally misuse `--jmespath` with a malformed expression. Confirm

--- a/tests/integration/test_jmespath_output.py
+++ b/tests/integration/test_jmespath_output.py
@@ -1,0 +1,66 @@
+import json
+import logging
+
+from tests.framework.constants import GO_EP1_ID, GO_EP2_ID
+from tests.framework.cli_testcase import CliTestCase
+
+log = logging.getLogger(__name__)
+
+
+class JMESPathTests(CliTestCase):
+    """
+    Tests bookmark commands
+    """
+    def test_jmespath_noop(self):
+        """
+        Runs some simple fetch operations and confirms that `--jmespath '@'`
+        doesn't change the output (but also that it overrides --format TEXT)
+        """
+        output = self.run_line(
+            "globus endpoint show {} -Fjson".format(GO_EP1_ID))
+        jmespathoutput = self.run_line(
+            "globus endpoint show {} -Ftext --jmespath '@'".format(GO_EP1_ID))
+        self.assertEquals(output, jmespathoutput)
+
+    def test_jmespath_extract_from_list(self):
+        """
+        Uses jmespath to extract a value from a list result using a filter.
+        Confirms that the result is identical to a direct fetch of that
+        resource.
+        """
+        self.maxDiff = None
+        # list tutorial endpoints with a search, but extract go#ep2
+        output = self.run_line(
+            ("globus endpoint search 'Tutorial' "
+             "--filter-owner-id go@globusid.org "
+             "--jmespath 'DATA[?id==`{}`] | [0]'").format(GO_EP2_ID))
+        outputdict = json.loads(output)
+
+        show_output = self.run_line(
+            "globus endpoint show {} -Fjson".format(GO_EP2_ID))
+        showdict = json.loads(show_output)
+
+        # check specific keys because search includes `_rank` and doesn't
+        # include the server list
+        # just a random selection of "probably stable" values for this test
+        for k in ('id', 'display_name', 'owner_id', 'subscription_id'):
+            self.assertEquals(outputdict[k], showdict[k])
+
+    def test_jmespath_no_expression_error(self):
+        """
+        Intentionally misuse `--jmespath` with no provided expression. Confirm
+        that it gives a usage error.
+        """
+        output = self.run_line("globus endpoint search 'Tutorial' --jmespath",
+                               assert_exit_code=2)
+        self.assertIn('Error: --jmespath option requires an argument', output)
+
+    def test_jmespath_invalid_expression_error(self):
+        """
+        Intentionally misuse `--jmespath` with a malformed expression. Confirm
+        that it gives a JMESPath ParseError.
+        """
+        output = self.run_line(("globus endpoint search 'Tutorial' "
+                                "--jmespath '{}'"),
+                               assert_exit_code=1)
+        self.assertIn('ParseError:', output)


### PR DESCRIPTION
Possible now that #251 is merged.

This option takes a JMESPath expression, coerces the output format to JSON, and post-processes the output results with the given expression. Compilation happens at option callback evaluation time, so no calls are made if we're given a malformed expression.

Adds dependency on jmespath==0.9.2 (latest release)

Includes a couple of simple tests, nothing too fancy.