### PR TITLE
Revoke any previously existing tokens on login

### DIFF
--- a/globus_cli/commands/login.py
+++ b/globus_cli/commands/login.py
@@ -185,18 +185,21 @@ def exchange_code_and_store_config(native_client, auth_code):
     # in the list is the primary.
     identity = res['identities'][0]
 
-    # write data to config
-    # TODO: remove once we deprecate these fully
-    write_option('transfer_token', transfer_at, section='general')
-    write_option('auth_token', auth_at, section='general')
-    # new values we want to use moving forward
+    # revoke any existing tokens
+    for token_opt in (TRANSFER_RT_OPTNAME, TRANSFER_AT_OPTNAME,
+                      AUTH_RT_OPTNAME, AUTH_AT_OPTNAME):
+        token = lookup_option(token_opt)
+        if token:
+            native_client.oauth2_revoke_token(token)
+
+    # write new tokens to config
     write_option(TRANSFER_RT_OPTNAME, transfer_rt)
     write_option(TRANSFER_AT_OPTNAME, transfer_at)
     write_option(TRANSFER_AT_EXPIRES_OPTNAME, transfer_at_expires)
     write_option(AUTH_RT_OPTNAME, auth_rt)
     write_option(AUTH_AT_OPTNAME, auth_at)
     write_option(AUTH_AT_EXPIRES_OPTNAME, auth_at_expires)
-    # whoami data
+    # write whoami data to config
     write_option(WHOAMI_ID_OPTNAME, identity['id'])
     write_option(WHOAMI_USERNAME_OPTNAME, identity['username'])
     write_option(WHOAMI_EMAIL_OPTNAME, identity['email'])

--- a/tests/framework/constants.py
+++ b/tests/framework/constants.py
@@ -5,11 +5,11 @@ GO_EP2_ID = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
 # tokens #
 # ------ #
 CLITESTER1A_TRANSFER_RT = (
-    "AQEAAAAAAASZW2ABfUlIETww7c_hJsL4dDU4WdcWzO"
-    "LsUHlLOdcfXbiSDBv7VsZuWKevElbz5rRYRSf3meMT")
+    "AQEAAAAAAASZW3DsgHBmLpsSmnI5ZtmhXOhHaovMnd"
+    "1Ehs_H0h7qy4dn_82sKlSFrJ6Imo_1iWT_YFFD4dmm")
 CLITESTER1A_AUTH_RT = (
-    "AQEAAAAAAASZXMLuxZGk0qeOIQ-Gajl44V4NJ2w5HO"
-    "N1MSE8pO-io_4wQgDkgmlWnA4-5yrdy0eHgssJmsZ0")
+    "AQEAAAAAAASZXM-UJaOOO0eBAmfVDGAQxezLdkF5Nf"
+    "gcUG6-DRtreGA--ctzQQAI13ClmHxPLH-_Jc5xabRK")
 # ---------- #
 # end tokens #
 # ---------- #


### PR DESCRIPTION
While writing login docs I realized that when using --force on login existing tokens were just being overwritten and not revoked.

Also removed some depreciated tokens that had a todo to remove them.

I accidentally revoked the clitester's tokens during a quick manual test (it worked), so there are some new ones here, if we don't want to make this change I'll make a quick PR to fix that.