### PR TITLE
Decapitalize endpoint and share in help text

### DIFF
--- a/globus_cli/commands/delete.py
+++ b/globus_cli/commands/delete.py
@@ -12,7 +12,7 @@ from globus_cli.services.transfer import get_client, autoactivate
 
 
 @click.command('delete', short_help='Submit a delete task',
-               help=('Delete a file or directory from one Endpoint as an '
+               help=('Delete a file or directory from one endpoint as an '
                      'asynchronous task.'))
 @common_options
 @task_submission_options

--- a/globus_cli/commands/endpoint/create.py
+++ b/globus_cli/commands/endpoint/create.py
@@ -22,7 +22,7 @@ GCP_FIELDS = [
     "create", short_help="Create a new endpoint",
     help=("Create a new endpoint. Requires a display name and exactly one of "
           "--personal, --server, or --shared to make a Globus Connect "
-          "Personal, Globus Connect Server, or Shared endpoint respectively."))
+          "Personal, Globus Connect Server, or shared endpoint respectively."))
 @common_options
 @endpoint_create_and_update_params(create=True)
 @click.option("--personal", is_flag=True,


### PR DESCRIPTION
Minor change for #223

Only place I can find any capitals for Endpoint Bookmark Share or Task in the cli itself is in the fields for output, which seem to be all caps for anything.

When we get --fields working we should probably make sure those names match the json fields they reference too, but not an issue yet.