### PR TITLE
Update to v1.0.0.0

### DIFF
--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -19,7 +19,7 @@ from distutils.version import LooseVersion
 #       2.4.6.1.2   -- no additional point versions
 #       0.1.0.0     -- no special rules for things like this
 #       1.4.6.0     -- differing major version, obviously wrong
-__version__ = "0.7.2.0"
+__version__ = "1.0.0.0"
 
 # app name to send as part of SDK requests
 app_name = 'Globus CLI v{} - Beta'.format(__version__)

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,12 @@ setup(
     version=version,
     packages=find_packages(),
     install_requires=[
-        'globus-sdk==0.7.2',
+        'globus-sdk==1.0.0',
         'click>=6.6,<7.0',
         'jmespath==0.9.2',
         'configobj>=5.0.6,<6.0.0',
         'requests>=2.0.0,<3.0.0',
-        'six>=1.0.0,<2.0.0'
+        'six>=1.1.0,<2.0.0'
     ],
 
     entry_points={

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -69,7 +69,7 @@ class BasicTests(CliTestCase):
             "globus get-identities " +
             get_user_data()["clitester1a"]["username"],
             assert_exit_code=1)
-        self.assertIn("A GLobus API Error Occurred", output)
+        self.assertIn("A Globus Error Occurred", output)
         self.assertIn("401", output)
 
     def test_auth_call(self):


### PR DESCRIPTION
Updates SDK dependency (still exact version required!) to 1.0.0
Minor fix to the tests due to a change in error type on unauthed API calls to Auth.