### PR TITLE
Add --fields option

### DIFF
--- a/globus_cli/helpers/__init__.py
+++ b/globus_cli/helpers/__init__.py
@@ -1,6 +1,6 @@
 from globus_cli.helpers.options import (
     outformat_is_json, outformat_is_text, verbosity, is_verbose,
-    get_jmespath_expression)
+    get_jmespath_expression, get_output_fields)
 from globus_cli.helpers.version import print_version
 from globus_cli.helpers.local_server import (
     start_local_server, is_remote_session, LocalServerError)
@@ -12,7 +12,7 @@ __all__ = [
     'outformat_is_json', 'outformat_is_text',
     'get_jmespath_expression',
 
-    "verbosity", "is_verbose",
+    "verbosity", "is_verbose", "get_output_fields",
 
     'start_local_server', 'is_remote_session', 'LocalServerError'
 ]

--- a/globus_cli/helpers/options.py
+++ b/globus_cli/helpers/options.py
@@ -46,3 +46,12 @@ def is_verbose():
     ctx = click.get_current_context()
     state = ctx.ensure_object(CommandState)
     return state.is_verbose()
+
+
+def get_output_fields():
+    """
+    Only safe to call within a click context.
+    """
+    ctx = click.get_current_context()
+    state = ctx.ensure_object(CommandState)
+    return state.output_fields

--- a/globus_cli/parsing/command_state.py
+++ b/globus_cli/parsing/command_state.py
@@ -25,6 +25,8 @@ class CommandState(object):
         self.verbosity = 0
         # by default, empty dict
         self.http_status_map = {}
+        # by default, empty list
+        self.output_fields = []
 
     def outformat_is_text(self):
         return self.output_format == TEXT_FORMAT
@@ -171,3 +173,20 @@ def map_http_status_option(f):
         help=('Map HTTP statuses to any of these exit codes: 0,1,50-99. '
               'e.g. "404=50,403=51"'),
         expose_value=False, callback=callback, multiple=True)(f)
+
+
+def fields_option(f):
+    def callback(ctx, param, value):
+        """
+        Split the comma separated list of fields into a list of fields.
+        """
+        state = ctx.ensure_object(CommandState)
+
+        # allow caps and spaces, but force them into field names
+        # this assumes all json fields use only lower case and have no spaces.
+        if value:
+            state.output_fields = value.split(",")
+
+    return click.option(
+        "--fields", expose_value=False, callback=callback,
+        help="Comma separated list of fields to output")(f)

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -2,7 +2,7 @@ import click
 
 from globus_cli.parsing.command_state import (
     format_option, debug_option, map_http_status_option,
-    verbose_option, HiddenOption)
+    verbose_option, fields_option, HiddenOption)
 from globus_cli.parsing.version_option import version_option
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
 from globus_cli.parsing.detect_and_decorate import detect_and_decorate
@@ -45,6 +45,10 @@ def common_options(*args, **kwargs):
         # if the --map-http-status option is being allowed, ...
         if not kwargs.get('no_map_http_status_option'):
             f = map_http_status_option(f)
+
+        # if the fields option is being allowed, ...
+        if not kwargs.get("no_fields_option"):
+            f = fields_option(f)
 
         return f
 


### PR DESCRIPTION
First pass attempt to resolve #117 and figure out what questions still need answering to finish this.

usage [COMMAND] [OPTIONS] --fields FIELD,FIELD,...

where each FIELD is either a named field in output, or a json key
e.g. globus enpdoint search "Tutorial" --fields Owner,ID,keywords,expires_in


Questions that need answering:

Should this option mean anything with -F json?

How to handle repeat/non-existing fields?
Currently I'm including any repeats and erroring on non-existent fields

If only one field is given to colon print, should we not output the field-name to make something like this possible?:
owner_id=$(globus endpoint show <ID> --fields owner_id)

Do we want this option to be used to specify which single line output is used for commands like globus whoami and globus get-identities? (and error if more than one field is passed?) e.g.:
my_id=$(globus whoami --fields ID)
Or maybe even not make single line output default anymore and suggest that --fields be used instead?