### PR TITLE
Depend on six>=1.10.0 to ensure healthy SDK install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'jmespath==0.9.2',
         'configobj>=5.0.6,<6.0.0',
         'requests>=2.0.0,<3.0.0',
-        'six>=1.1.0,<2.0.0'
+        'six>=1.10.0,<2.0.0'
     ],
 
     entry_points={


### PR DESCRIPTION
This is all about handling pypa/pip#988
Resolves #265