### PR TITLE
rm command

### DIFF
--- a/globus_cli/commands/main.py
+++ b/globus_cli/commands/main.py
@@ -12,6 +12,7 @@ from globus_cli.commands.whoami import whoami_command
 from globus_cli.commands.get_identities import get_identities_command
 from globus_cli.commands.ls import ls_command
 from globus_cli.commands.delete import delete_command
+from globus_cli.commands.rm import rm_command
 from globus_cli.commands.transfer import transfer_command
 from globus_cli.commands.mkdir import mkdir_command
 from globus_cli.commands.rename import rename_command
@@ -40,6 +41,7 @@ main.add_command(ls_command)
 main.add_command(mkdir_command)
 main.add_command(rename_command)
 main.add_command(delete_command)
+main.add_command(rm_command)
 main.add_command(transfer_command)
 
 main.add_command(endpoint_command)

--- a/globus_cli/commands/rm.py
+++ b/globus_cli/commands/rm.py
@@ -1,0 +1,81 @@
+import click
+
+from globus_sdk import DeleteData
+
+
+from globus_cli.parsing import (
+    common_options, task_submission_options, ENDPOINT_PLUS_REQPATH)
+from globus_cli.safeio import (
+    formatted_print, FORMAT_TEXT_RECORD, FORMAT_SILENT)
+from globus_cli.helpers import is_verbose
+from globus_cli.services.transfer import get_client, autoactivate
+
+
+@click.command("rm", short_help="Remove files or directories",
+               help=("Remove a file or directory from an endpoint as a "
+                     "synchronous task. Similar to `globus delete`, but waits "
+                     "for the delete task to finish before exiting."))
+@common_options
+@task_submission_options
+@click.option(
+    "--recursive", "-r", is_flag=True, help="Recursively remove dirs")
+@click.option("--ignore-missing", "-f", is_flag=True,
+              help="Don't throw errors if the file or dir is absent")
+@click.argument("endpoint_plus_path", metavar=ENDPOINT_PLUS_REQPATH.metavar,
+                type=ENDPOINT_PLUS_REQPATH)
+@click.option(
+    "--timeout", type=int, metavar="N", default=60, show_default=True,
+    help=("If the delete task does not terminate after N seconds, this command"
+          " will exit with code 1. The task will continue to exist and may "
+          "finish in the background."))
+def rm_command(ignore_missing, recursive, endpoint_plus_path,
+               label, submission_id, dry_run, deadline, timeout):
+    """
+    Executor for `globus rm`
+    """
+    endpoint_id, path = endpoint_plus_path
+
+    client = get_client()
+    autoactivate(client, endpoint_id, if_expires_in=60)
+
+    delete_data = DeleteData(client, endpoint_id,
+                             label=label,
+                             recursive=recursive,
+                             ignore_missing=ignore_missing,
+                             submission_id=submission_id,
+                             deadline=deadline)
+    delete_data.add_item(path)
+
+    if dry_run:
+        formatted_print(delete_data, response_key="DATA",
+                        fields=[("Path", "path")])
+        # exit safely
+        return
+
+    # submit task, wait for it to finish or timeout, then get task information
+    task_id = client.submit_delete(delete_data)["task_id"]
+    client.task_wait(task_id, timeout=timeout, polling_interval=1)
+    res = client.get_task(task_id)
+
+    # exit 0 if success
+    if res["status"] == "SUCCEEDED":
+        if is_verbose():
+            formatted_print(res, text_format=FORMAT_TEXT_RECORD,
+                            fields=(("Status", "status"),
+                                    ("Task ID", "task_id")))
+        else:
+            formatted_print(res, text_format=FORMAT_SILENT)
+
+    # exit 1 if failed, and give some details for why
+    elif res["status"] == "FAILED":
+        details = client.task_event_list(
+            task_id, filter="is_error:1")[0]["details"]
+        formatted_print(res, simple_text=("Task failed with "
+                                          "details: {}.".format(details)))
+        click.get_current_context().exit(1)
+
+    # exit 1 if timeout
+    else:
+        formatted_print(res, simple_text=("Task has yet to complete after {}"
+                                          " seconds.".format(timeout)))
+        click.get_current_context().exit(1)

--- a/globus_cli/commands/rm.py
+++ b/globus_cli/commands/rm.py
@@ -14,7 +14,9 @@ from globus_cli.services.transfer import get_client, autoactivate
 @click.command("rm", short_help="Remove files or directories",
                help=("Remove a file or directory from an endpoint as a "
                      "synchronous task. Similar to `globus delete`, but waits "
-                     "for the delete task to finish before exiting."))
+                     "for the delete task to finish before exiting. "
+                     "Allows for bash style globbing with `*`, `?`, `[`, and "
+                     "`]`."))
 @common_options
 @task_submission_options
 @click.option(
@@ -43,7 +45,8 @@ def rm_command(ignore_missing, recursive, endpoint_plus_path,
                              recursive=recursive,
                              ignore_missing=ignore_missing,
                              submission_id=submission_id,
-                             deadline=deadline)
+                             deadline=deadline,
+                             interpret_globs=True)
     delete_data.add_item(path)
 
     if dry_run:

--- a/tests/unit/test_rm.py
+++ b/tests/unit/test_rm.py
@@ -1,0 +1,134 @@
+from random import getrandbits
+import json
+
+from tests.framework.cli_testcase import CliTestCase
+from tests.framework.constants import GO_EP1_ID
+
+
+class RMTests(CliTestCase):
+
+    def test_recursive(self):
+        """
+        Makes a dir on ep1, then --recursive rm's it.
+        Confirms delete task was successful.
+        """
+        # name randomized to prevent collision
+        path = "/~/rm_dir-{}".format(str(getrandbits(128)))
+        self.tc.operation_mkdir(GO_EP1_ID, path)
+
+        output = self.run_line(
+            "globus rm -r -F json {}:{}".format(GO_EP1_ID, path))
+        res = json.loads(output)
+        self.assertEqual(res["status"], "SUCCEEDED")
+
+    def test_no_file(self):
+        """
+        Attempts to remove a non-existant file. Confirms exit code 1
+        """
+        path = "/~/nofilehere.txt"
+        self.run_line(
+            "globus rm {}:{}".format(GO_EP1_ID, path), assert_exit_code=1)
+
+    def test_ignore_missing(self):
+        """
+        Attempts to remove a non-existant file path, with --ignore-missing.
+        Confirms exit code 0 and silent output.
+        """
+        path = "/~/nofilehere.txt"
+        output = self.run_line("globus rm -f {}:{}".format(GO_EP1_ID, path))
+        self.assertEqual(output, "")
+
+    def test_pattern_globbing(self):
+        """
+        Makes 3 dirs with the same prefix, and uses * globbing to rm them all.
+        Confirms delete task was successful and removed 3 dirs.
+        """
+        # mark all dirs with a random generated prefix to prevent collision
+        rand = str(getrandbits(128))
+        for i in range(3):
+            path = "/~/rm_dir{}-{}".format(rand, i)
+            self.tc.operation_mkdir(GO_EP1_ID, path)
+
+        # remove all dirs with the prefix
+        glob = "rm_dir{}*".format(rand)
+        output = self.run_line(
+            "globus rm -r -F json {}:{}".format(GO_EP1_ID, glob))
+        res = json.loads(output)
+        self.assertEqual(res["status"], "SUCCEEDED")
+
+        # confirm no dirs with the prefix exist on the endpoint
+        filter_string = "name:~rm_dir{}*".format(rand)
+        ls_doc = self.tc.operation_ls(GO_EP1_ID, filter=filter_string)
+        for item in ls_doc:
+            self.assertTrue(False)
+
+    def test_wild_globbing(self):
+        """
+        Makes 3 dirs with the same prefix, and uses ? globbing to rm them all.
+        Confirms delete task was successful and removed 3 dirs.
+        """
+        # mark all dirs with a random generated prefix to prevent collision
+        rand = str(getrandbits(128))
+        for i in range(3):
+            path = "/~/rm_dir{}-{}".format(rand, i)
+            self.tc.operation_mkdir(GO_EP1_ID, path)
+
+        # remove all dirs with the prefix
+        glob = "rm_dir{}-?".format(rand)
+        output = self.run_line(
+            "globus rm -r -F json {}:{}".format(GO_EP1_ID, glob))
+        res = json.loads(output)
+        self.assertEqual(res["status"], "SUCCEEDED")
+
+        # confirm no dirs with the prefix exist on the endpoint
+        filter_string = "name:~rm_dir{}*".format(rand)
+        ls_doc = self.tc.operation_ls(GO_EP1_ID, filter=filter_string)
+        for item in ls_doc:
+            self.assertTrue(False)
+
+    def test_bracket_globbing(self):
+        """
+        Makes 3 dirs with the same prefix, and uses [] globbing to rm them all.
+        Confirms delete task was successful and removed 3 dirs.
+        """
+        # mark all dirs with a random generated prefix to prevent collision
+        rand = str(getrandbits(128))
+        for i in range(3):
+            path = "/~/rm_dir{}-{}".format(rand, i)
+            self.tc.operation_mkdir(GO_EP1_ID, path)
+
+        # remove all dirs with the prefix
+        glob = "rm_dir{}-[012]".format(rand)
+        output = self.run_line(
+            "globus rm -r -F json {}:{}".format(GO_EP1_ID, glob))
+        res = json.loads(output)
+        self.assertEqual(res["status"], "SUCCEEDED")
+
+        # confirm no dirs with the prefix exist on the endpoint
+        filter_string = "name:~rm_dir{}*".format(rand)
+        ls_doc = self.tc.operation_ls(GO_EP1_ID, filter=filter_string)
+        for item in ls_doc:
+            print item["name"]
+            self.assertTrue(False)
+
+    def test_timeout(self):
+        """
+        Attempts to remove a path we are not allowed to remove,
+        confirms rm times out and exits 1 after given timeout.
+        """
+        timeout = 2
+        path = "/share/godata/file1.txt"
+        output = self.run_line(
+            "globus rm -r --timeout {} {}:{}".format(timeout, GO_EP1_ID, path),
+            assert_exit_code=1)
+        self.assertIn(("Task has yet to complete "
+                       "after {} seconds.".format(timeout)), output)
+
+    def test_unsafe(self):
+        """
+        Attempts to remove an unsafe path, confirms API Error is raised
+        """
+        path = "/"
+        output = self.run_line("globus rm -r {}:{}".format(GO_EP1_ID, path),
+                               assert_exit_code=1)
+        self.assertIn("Unsafe delete path", output)


### PR DESCRIPTION
First pass to resolve #196, I'll add some unit tests soon.

It felt a little weird having the task_submission_options on this command since the point of rm is to pretend like a delete task is synchronous, but since the hosted cli has --label and --deadline I figured --dry-run and --submission-id wouldn't hurt?

I left out the -D option from the hosted cli since users can now just use 'globus rm EP:PATH &' if they want to make their synchronous wrapper of an asynchronous task run asynchronously again for some reason.

I decided to add a --timeout that defaulted to a minute, because I dislike the idea of a user submitting a task that becomes inactive or takes longer than expected time and getting stuck. However since the point of rm is blocking I wouldn't mind removing this or making it not a default.

Should I add a --no-globbing option in case people happen to be rming files that have a bunch of * ? [ or ] in their names and don't want to have to escape their characters?

Issue #129 also applies here.