### PR TITLE
Update login command to print more help

### DIFF
--- a/globus_cli/commands/login.py
+++ b/globus_cli/commands/login.py
@@ -121,6 +121,12 @@ def do_local_server_login_flow():
     Starts a local http server, opens a browser to have the user login,
     and gets the code redirected to the server (no copy and pasting required)
     """
+    safeprint(
+        "You are running 'globus login', which should automatically open "
+        "a browser window for you to login.\n"
+        "If this fails or you experience difficulty, try "
+        "'globus login --no-local-server'"
+        "\n---")
     # start local server and create matching redirect_uri
     with start_local_server(listen=('127.0.0.1', 0)) as server:
         _, port = server.socket.getsockname()


### PR DESCRIPTION
If the user is doing local login, we might have issues with opening the
magic browser. Print a message about running with `--no-local-server`

Sample output:
```shell
$ globus login
You are running 'globus login', which should automatically open a browser window for you to login.
If this fails or you experience difficulty, try 'globus login --no-local-server'
---

You have successfully logged in to the Globus CLI as sirosen@globusid.org

You can always check your current identity with
  globus whoami

Logout of the Globus CLI with
  globus logout

```
