### PR TITLE
Add --orderby and globbing to ls, with unit tests

### DIFF
--- a/adoc/ls.1.adoc
+++ b/adoc/ls.1.adoc
@@ -14,9 +14,10 @@ globus ls - List endpoint directory contents
 The *globus ls* command lists files and subdirectories on an endpoint. If no
 path is given, the default directory on that endpoint will be used.
 
-If using text output files and directories are printed with one entry per
-line in alphabetical order.  Directories are always displayed with a
-trailing '/'.
+POSIX style globbing using the wildcard characters ? (matches any single
+character) and * (matches any string, including the empty string) is allowed
+in the final component of the PATH. If you want to use literall * or ?
+characters, the --no-globbing option disables this feature.
 
 include::include/cli_autoactivate.adoc[]
 
@@ -38,12 +39,40 @@ the --recursive-depth-limit. Note that this can quickly become a very expensive
 operation and may take a significant amount of time to complete or even fail on
 rate limits.
 
-*--recursive-depth-limit*::
+*--recursive-depth-limit* INTEGER::
 
 Set the depth limit when using the --recursive option. Defaults to 3 if not
 given.
 
+*--orderby* FIELD::
+
+Order results by the given field name in ascending order. The field name
+may either be as shown with --long output (see OUTPUT), or a json key.
+
+*--no-globbing*::
+
+Disable globbing in the final component of the PATH, allowing * and ? to be
+used as literal characters instead of wildcards.
+
 include::include/common_options.adoc[]
+
+
+== OUTPUT
+
+If using text output files and directories are printed with one entry per
+line in alphabetical order.  Directories are always displayed with a
+trailing '/'.
+
+If using --long text output a table is shown with the following fields, any of
+which can be used as an argument to --orderby:
+
+- 'Permissions'
+- 'User'
+- 'Group'
+- 'Size'
+- 'Last Modified'
+- 'File Type'
+- 'Filename'
 
 
 == EXAMPLES

--- a/tests/unit/test_ls.py
+++ b/tests/unit/test_ls.py
@@ -1,0 +1,82 @@
+import json
+
+from tests.framework.cli_testcase import CliTestCase
+from tests.framework.constants import GO_EP1_ID
+
+
+class LsTests(CliTestCase):
+    """
+    Tests globus ls command
+    """
+
+    def test_path(self):
+        """
+        Does an ls on EP1:/, confirms expected results.
+        """
+        path = "/"
+        output = self.run_line("globus ls {}:{}".format(GO_EP1_ID, path))
+
+        expected = ["home/", "mnt/", "not shareable/", "share/"]
+        for item in expected:
+            self.assertIn(item, output)
+
+    def test_recursive(self):
+        """
+        Does a recursive ls on EP1:/share/, confirms expected results
+        """
+        path = "/share/"
+        output = self.run_line("globus ls -r {}:{}".format(GO_EP1_ID, path))
+
+        expected = ["godata/",
+                    "godata/file1.txt", "godata/file2.txt", "godata/file3.txt"]
+        for item in expected:
+            self.assertIn(item, output)
+
+    def test_orderby(self):
+        """
+        Uses the Size field from long output as an argument to --orderby,
+        confirms results in ascending order by size json field
+        """
+        path = "/"
+        output = json.loads(self.run_line(
+            "globus ls -F json --orderby Size {}:{}".format(GO_EP1_ID, path)))
+
+        prev_size = 0
+        for item in output["DATA"]:
+            self.assertTrue(item["size"] >= prev_size)
+            prev_size = item["size"]
+
+    def test_pattern_globbing(self):
+        """
+        Does an ls on EP1:/share/godata/file*, confirms all 3 files listed
+        """
+        path = "/share/godata/file*"
+        output = self.run_line("globus ls {}:{}".format(GO_EP1_ID, path))
+
+        expected = ["file1.txt", "file2.txt", "file3.txt"]
+        for item in expected:
+            self.assertIn(item, output)
+
+    def test_wildcard_globbing(self):
+        """
+        Does an ls on EP1:/share/godata/file?.txt, confirms all 3 files listed
+        """
+        path = "/share/godata/file?.txt"
+        output = self.run_line("globus ls {}:{}".format(GO_EP1_ID, path))
+
+        expected = ["file1.txt", "file2.txt", "file3.txt"]
+        for item in expected:
+            self.assertIn(item, output)
+
+    def test_no_globbing(self):
+        """
+        Does an ls on EP1:~/* with --no-globbing,
+        confirms exit 1 on error as no * dir exists
+        """
+        path = "~/*"
+        output = self.run_line(
+            "globus ls --no-globbing {}:{}".format(GO_EP1_ID, path),
+            assert_exit_code=1)
+
+        self.assertIn("ClientError.NotFound", output)
+        self.assertIn("Directory '/~/%2A' not found", output)


### PR DESCRIPTION
resolves #195 and #192, and adds some unit tests to make sure things are working properly.

globbing is only handled in the last component of the path which is equivalent with the hosted CLI. I also added a `--no-globbing` flag incase people want litteral * or ? characters.

the output when combining `--orderby` with `--recursive` is inconsistent with bash `ls -R` because we are using DFS. I could switch to BFS here, but #46 will take care of this anyways?