### PR TITLE
Resolve bookmark to endpoint plus path

### DIFF
--- a/globus_cli/commands/bookmark/delete.py
+++ b/globus_cli/commands/bookmark/delete.py
@@ -3,7 +3,7 @@ import click
 from globus_cli.parsing import common_options
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RAW
 from globus_cli.services.transfer import get_client
-from globus_cli.commands.bookmark.helpers import resolve_id_or_name
+from globus_cli.helpers import resolve_bookmark_id_or_name
 
 
 @click.command('delete', help='Delete a bookmark')
@@ -14,7 +14,7 @@ def bookmark_delete(bookmark_id_or_name):
     Executor for `globus bookmark delete`
     """
     client = get_client()
-    bookmark_id = resolve_id_or_name(client, bookmark_id_or_name)["id"]
+    bookmark_id = resolve_bookmark_id_or_name(bookmark_id_or_name)["id"]
 
     res = client.delete_bookmark(bookmark_id)
     formatted_print(res, text_format=FORMAT_TEXT_RAW, response_key='message')

--- a/globus_cli/commands/bookmark/rename.py
+++ b/globus_cli/commands/bookmark/rename.py
@@ -3,7 +3,7 @@ import click
 from globus_cli.parsing import common_options
 from globus_cli.safeio import formatted_print
 from globus_cli.services.transfer import get_client
-from globus_cli.commands.bookmark.helpers import resolve_id_or_name
+from globus_cli.helpers import resolve_bookmark_id_or_name
 
 
 @click.command('rename', help='Change a bookmark\'s name')
@@ -15,7 +15,7 @@ def bookmark_rename(bookmark_id_or_name, new_bookmark_name):
     Executor for `globus bookmark rename`
     """
     client = get_client()
-    bookmark_id = resolve_id_or_name(client, bookmark_id_or_name)["id"]
+    bookmark_id = resolve_bookmark_id_or_name(bookmark_id_or_name)["id"]
 
     submit_data = {
         'name': new_bookmark_name

--- a/globus_cli/commands/bookmark/show.py
+++ b/globus_cli/commands/bookmark/show.py
@@ -4,8 +4,7 @@ from globus_cli.parsing import common_options
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RECORD
 from globus_cli.helpers import is_verbose
 
-from globus_cli.services.transfer import get_client
-from globus_cli.commands.bookmark.helpers import resolve_id_or_name
+from globus_cli.helpers import resolve_bookmark_id_or_name
 
 
 @click.command(
@@ -17,8 +16,7 @@ def bookmark_show(bookmark_id_or_name):
     """
     Executor for `globus bookmark show`
     """
-    client = get_client()
-    res = resolve_id_or_name(client, bookmark_id_or_name)
+    res = resolve_bookmark_id_or_name(bookmark_id_or_name)
     formatted_print(
         res, text_format=FORMAT_TEXT_RECORD,
         fields=(('ID', 'id'), ('Name', 'name'),

--- a/globus_cli/commands/delete.py
+++ b/globus_cli/commands/delete.py
@@ -4,8 +4,8 @@ from globus_sdk import DeleteData
 
 
 from globus_cli.parsing import (
-    common_options, task_submission_options, TaskPath, ENDPOINT_PLUS_OPTPATH,
-    shlex_process_stdin)
+    common_options, task_submission_options, TaskPath, shlex_process_stdin,
+    endpoint_plus_path_options, parse_endpoint_plus_path)
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RECORD
 
 from globus_cli.services.transfer import get_client, autoactivate
@@ -25,14 +25,15 @@ from globus_cli.services.transfer import get_client, autoactivate
                     'batchmode). Uses ENDPOINT_ID as passed on the '
                     'commandline. Any commandline PATH given will be used as '
                     'a prefix to all paths given'))
-@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
-                type=ENDPOINT_PLUS_OPTPATH)
+@endpoint_plus_path_options(path_required=False)
 def delete_command(batch, ignore_missing, recursive, endpoint_plus_path,
-                   label, submission_id, dry_run, deadline):
+                   bookmark, label, submission_id, dry_run, deadline):
     """
     Executor for `globus delete`
     """
-    endpoint_id, path = endpoint_plus_path
+    endpoint_id, path = parse_endpoint_plus_path(
+        endpoint_plus_path, bookmark, path_required=False)
+
     if path is None and (not batch):
         raise click.UsageError(
             'delete requires either a PATH OR --batch')

--- a/globus_cli/commands/endpoint/permission/create.py
+++ b/globus_cli/commands/endpoint/permission/create.py
@@ -1,8 +1,8 @@
 import click
 
 from globus_cli.parsing import (
-    CaseInsensitiveChoice, common_options, ENDPOINT_PLUS_REQPATH,
-    security_principal_opts)
+    CaseInsensitiveChoice, common_options, security_principal_opts,
+    endpoint_plus_path_options, parse_endpoint_plus_path)
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RECORD
 
 from globus_cli.services.auth import maybe_lookup_identity_id
@@ -17,9 +17,8 @@ from globus_cli.services.transfer import get_client, assemble_generic_doc
 @click.option('--permissions', required=True,
               type=CaseInsensitiveChoice(('r', 'rw')),
               help='Permissions to add. Read-Only or Read/Write')
-@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_REQPATH.metavar,
-                type=ENDPOINT_PLUS_REQPATH)
-def create_command(principal, permissions, endpoint_plus_path):
+@endpoint_plus_path_options(path_required=True)
+def create_command(principal, permissions, endpoint_plus_path, bookmark):
     """
     Executor for `globus endpoint permission create`
     """
@@ -27,7 +26,8 @@ def create_command(principal, permissions, endpoint_plus_path):
         raise click.UsageError(
             'A security principal is required for this command')
 
-    endpoint_id, path = endpoint_plus_path
+    endpoint_id, path = parse_endpoint_plus_path(
+        endpoint_plus_path, bookmark, path_required=True)
     principal_type, principal_val = principal
 
     client = get_client()

--- a/globus_cli/commands/ls.py
+++ b/globus_cli/commands/ls.py
@@ -1,6 +1,7 @@
 import click
 
-from globus_cli.parsing import common_options, ENDPOINT_PLUS_OPTPATH
+from globus_cli.parsing import (
+    common_options, endpoint_plus_path_options, parse_endpoint_plus_path)
 from globus_cli.safeio import formatted_print
 from globus_cli.helpers import is_verbose
 from globus_cli.services.transfer import get_client, autoactivate
@@ -74,8 +75,7 @@ def _get_ls_res(client, path, endpoint_id, recursive, depth, show_hidden):
 @click.command('ls', help='List the contents of a directory on an endpoint',
                short_help='List endpoint directory contents')
 @common_options
-@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
-                type=ENDPOINT_PLUS_OPTPATH)
+@endpoint_plus_path_options(path_required=False)
 @click.option('--all', '-a', is_flag=True,
               help=('Show files and directories that start with `.`'))
 @click.option('--long', '-l', is_flag=True,
@@ -89,12 +89,13 @@ def _get_ls_res(client, path, endpoint_id, recursive, depth, show_hidden):
               help=('Limit to number of directories to traverse in '
                     '`--recursive` listings. A value of 0 indicates that '
                     'this should behave like a non-recursive `ls`'))
-def ls_command(endpoint_plus_path, recursive_depth_limit,
+def ls_command(endpoint_plus_path, bookmark, recursive_depth_limit,
                recursive, long, all):
     """
     Executor for `globus ls`
     """
-    endpoint_id, path = endpoint_plus_path
+    endpoint_id, path = parse_endpoint_plus_path(
+        endpoint_plus_path, bookmark, path_required=False)
 
     # do autoactivation before the `ls` call so that recursive invocations
     # won't do this repeatedly, and won't have to instantiate new clients

--- a/globus_cli/commands/mkdir.py
+++ b/globus_cli/commands/mkdir.py
@@ -1,6 +1,7 @@
 import click
 
-from globus_cli.parsing import common_options, ENDPOINT_PLUS_REQPATH
+from globus_cli.parsing import (
+    common_options, endpoint_plus_path_options, parse_endpoint_plus_path)
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RAW
 
 from globus_cli.services.transfer import get_client, autoactivate
@@ -8,13 +9,13 @@ from globus_cli.services.transfer import get_client, autoactivate
 
 @click.command('mkdir', help='Make a directory on an endpoint')
 @common_options
-@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_REQPATH.metavar,
-                type=ENDPOINT_PLUS_REQPATH)
-def mkdir_command(endpoint_plus_path):
+@endpoint_plus_path_options(path_required=True)
+def mkdir_command(endpoint_plus_path, bookmark):
     """
     Executor for `globus mkdir`
     """
-    endpoint_id, path = endpoint_plus_path
+    endpoint_id, path = parse_endpoint_plus_path(
+        endpoint_plus_path, bookmark, path_required=True)
 
     client = get_client()
     autoactivate(client, endpoint_id, if_expires_in=60)

--- a/globus_cli/commands/rename.py
+++ b/globus_cli/commands/rename.py
@@ -1,6 +1,8 @@
 import click
 
-from globus_cli.parsing import common_options, ENDPOINT_PLUS_REQPATH
+from globus_cli.parsing import (
+    common_options, endpoint_plus_path_options,
+    parse_source_and_dest_endpoint_plus_path)
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RAW
 
 from globus_cli.services.transfer import get_client, autoactivate
@@ -8,16 +10,17 @@ from globus_cli.services.transfer import get_client, autoactivate
 
 @click.command('rename', help='Rename a file or directory on an endpoint')
 @common_options
-@click.argument('source', metavar='ENDPOINT_ID:SOURCE_PATH',
-                type=ENDPOINT_PLUS_REQPATH)
-@click.argument('destination', metavar='ENDPOINT_ID:DEST_PATH',
-                type=ENDPOINT_PLUS_REQPATH)
-def rename_command(source, destination):
+@endpoint_plus_path_options(path_required=True, prefix="source")
+@endpoint_plus_path_options(path_required=True, prefix="destination")
+def rename_command(source_endpoint_plus_path, source_bookmark,
+                   destination_endpoint_plus_path, destination_bookmark):
     """
     Executor for `globus rename`
     """
-    source_ep, source_path = source
-    dest_ep, dest_path = destination
+    source_ep, source_path, dest_ep, dest_path = (
+        parse_source_and_dest_endpoint_plus_path(
+            source_endpoint_plus_path, source_bookmark,
+            destination_endpoint_plus_path, destination_bookmark))
 
     if source_ep != dest_ep:
         raise click.UsageError(('rename requires that the source and dest '

--- a/globus_cli/commands/transfer.py
+++ b/globus_cli/commands/transfer.py
@@ -4,7 +4,8 @@ from globus_sdk import TransferData
 
 from globus_cli.parsing import (
     CaseInsensitiveChoice, common_options, task_submission_options,
-    TaskPath, ENDPOINT_PLUS_OPTPATH, shlex_process_stdin)
+    TaskPath, shlex_process_stdin, endpoint_plus_path_options,
+    parse_source_and_dest_endpoint_plus_path)
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RECORD
 
 from globus_cli.services.transfer import get_client, autoactivate
@@ -88,18 +89,20 @@ from globus_cli.services.transfer import get_client, autoactivate
                     'Uses SOURCE_ENDPOINT_ID and DEST_ENDPOINT_ID as passed '
                     'on the commandline. Commandline paths are still allowed '
                     'and are used as prefixes to the batchmode inputs.'))
-@click.argument('source', metavar='SOURCE_ENDPOINT_ID[:SOURCE_PATH]',
-                type=ENDPOINT_PLUS_OPTPATH)
-@click.argument('destination', metavar='DEST_ENDPOINT_ID[:DEST_PATH]',
-                type=ENDPOINT_PLUS_OPTPATH)
-def transfer_command(batch, sync_level, recursive, destination, source, label,
+@endpoint_plus_path_options(path_required=False, prefix="source")
+@endpoint_plus_path_options(path_required=False, prefix="destination")
+def transfer_command(batch, sync_level, recursive, label,
+                     source_endpoint_plus_path, source_bookmark,
+                     destination_endpoint_plus_path, destination_bookmark,
                      preserve_mtime, verify_checksum, encrypt, submission_id,
                      dry_run, delete, deadline):
     """
     Executor for `globus transfer`
     """
-    source_endpoint, cmd_source_path = source
-    dest_endpoint, cmd_dest_path = destination
+    source_endpoint, cmd_source_path, dest_endpoint, cmd_dest_path = (
+        parse_source_and_dest_endpoint_plus_path(
+            source_endpoint_plus_path, source_bookmark,
+            destination_endpoint_plus_path, destination_bookmark))
 
     if recursive and batch:
         raise click.UsageError(

--- a/globus_cli/helpers/__init__.py
+++ b/globus_cli/helpers/__init__.py
@@ -4,6 +4,7 @@ from globus_cli.helpers.options import (
 from globus_cli.helpers.version import print_version
 from globus_cli.helpers.local_server import (
     start_local_server, is_remote_session, LocalServerError)
+from globus_cli.helpers.resolve_bookmark import resolve_bookmark_id_or_name
 from globus_cli.helpers.delegate_proxy import (
     fill_delegate_proxy_activation_requirements)
 
@@ -15,6 +16,7 @@ __all__ = [
     'get_jmespath_expression',
 
     "verbosity", "is_verbose",
+    "resolve_bookmark_id_or_name",
 
     'start_local_server', 'is_remote_session', 'LocalServerError',
 

--- a/globus_cli/helpers/resolve_bookmark.py
+++ b/globus_cli/helpers/resolve_bookmark.py
@@ -2,14 +2,15 @@ from uuid import UUID
 
 import click
 from globus_sdk.exc import TransferAPIError
-
+from globus_cli.services.transfer import get_client
 from globus_cli.safeio import safeprint
 
 
-def resolve_id_or_name(client, bookmark_id_or_name):
+def resolve_bookmark_id_or_name(bookmark_id_or_name):
     # leading/trailing whitespace doesn't make sense for UUIDs and the Transfer
     # service outright forbids it for bookmark names, so we can strip it off
     bookmark_id_or_name = bookmark_id_or_name.strip()
+    client = get_client()
 
     res = None
     try:

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -14,7 +14,9 @@ from globus_cli.parsing.shared_options import (
     endpoint_create_and_update_params,
     validate_endpoint_create_and_update_params,
     role_id_arg, server_id_arg, server_add_and_update_opts,
-    security_principal_opts)
+    security_principal_opts,
+    endpoint_plus_path_options, parse_endpoint_plus_path,
+    parse_source_and_dest_endpoint_plus_path)
 
 from globus_cli.parsing.process_stdin import shlex_process_stdin
 
@@ -37,6 +39,8 @@ __all__ = [
     'validate_endpoint_create_and_update_params',
     'role_id_arg', 'server_id_arg', 'server_add_and_update_opts',
     'security_principal_opts',
+    'endpoint_plus_path_options', 'parse_endpoint_plus_path',
+    'parse_source_and_dest_endpoint_plus_path',
 
     'shlex_process_stdin',
 ]

--- a/globus_cli/parsing/endpoint_plus_path.py
+++ b/globus_cli/parsing/endpoint_plus_path.py
@@ -13,6 +13,7 @@ class EndpointPlusPath(click.ParamType):
     def __init__(self, *args, **kwargs):
         # path requirement defaults to True, but can be tweaked by a kwarg
         self.path_required = kwargs.pop('path_required', True)
+        self.prefix = kwargs.pop("prefix", "")
 
         super(EndpointPlusPath, self).__init__(*args, **kwargs)
 
@@ -31,9 +32,9 @@ class EndpointPlusPath(click.ParamType):
         https://github.com/pallets/click/issues/674
         """
         if self.path_required:
-            return "ENDPOINT_ID:PATH"
+            return "{}ENDPOINT_ID:{}PATH".format(self.prefix, self.prefix)
         else:
-            return "ENDPOINT_ID[:PATH]"
+            return "{}ENDPOINT_ID[:{}PATH]".format(self.prefix, self.prefix)
 
     def convert(self, value, param, ctx):
         """


### PR DESCRIPTION
First pass at resolving #105 with explicit options.

If we decide we prefer the "^Bookmark Name" syntax feel free to ignore this PR, this is more of a proof of concept at the moment. Either method will require documentation in the adoc files before merging.

Example Usage:

`globus ls -b "Bookmark Name:relative/path/"`
`globus transfer -r --source-bookmark "Bookmark1 Name" --destination-bookmark "Bookmark2 Name"`

I felt short options were justified here since the point of bookmarks is to take shortcuts and typing `--destination-bookmark` uses almost as many characters as typing `$(globus bookmark show)`

I allowed for an optional `[:PATH]` to the bookmark id or name. As noted in the issue discussion, this will prevent bookmarks with literal `:` in their names from being resolved by name with these options, but I feel the ability to add relative paths to a bookmark is useful, and a user can still pass the bookmark by id or do an explicit `$(globus bookmark show)` to get the endpoint plus path. If this trade-off is not worth it, it can easily be removed.