### PR TITLE
whoami use userinfo and add --linked-identities option

### DIFF
--- a/adoc/whoami.1.adoc
+++ b/adoc/whoami.1.adoc
@@ -10,14 +10,16 @@ globus whoami - Show the currently logged-in identity.
 
 == DESCRIPTION
 
-The *globus whoami* command will display information for the currently logged
-in user.
-
-The default output is just the username, but if --verbose is given
-Name, ID and email are displayed as well.
+The *globus whoami* command will display information for the currently
+logged-in user.
 
 
 == OPTIONS
+
+*--linked-identities* ::
+
+Show the full identity set of the currently logged in identity, which contains
+the primary identity and any identities linked to it.
 
 include::include/format_option.adoc[]
 
@@ -25,12 +27,36 @@ include::include/help_option.adoc[]
 
 include::include/verbose_option.adoc[]
 
+
+== OUTPUT
+
+If no options are given the default output is just the preferred
+username of the logged in identity.
+
+If *--linked-identities* is given the output will be each username in the
+logged-in user's identity set.
+
+If *--verbose* is given, the following fields will be output, either in
+a record format or a table format if *--linked-identities* is also given.
+
+- 'Username'
+- 'Name'
+- 'ID'
+- 'Email'
+
+
 == EXAMPLES
 
 Display multiple fields of the current user's information:
 
 ----
 $ globus whoami -v
+----
+
+Display each username in the current user's identity set:
+
+----
+$ globus whoami --linked-identities
 ----
 
 include::include/exit_status_no_http.adoc[]

--- a/globus_cli/commands/whoami.py
+++ b/globus_cli/commands/whoami.py
@@ -1,35 +1,53 @@
 import click
 
-from globus_cli.safeio import (
-    safeprint, formatted_print, FORMAT_TEXT_RECORD, FORMAT_TEXT_RAW)
+from globus_sdk.exc import AuthAPIError
+
+from globus_cli.safeio import safeprint, formatted_print, FORMAT_TEXT_RECORD
 from globus_cli.parsing import common_options
 from globus_cli.helpers import is_verbose
-from globus_cli.config import (
-    WHOAMI_ID_OPTNAME, WHOAMI_USERNAME_OPTNAME,
-    WHOAMI_EMAIL_OPTNAME, WHOAMI_NAME_OPTNAME,
-    lookup_option)
+from globus_cli.services.auth import get_auth_client
 
 
 @click.command('whoami',
                help=('Show the currently logged-in identity.'))
 @common_options(no_map_http_status_option=True)
-def whoami_command():
+@click.option("--linked-identities", is_flag=True,
+              help=("Also show identities linked to the currently logged-in "
+                    "identity."))
+def whoami_command(linked_identities):
     """
     Executor for `globus whoami`
     """
+    client = get_auth_client()
 
-    username = lookup_option(WHOAMI_USERNAME_OPTNAME)
-    if not username:
-        safeprint('No login information available. Please try '
+    # get userinfo from auth.
+    # if we get back an error the user likely needs to log in again
+    try:
+        res = client.oauth2_userinfo()
+    except AuthAPIError:
+        safeprint('Unable to get user information. Please try '
                   'logging in again.', write_to_stderr=True)
         click.get_current_context().exit(1)
 
-    fields = tuple((x, x) for x in ('Username', 'Name', 'ID', 'Email'))
-    formatted_print({
-            'Username': username,
-            'Name': lookup_option(WHOAMI_NAME_OPTNAME),
-            'ID': lookup_option(WHOAMI_ID_OPTNAME),
-            'Email': lookup_option(WHOAMI_EMAIL_OPTNAME)
-        }, fields=fields,
-        text_format=(FORMAT_TEXT_RECORD if is_verbose() else FORMAT_TEXT_RAW),
-        response_key=None if is_verbose() else 'Username')
+    # --linked-identities either displays all usernames or a table if verbose
+    if linked_identities:
+        try:
+            formatted_print(
+                res["identity_set"],
+                fields=[("Username", "username"), ("Name", "name"),
+                        ("ID", "sub"), ("Email", "email")],
+                simple_text=(None if is_verbose() else "\n".join(
+                    [x["username"] for x in res["identity_set"]])))
+        except KeyError:
+            safeprint("Your current login does not have the consents required "
+                      "to view your full identity set. Please log in again "
+                      "to agree to the required consents.",
+                      write_to_stderr=True)
+
+    # Default output is the top level data
+    else:
+        formatted_print(
+            res, text_format=FORMAT_TEXT_RECORD,
+            fields=[("Username", "preferred_username"), ("Name", "name"),
+                    ("ID", "sub"), ("Email", "email")],
+            simple_text=(None if is_verbose() else res["preferred_username"]))

--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -77,7 +77,15 @@ def get_config_obj(system=False, file_error=False):
     else:
         path = os.path.expanduser("~/.globus.cfg")
 
-    return ConfigObj(path, encoding='utf-8', file_error=file_error)
+    conf = ConfigObj(path, encoding='utf-8', file_error=file_error)
+
+    # delete any old whomai values in the cli section
+    for key in conf.get("cli", {}):
+        if "whoami_identity_" in key:
+            del conf["cli"][key]
+            conf.write()
+
+    return conf
 
 
 def lookup_option(option, section='cli', environment=None):

--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -16,10 +16,6 @@ __all__ = [
     'TRANSFER_RT_OPTNAME',
     'TRANSFER_AT_OPTNAME',
     'AUTH_AT_EXPIRES_OPTNAME',
-    'WHOAMI_ID_OPTNAME',
-    'WHOAMI_USERNAME_OPTNAME',
-    'WHOAMI_EMAIL_OPTNAME',
-    'WHOAMI_NAME_OPTNAME',
 
     'GLOBUS_ENV',
 
@@ -50,10 +46,6 @@ AUTH_AT_EXPIRES_OPTNAME = 'auth_access_token_expires'
 TRANSFER_RT_OPTNAME = 'transfer_refresh_token'
 TRANSFER_AT_OPTNAME = 'transfer_access_token'
 TRANSFER_AT_EXPIRES_OPTNAME = 'transfer_access_token_expires'
-WHOAMI_ID_OPTNAME = 'whoami_identity_id'
-WHOAMI_USERNAME_OPTNAME = 'whoami_identity_username'
-WHOAMI_EMAIL_OPTNAME = 'whoami_identity_email'
-WHOAMI_NAME_OPTNAME = 'whoami_identity_display_name'
 
 # get the environment from env var (not exported)
 GLOBUS_ENV = os.environ.get('GLOBUS_SDK_ENVIRONMENT')
@@ -69,10 +61,6 @@ if GLOBUS_ENV:
     TRANSFER_AT_OPTNAME = '{0}_transfer_access_token'.format(GLOBUS_ENV)
     TRANSFER_AT_EXPIRES_OPTNAME = '{0}_transfer_access_token_expires'.format(
         GLOBUS_ENV)
-    WHOAMI_ID_OPTNAME = '{0}_whoami_identity_id'.format(GLOBUS_ENV)
-    WHOAMI_USERNAME_OPTNAME = '{0}_whoami_identity_username'.format(GLOBUS_ENV)
-    WHOAMI_EMAIL_OPTNAME = '{0}_whoami_identity_email'.format(GLOBUS_ENV)
-    WHOAMI_NAME_OPTNAME = '{0}_whoami_identity_display_name'.format(GLOBUS_ENV)
 
     CLIENT_ID = {
         'sandbox':      '33b6a241-bce4-4359-9c6d-09f88b3c9eef',

--- a/tests/framework/cli_testcase.py
+++ b/tests/framework/cli_testcase.py
@@ -14,15 +14,12 @@ import globus_sdk
 from globus_cli import main
 from globus_cli.config import (
     AUTH_RT_OPTNAME, AUTH_AT_OPTNAME, AUTH_AT_EXPIRES_OPTNAME,
-    TRANSFER_RT_OPTNAME, TRANSFER_AT_OPTNAME, TRANSFER_AT_EXPIRES_OPTNAME,
-    WHOAMI_ID_OPTNAME, WHOAMI_USERNAME_OPTNAME, WHOAMI_NAME_OPTNAME,
-    WHOAMI_EMAIL_OPTNAME)
+    TRANSFER_RT_OPTNAME, TRANSFER_AT_OPTNAME, TRANSFER_AT_EXPIRES_OPTNAME)
 from globus_cli.services.transfer import get_client
 from globus_cli.services.auth import get_auth_client
 
 from tests.framework.constants import (CLITESTER1A_TRANSFER_RT,
                                        CLITESTER1A_AUTH_RT, GO_EP1_ID)
-from tests.framework.tools import get_user_data
 
 
 def clean_sharing():
@@ -53,11 +50,9 @@ def clean_sharing():
 
 def default_test_config(*args, **kwargs):
     """
-    Returns a ConfigObj with the clitester's refresh tokens and whoami info
-    as if the clitester was logged in and a call to get_config_obj was made.
+    Returns a ConfigObj with the clitester's refresh tokens as if the
+    clitester was logged in and a call to get_config_obj was made.
     """
-    user_data = get_user_data()["clitester1a"]
-
     # create a ConfgObj from a dict of testing constants. a ConfigObj created
     # this way will not be tied to a config file on disk, meaning that
     # ConfigObj.filename = None and ConfigObj.write() returns a string without
@@ -69,10 +64,6 @@ def default_test_config(*args, **kwargs):
         TRANSFER_RT_OPTNAME: CLITESTER1A_TRANSFER_RT,
         TRANSFER_AT_OPTNAME: "",
         TRANSFER_AT_EXPIRES_OPTNAME: 0,
-        WHOAMI_ID_OPTNAME: user_data["id"],
-        WHOAMI_USERNAME_OPTNAME: user_data["username"],
-        WHOAMI_NAME_OPTNAME: user_data["name"],
-        WHOAMI_EMAIL_OPTNAME: user_data["email"]
         }
     })
 

--- a/tests/framework/constants.py
+++ b/tests/framework/constants.py
@@ -5,11 +5,11 @@ GO_EP2_ID = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
 # tokens #
 # ------ #
 CLITESTER1A_TRANSFER_RT = (
-    "AQEAAAAAAASZW7VXUe_Yn-Fzlt-0tMbrezfW4lIEO-"
-    "jqobxmWGVTogIrUsMJ5MRUwW5WOWUULm5KXoOfGuis")
+    "Agjx3GdEMnMjOBEl51pw9yVq87V8NKk5jvVzNjaxx00mJyl"
+    "ak3IKUE2xeEP29k45Dx849yKzD8EJjJDJ9X5qwyol6GnQw")
 CLITESTER1A_AUTH_RT = (
-    "AQEAAAAAAASZXLSQqrP1hf0RKXr3JchDxVCUgDP-bV"
-    "8fz_A8WcrEbgCIJFSoXPPhjyHo008AktwOCSM1jpT0")
+    "AgjoXqonapykQdQ2M8gjB5JkOVxKqnznoGpyBoGE5raW1dk"
+    "XKnUKUb9PwyaV3XY339xlxDd9q2q2NvoQVEJ79JJpg4M8j")
 # ---------- #
 # end tokens #
 # ---------- #

--- a/tests/framework/files/clitester1alinked@globusid.org.json
+++ b/tests/framework/files/clitester1alinked@globusid.org.json
@@ -1,0 +1,8 @@
+{
+  "username": "clitester1a@globusid.org",
+  "name": "CLI Tester",
+  "email": "aaschaer+clitester1alinked@globus.org",
+  "id": "e5ff2835-9eed-4221-a6b6-708fefe3f17a",
+  "identity_provider": "41143743-f3c8-4d60-bbdb-eeecaba85bd9",
+  "organization": "Globus"
+}

--- a/tests/framework/tools.py
+++ b/tests/framework/tools.py
@@ -14,7 +14,7 @@ def get_file_dir():
 def get_user_data():
     dirname = get_file_dir()
     ret = {}
-    for uname in ("clitester1a", "go"):
+    for uname in ("clitester1a", "clitester1alinked", "go"):
         with open(os.path.join(dirname,
                                uname + "@globusid.org.json")) as f:
             ret[uname] = json.load(f)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -59,15 +59,15 @@ class BasicTests(CliTestCase):
         Runs whoami with config set to be empty, confirms no login seen.
         """
         output = self.run_line("globus whoami", config={}, assert_exit_code=1)
-        self.assertIn("No login information available", output)
+        self.assertIn("Unable to get user information", output)
 
     def test_json_raw_string_output(self):
         """
         Get single-field jmespath output and make sure it's quoted
         """
-        output = self.run_line("globus whoami --jmespath Username").strip()
+        output = self.run_line("globus whoami --jmespath name").strip()
         self.assertEquals(
-            '"{}"'.format(get_user_data()["clitester1a"]["username"]), output)
+            '"{}"'.format(get_user_data()["clitester1a"]["name"]), output)
 
     def test_auth_call_no_auth(self):
         """

--- a/tests/unit/test_whoami.py
+++ b/tests/unit/test_whoami.py
@@ -1,0 +1,37 @@
+from tests.framework.cli_testcase import CliTestCase
+from tests.framework.tools import get_user_data
+
+
+class WhoamiTests(CliTestCase):
+
+    # basic whoami functionality tested in test_basics.py
+
+    def test_verbose(self):
+        """
+        Confirms --verbose includes Name, Email, and ID fields.
+        """
+        output = self.run_line("globus whoami --verbose")
+        for field in ["Username", "Name", "Email", "ID"]:
+            self.assertIn(field, output)
+        for field in ["username", "name", "email", "id"]:
+            self.assertIn(get_user_data()["clitester1a"][field], output)
+
+    def test_linked_identities(self):
+        """
+        Confirms --linked-identities sees cliester1a-linked#globusid.org
+        """
+        output = self.run_line("globus whoami --linked-identities")
+        self.assertIn(get_user_data()["clitester1a"]["username"], output)
+        self.assertIn(get_user_data()["clitester1alinked"]["username"], output)
+
+    def test_verbose_linked_identities(self):
+        """
+        Confirms combining --verbose and --linked-identities has expected
+        values present for the whole identity set.
+        """
+        output = self.run_line("globus whoami --linked-identities -v")
+        for field in ["Username", "Name", "Email", "ID"]:
+            self.assertIn(field, output)
+        for field in ["username", "name", "email", "id"]:
+            self.assertIn(get_user_data()["clitester1a"][field], output)
+            self.assertIn(get_user_data()["clitester1alinked"][field], output)


### PR DESCRIPTION
Resolves #115

Probably shouldn't be merged until globus/globus-sdk-python/issues/202 is resolved and the view_identity_set scope is publicly documented, but any changes in the SDK will need to preserve access to the top level fields, so this should continue to work even if a more pythonic way of getting the identity_set is added.