### PR TITLE
Improve autoactivation failure messages

### DIFF
--- a/globus_cli/commands/endpoint/activate.py
+++ b/globus_cli/commands/endpoint/activate.py
@@ -13,9 +13,11 @@ except ImportError:
 from globus_cli.parsing import common_options, endpoint_id_arg, HiddenOption
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RAW
 from globus_cli.config import lookup_option, MYPROXY_USERNAME_OPTNAME
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import (
+    get_client, activation_requirements_help_text)
 from globus_cli.helpers import (
     is_remote_session, fill_delegate_proxy_activation_requirements)
+
 
 delegate_proxy_long_help = """
     \b
@@ -148,8 +150,9 @@ def endpoint_activate(endpoint_id, myproxy, myproxy_username, myproxy_password,
 
         # override potentially confusing autoactivation failure response
         else:
-            res = {"message": ("Auto-activation failed, please "
-                               "use another activation method")}
+            message = ("The endpoint could not be auto-activated.\n\n" +
+                       activation_requirements_help_text(res, endpoint_id))
+            res = {"message": message}
 
     # myproxy activation
     if myproxy:

--- a/globus_cli/services/transfer.py
+++ b/globus_cli/services/transfer.py
@@ -4,11 +4,11 @@ import time
 import click
 
 try:
-    import M2Crypto
+    import cryptography
     # slightly hacky way of preventing flake8 from complaining
-    m2crypto_imported = bool(M2Crypto)
+    cryptography_imported = bool(cryptography)
 except ImportError:
-    m2crypto_imported = False
+    cryptography_imported = False
 
 from globus_sdk import TransferClient, RefreshTokenAuthorizer
 from globus_sdk.exc import NetworkError
@@ -158,12 +158,12 @@ def activation_requirements_help_text(res, ep_id):
         ("For delegate proxy activation use:\n"
          "'globus endpoint activate --delegate-proxy "
          "X.509_PEM_FILE {}'\n".format(ep_id)
-         if "delegate_proxy" in methods and m2crypto_imported else ""),
+         if "delegate_proxy" in methods and cryptography_imported else ""),
 
         ("Delegate proxy activation requires an additional dependency on "
-         "M2Crypto. See the docs for details:\n"
+         "cryptography. See the docs for details:\n"
          "https://docs.globus.org/cli/reference/endpoint_activate/\n"
-         if "delegate_proxy" in methods and not m2crypto_imported else ""),
+         if "delegate_proxy" in methods and not cryptography_imported else ""),
     ]
 
     return "".join(lines)

--- a/globus_cli/services/transfer.py
+++ b/globus_cli/services/transfer.py
@@ -1,11 +1,20 @@
 import uuid
 import random
 import time
+import click
+
+try:
+    import M2Crypto
+    # slightly hacky way of preventing flake8 from complaining
+    m2crypto_imported = bool(M2Crypto)
+except ImportError:
+    m2crypto_imported = False
 
 from globus_sdk import TransferClient, RefreshTokenAuthorizer
 from globus_sdk.exc import NetworkError
 
 from globus_cli import version
+from globus_cli.safeio import safeprint
 from globus_cli.config import (
     get_transfer_tokens, internal_auth_client, set_transfer_access_token)
 
@@ -98,12 +107,91 @@ def assemble_generic_doc(datatype, **kwargs):
     return doc
 
 
+def supported_activation_methods(res):
+    """
+    Given an activation_requirements document
+    returns a list of activation methods supported by this endpoint.
+    """
+    supported = ["web"]  # web activation is always supported.
+
+    # oauth
+    if res["oauth_server"]:
+        supported.append("oauth")
+
+    for req in res["DATA"]:
+        # myproxy
+        if (req["type"] == "myproxy" and req["name"] == "hostname" and
+                req["value"] != "myproxy.globusonline.org"):
+            supported.append("myproxy")
+
+        # delegate_proxy
+        if req["type"] == "delegate_proxy" and req["name"] == "public_key":
+            supported.append("delegate_proxy")
+
+    return supported
+
+
+def activation_requirements_help_text(res, ep_id):
+    """
+    Given an activation requirements document and an endpoint_id
+    returns a string of help text for how to activate the endpoint
+    """
+    methods = supported_activation_methods(res)
+
+    lines = [
+        "This endpoint supports the following activation methods: ",
+        ", ".join(methods).replace("_", " "),
+        "\n",
+
+        ("For web activation use:\n"
+         "'globus endpoint activate --web {}'\n".format(ep_id)
+         if "web" in methods else ""),
+
+        ("For myproxy activation use:\n"
+         "'globus endpoint activate --myproxy {}'\n".format(ep_id)
+         if "myproxy" in methods else ""),
+
+        ("For oauth activation use web activation:\n"
+         "'globus endpoint activate --web {}'\n".format(ep_id)
+         if "oauth" in methods else ""),
+
+        ("For delegate proxy activation use:\n"
+         "'globus endpoint activate --delegate-proxy "
+         "X.509_PEM_FILE {}'\n".format(ep_id)
+         if "delegate_proxy" in methods and m2crypto_imported else ""),
+
+        ("Delegate proxy activation requires an additional dependency on "
+         "M2Crypto. See the docs for details:\n"
+         "https://docs.globus.org/cli/reference/endpoint_activate/\n"
+         if "delegate_proxy" in methods and not m2crypto_imported else ""),
+    ]
+
+    return "".join(lines)
+
+
 def autoactivate(client, endpoint_id, if_expires_in=None):
+    """
+    Attempts to auto-activate the given endpoint with the given client
+    If auto-activation fails, parses the returned activation requirements
+    to determine which methods of activation are supported, then tells
+    the user to use 'globus endpoint activate' with the correct options(s)
+    """
     kwargs = {}
     if if_expires_in is not None:
         kwargs['if_expires_in'] = if_expires_in
 
-    return client.endpoint_autoactivate(endpoint_id, **kwargs)
+    res = client.endpoint_autoactivate(endpoint_id, **kwargs)
+    if res["code"] == "AutoActivationFailed":
+
+        message = ("The endpoint could not be auto-activated and must be "
+                   "activated before it can be used.\n\n" +
+                   activation_requirements_help_text(res, endpoint_id))
+
+        safeprint(message, write_to_stderr=True)
+        click.get_current_context().exit(1)
+
+    else:
+        return res
 
 
 ENDPOINT_LIST_FIELDS = (('ID', 'id'), ('Owner', 'owner_string'),


### PR DESCRIPTION
Resolves #30 and improves the autoactivation failure messages in endpoint activate and is-activated as well.

As the issue says it might be nice if some of the activation_requirements parsing were done in the SDK, but it seemed reasonable enough to do it in the CLI for now.

I didn't write any automated tests for these without a stable endpoint that doesn't accept auto-activation to test against, but manual testing against my own GCS endpoint worked fine.
