### PR TITLE
Add OneUseOption and decorator

### DIFF
--- a/globus_cli/commands/endpoint/create.py
+++ b/globus_cli/commands/endpoint/create.py
@@ -1,7 +1,7 @@
 import click
 
 from globus_cli.parsing import (
-    common_options, endpoint_create_and_update_params,
+    common_options, endpoint_create_and_update_params, one_use_option,
     validate_endpoint_create_and_update_params, ENDPOINT_PLUS_REQPATH)
 from globus_cli.services.transfer import (
     autoactivate, get_client, assemble_generic_doc)
@@ -25,17 +25,17 @@ GCP_FIELDS = [
           "Personal, Globus Connect Server, or shared endpoint respectively."))
 @common_options
 @endpoint_create_and_update_params(create=True)
-@click.option("--personal", is_flag=True,
-              help=("Create a Globus Connect Personal endpoint. "
-                    "Mutually exclusive with --server and --shared. "))
-@click.option("--server", is_flag=True,
-              help=("Create a Globus Connect Server endpoint. "
-                    "Mutually exclusive with --personal and --shared."))
-@click.option("--shared", default=None, type=ENDPOINT_PLUS_REQPATH,
-              metavar=ENDPOINT_PLUS_REQPATH.metavar,
-              help=("Create a shared endpoint hosted on the given endpoint "
-                    "and path. Mutually exclusive with --personal and "
-                    "--server."))
+@one_use_option("--personal", is_flag=True,
+                help=("Create a Globus Connect Personal endpoint. "
+                      "Mutually exclusive with --server and --shared. "))
+@one_use_option("--server", is_flag=True,
+                help=("Create a Globus Connect Server endpoint. "
+                      "Mutually exclusive with --personal and --shared."))
+@one_use_option("--shared", default=None, type=ENDPOINT_PLUS_REQPATH,
+                metavar=ENDPOINT_PLUS_REQPATH.metavar,
+                help=("Create a shared endpoint hosted on the given endpoint "
+                      "and path. Mutually exclusive with --personal and "
+                      "--server."))
 def endpoint_create(**kwargs):
     """
     Executor for `globus endpoint create`

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -18,6 +18,8 @@ from globus_cli.parsing.shared_options import (
 
 from globus_cli.parsing.process_stdin import shlex_process_stdin
 
+from globus_cli.parsing.one_use_option import one_use_option
+
 
 __all__ = [
     'globus_group',
@@ -26,6 +28,8 @@ __all__ = [
     'CaseInsensitiveChoice',
     'ENDPOINT_PLUS_OPTPATH', 'ENDPOINT_PLUS_REQPATH',
     'TaskPath',
+
+    'one_use_option',
 
     'HiddenOption',
     'ISOTimeType',

--- a/globus_cli/parsing/one_use_option.py
+++ b/globus_cli/parsing/one_use_option.py
@@ -1,0 +1,73 @@
+import click
+
+
+class OneUseOption(click.Option):
+    """
+    Overwrites the type_cast_value function inherited from click.Parameter
+    to assert an option was only used once, and then converts it back
+    to the original value type.
+    """
+
+    def type_cast_value(self, ctx, value):
+
+        # get the result of a normal type_cast
+        converted_val = super(OneUseOption, self).type_cast_value(ctx, value)
+
+        # if the option takes arguments (multiple was set to true)
+        # assert no more than one argument was gotten, and if an argument
+        # was gotten, take it out of the tuple and return it
+        if self.multiple:
+            if len(converted_val) > 1:
+                raise click.BadParameter(
+                    "Option used multiple times.", ctx=ctx)
+            if len(converted_val):
+                return converted_val[0]
+            else:
+                return None
+
+        # if the option was a flag (converted to a count) assert that the flag
+        # count is no more than one, and type cast back to a bool
+        elif self.count:
+            if converted_val > 1:
+                raise click.BadParameter(
+                    "Option used multiple times.", ctx=ctx)
+            return bool(converted_val)
+
+        else:
+            raise ValueError(("Internal error, OneUseOption expected either "
+                              "multiple or count, but got neither."))
+
+
+def one_use_option(*args, **kwargs):
+    """
+    Wrapper of the click.option decorator that replaces any instances of
+    the Option class with the custom OneUseOption class
+    """
+    # cannot force a multiple or count option to be single use
+    if "multiple" in kwargs or "count" in kwargs:
+        raise ValueError("Internal error, one_use_option cannot be  used "
+                         "with multiple or count.")
+
+    # cannot force a non Option Paramater (argument) to be a OneUseOption
+    if kwargs.get("cls"):
+        raise TypeError("Internal error, one_use_option cannot overwrite "
+                        "cls {}.".format(kwargs.get("cls")))
+
+    # use our OneUseOption class instead of a normal Option
+    kwargs["cls"] = OneUseOption
+
+    # if dealing with a flag, switch to a counting option,
+    # and then assert if the count is not greater than 1 and cast to a bool
+    if kwargs.get("is_flag"):
+        kwargs["is_flag"] = False  # mutually exclusive with count
+        kwargs["count"] = True
+
+    # if not a flag, this option takes an argument(s), switch to a multiple
+    # option, assert the len is 1, and treat the first element as the value
+    else:
+        kwargs["multiple"] = True
+
+    # decorate with the click.option decorator, but with our custom kwargs
+    def decorator(f):
+        return click.option(*args, **kwargs)(f)
+    return decorator

--- a/tests/unit/test_one_use_option.py
+++ b/tests/unit/test_one_use_option.py
@@ -1,0 +1,30 @@
+from tests.framework.cli_testcase import CliTestCase
+from tests.framework.constants import GO_EP1_ID
+
+
+class OneUseOption(CliTestCase):
+
+    def test_multiple_argument_options(self):
+        """
+        Runs endpoint create with two --shared options
+        Confirms exit code is 2 after click.BadParamater is raised
+        """
+        output = self.run_line((
+            "globus endpoint create ep_name "
+            "--shared {0}:/ --shared {0}:/".format(GO_EP1_ID)),
+            assert_exit_code=2)
+
+        self.assertIn('Invalid value for "--shared"', output)
+        self.assertIn("Option used multiple times.", output)
+
+    def test_multiple_flag_options(self):
+        """
+        Runs endpoint create with two --personal options
+        Confirms exit code is 2 after click.BadParamater is raised
+        """
+        output = self.run_line(
+            "globus endpoint create ep_name --personal --personal",
+            assert_exit_code=2)
+
+        self.assertIn('Invalid value for "--personal"', output)
+        self.assertIn("Option used multiple times.", output)


### PR DESCRIPTION
Resolves #33 and adds a decorator for easy substitution of existing click.option decorators.

I feel like most of the options this issue was created for are now arguments, but the endpoint create options seemed like a reasonable enough use case for trying this out. If desired I can go add this to any options that probably shouldn't be used more than once.

