### PR TITLE
Improve missing / invalid token error handling

### DIFF
--- a/globus_cli/parsing/excepthook.py
+++ b/globus_cli/parsing/excepthook.py
@@ -73,6 +73,17 @@ def authentication_hook(exception):
     exit_with_mapped_status(exception.http_status)
 
 
+def invalidrefresh_hook(exception):
+    write_error_info(
+        "Invalid Refresh Token",
+        [PrintableErrorField("HTTP status", exception.http_status),
+         PrintableErrorField("code", exception.code),
+         PrintableErrorField("message", exception.message, multiline=True)],
+        message=("Globus CLI Error: Your credentials are no longer "
+                 "valid. Please log in again with 'globus login'."))
+    exit_with_mapped_status(exception.http_status)
+
+
 def globus_generic_hook(exception):
     write_error_info(
         'Globus Error',
@@ -123,6 +134,9 @@ def custom_except_hook(exc_info):
         elif isinstance(exception, exc.AuthAPIError):
             if exception.code == "UNAUTHORIZED":
                 authentication_hook(exception)
+            # invalid_grant occurs when the users refresh tokens are not valid
+            elif exception.message == "invalid_grant":
+                invalidrefresh_hook(exception)
             else:
                 authapi_hook(exception)
 

--- a/globus_cli/parsing/excepthook.py
+++ b/globus_cli/parsing/excepthook.py
@@ -44,12 +44,32 @@ def transferapi_hook(exception):
     exit_with_mapped_status(exception.http_status)
 
 
+def authapi_hook(exception):
+    write_error_info(
+        'Auth API Error',
+        [PrintableErrorField('HTTP status', exception.http_status),
+         PrintableErrorField('code', exception.code),
+         PrintableErrorField('message', exception.message, multiline=True)])
+    exit_with_mapped_status(exception.http_status)
+
+
 def globusapi_hook(exception):
     write_error_info(
         'GLobus API Error',
         [PrintableErrorField('HTTP status', exception.http_status),
          PrintableErrorField('code', exception.code),
          PrintableErrorField('message', exception.message, multiline=True)])
+    exit_with_mapped_status(exception.http_status)
+
+
+def authentication_hook(exception):
+    write_error_info(
+        "No Authentication Error",
+        [PrintableErrorField("HTTP status", exception.http_status),
+         PrintableErrorField("code", exception.code),
+         PrintableErrorField("message", exception.message, multiline=True)],
+        message=("Globus CLI Error: No Authentication provided. Make sure "
+                 "you have logged in with 'globus login'."))
     exit_with_mapped_status(exception.http_status)
 
 
@@ -94,9 +114,19 @@ def custom_except_hook(exc_info):
 
         # handle the Globus-raised errors with our special hooks
         # these will present the output (on stderr) as JSON
-        elif exception_type is exc.TransferAPIError:
-            transferapi_hook(exception)
-        elif exception_type is exc.GlobusAPIError:
+        elif isinstance(exception, exc.TransferAPIError):
+            if exception.code == "ClientError.AuthenticationFailed":
+                authentication_hook(exception)
+            else:
+                transferapi_hook(exception)
+
+        elif isinstance(exception, exc.AuthAPIError):
+            if exception.code == "UNAUTHORIZED":
+                authentication_hook(exception)
+            else:
+                authapi_hook(exception)
+
+        elif isinstance(exception, exc.GlobusAPIError):
             globusapi_hook(exception)
 
         # specific checks fell through -- now check if it's any kind of

--- a/globus_cli/safeio/errors.py
+++ b/globus_cli/safeio/errors.py
@@ -35,8 +35,7 @@ class PrintableErrorField(object):
                 name, spacer, spacer.join(self.value.split('\n')))
 
 
-def write_error_info(error_name, fields):
-    message = None
+def write_error_info(error_name, fields, message=None):
     if outformat_is_json():
         # dictify joined tuple lists and dump to json string
         message = json.dumps(
@@ -44,8 +43,10 @@ def write_error_info(error_name, fields):
                 [('error_name', error_name)] +
                 [(f.name, f.value) for f in fields]),
             indent=2)
-    else:
-        message = 'A {0} Occurred.\n{1}'.format(
+
+    if not message:
+        message = 'A{0} {1} Occurred.\n{2}'.format(
+            "n" if error_name[0] in "aeiouAEIOU" else "",
             error_name, '\n'.join(str(f) for f in fields))
         message = '{0} {1}'.format(PrintableErrorField.TEXT_PREFIX, message)
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -63,14 +63,13 @@ class BasicTests(CliTestCase):
 
     def test_auth_call_no_auth(self):
         """
-        Runs get-identities without auth, confirms 401
+        Runs get-identities without auth, confirms No Authentication CLI error.
         """
         output = self.run_line_no_auth(
             "globus get-identities " +
             get_user_data()["clitester1a"]["username"],
             assert_exit_code=1)
-        self.assertIn("A Globus Error Occurred", output)
-        self.assertIn("401", output)
+        self.assertIn("No Authentication provided.", output)
 
     def test_auth_call(self):
         """
@@ -84,12 +83,11 @@ class BasicTests(CliTestCase):
 
     def test_transfer_call_no_auth(self):
         """
-        Runs ls without auth, confirms 400
+        Runs ls without auth, confirms No Authentication CLI error.
         """
         output = self.run_line_no_auth("globus ls " + str(GO_EP1_ID),
                                        assert_exit_code=1)
-        self.assertIn("A Transfer API Error Occurred", output)
-        self.assertIn("400", output)
+        self.assertIn("No Authentication provided.", output)
 
     def test_transfer_call(self):
         """


### PR DESCRIPTION
Addresses #37, although rather than explicitly checking that a user is authenticated per call that requires authentication, I figured it would be more maintainable and require fewer network calls to just have specific exception handling for when we get back errors from missing or invalid tokens?

Unable to make automated tests for invalid fresh tokens, but manual testing worked as expected.