### PR TITLE
Add fields to task show missing from hosted CLI

### DIFF
--- a/adoc/task_show.1.adoc
+++ b/adoc/task_show.1.adoc
@@ -35,23 +35,36 @@ All of the following which apply will be shown:
 - 'Task ID'
 - 'Type'
 - 'Status'
+- 'Is Paused'
 - 'Label'
 - 'Files'
 - 'Directories'
 - 'Source Endpoint'
+- 'Source Endpoint ID'
 - 'Destination Endpoint'
+- 'Destination Endpoint ID'
 - 'Endpoint'
+- 'Endpoint ID'
 - 'Completion Time'
 - 'Deadline'
 - 'Details'
 - 'Request Time'
+- 'Bytes Transferred'
+- 'Bytes Per Second'
+- 'Faults'
+- 'Total Subtasks'
+- 'Subtasks Succeeded'
+- 'Subtasks Pending'
+- 'Subtasks Retrying'
+- 'Subtasks Failed'
+- 'Subtasks Canceled'
+- 'Subtasks Expired'
 
 If *--successful-transfers* is given, the following fields are used:
 
-- 'Source'
-- 'Destination'
+- 'Source Path'
+- 'Destination Path'
 
-which refer to the source and destination paths.
 
 == EXAMPLES
 

--- a/globus_cli/commands/task/show.py
+++ b/globus_cli/commands/task/show.py
@@ -9,11 +9,20 @@ from globus_cli.services.transfer import get_client, iterable_response_to_dict
 COMMON_FIELDS = [
     ('Label', 'label'),
     ('Task ID', 'task_id'),
+    ('Is Paused', 'is_paused'),
     ('Type', 'type'),
     ('Directories', 'directories'),
     ('Files', 'files'),
     ('Status', 'status'),
     ('Request Time', 'request_time'),
+    ('Faults', 'faults'),
+    ('Total Subtasks', 'subtasks_total'),
+    ('Subtasks Succeeded', 'subtasks_succeeded'),
+    ('Subtasks Pending', 'subtasks_pending'),
+    ('Subtasks Retrying', 'subtasks_retrying'),
+    ('Subtasks Failed', 'subtasks_failed'),
+    ('Subtasks Canceled', 'subtasks_canceled'),
+    ('Subtasks Expired', 'subtasks_expired'),
 ]
 
 ACTIVE_FIELDS = [
@@ -27,16 +36,21 @@ COMPLETED_FIELDS = [
 
 DELETE_FIELDS = [
     ('Endpoint', 'source_endpoint_display_name'),
+    ('Endpoint ID', 'source_endpoint_id'),
 ]
 
 TRANSFER_FIELDS = [
     ('Source Endpoint', 'source_endpoint_display_name'),
+    ('Source Endpoint ID', 'source_endpoint_id'),
     ('Destination Endpoint', 'destination_endpoint_display_name'),
+    ('Destination Endpoint ID', 'destination_endpoint_id'),
+    ('Bytes Transferred', 'bytes_transferred'),
+    ('Bytes Per Second', 'effective_bytes_per_second'),
 ]
 
 SUCCESSFULL_TRANSFER_FIELDS = [
-    ('Source', 'source_path'),
-    ('Destination', 'destination_path')
+    ('Source Path', 'source_path'),
+    ('Destination Path', 'destination_path')
 ]
 
 


### PR DESCRIPTION
Fixes #300

There were no equivalent fields for the hosted CLI's `expansions` or `command` fields, but I don't think `expansions` is something to block on, and `command` doesn't make as much sense outside of the context of a hosted CLI.

I will make a separate issue to track the missing -t for DELETE tasks functionality, as that is blocked on the API.