### PR TITLE
Bugfix: task show link in docs was broken

### DIFF
--- a/adoc/index.adoc
+++ b/adoc/index.adoc
@@ -137,7 +137,7 @@ Delete a bookmark
 link:task_event_list[globus task event-list]::
 List events for a given task
 
-link:task[globus task show]::
+link:task_show[globus task show]::
 Show detailed information about a specific task
 
 link:task_list[globus task list]::


### PR DESCRIPTION
Whoops. Fix here, then we'll get this synced to the docs site.