### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -2,27 +2,10 @@ from distutils.version import LooseVersion
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-
-# The Globus CLI version *always* starts with the version of the SDK which it
-# depends upon. If necessary, we do additional point releases upon the SDK
-# version.
-# For example, if the SDK version is
-#       2.4.6
-# then the following are valid CLI versions:
-#       2.4.6.0
-#       2.4.6.1
-#       2.4.6.10
-#       2.4.6.99
-# and the following invalid CLI versions:
-#       2.4.6       -- doesn't specify point release
-#       2.4.7.0     -- should depend on SDK 2.4.7
-#       2.4.6.1.2   -- no additional point versions
-#       0.1.0.0     -- no special rules for things like this
-#       1.4.6.0     -- differing major version, obviously wrong
-__version__ = "1.0.0.0"
+__version__ = "1.1.0"
 
 # app name to send as part of SDK requests
-app_name = 'Globus CLI v{} - Beta'.format(__version__)
+app_name = 'Globus CLI v{}'.format(__version__)
 
 
 # pull down version data from PyPi


### PR DESCRIPTION
- Note: This marks a change in the versioning scheme
  whereas the CLI used to be based off the SDK version
  and was a "four part" version, e.g., 1.x.x.x, it is now
  a standard major.minor.patch version.