### PR TITLE
Switch from M2Crypto to cryptography for delegate proxy activation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ travis:
 	pip install --upgrade "setuptools>=29,<30"
 	pip install -r test-requirements.txt
 ifeq (, $(findstring pypy, $(TRAVIS_PYTHON_VERSION)))
-	pip install "M2Crypto==0.26.0"
+	pip install "cryptography>=1.8.1,<2.0.0"
 endif
 	python setup.py develop
 	flake8

--- a/adoc/endpoint_activate.1.adoc
+++ b/adoc/endpoint_activate.1.adoc
@@ -45,10 +45,12 @@ history, but you may pass your password with the --myproxy-password
 or -P options.
 
 NOTE: Delegate Proxy activation requires the optional dependency of
-M2Crypto. This dependency is optional as it frequently requires additional
-non-python packages to be installed on your machine. Consult 
-https://gitlab.com/m2crypto/m2crypto/blob/master/INSTALL.rst[M2Crypto's Install Page]
-for details.
+cryptography which requires additional non-python binaries to be installed on
+your machine. Consult
+https://cryptography.io/en/latest/installation/[cryptography's Install Page]
+for details. Once those dependencies are met you can use
+'pip install globus_cli[delegate-proxy]' to include cryptography in the
+install of the Globus CLI.
 
 To use Delegate Proxy activation use the --delegate-proxy option with a
 file containing an X.509 certificate as an argument (e.g. an X.509
@@ -89,7 +91,7 @@ password in plain-text in your command history.
 Give a password to use with --myproxy, skipping the password prompt.
 
 NOTE: the --delegate-proxy and --proxy-lifetime options will only appear if
-M2Crypto was successfully imported, see above note for details.
+cryptography was successfully imported, see above note for details.
 
 *--delegate-proxy* X.509 PEM FILE::
 

--- a/globus_cli/commands/endpoint/activate.py
+++ b/globus_cli/commands/endpoint/activate.py
@@ -1,13 +1,13 @@
 import click
 import webbrowser
 
-# only have --delegate-proxy appear if M2Crypto is available
+# only have --delegate-proxy appear if cryptography is available
 try:
-    import M2Crypto
+    import cryptography
     # slightly hacky way of preventing flake8 from complaining
-    m2crypto_imported = bool(M2Crypto)
+    cryptography_imported = bool(cryptography)
 except ImportError:
-    m2crypto_imported = False
+    cryptography_imported = False
 
 
 from globus_cli.parsing import common_options, endpoint_id_arg, HiddenOption
@@ -62,15 +62,15 @@ delegate_proxy_long_help = """
     prompted to hide your inputs and keep your password out of your
     command history, but you may pass your password with the hidden
     --myproxy-password or -P options.
-    {}""".format(" Delegate Proxy," if m2crypto_imported else "",
-                 " --delegate-proxy" if m2crypto_imported else "",
-                 delegate_proxy_long_help if m2crypto_imported else ""))
+    {}""".format(" Delegate Proxy," if cryptography_imported else "",
+                 " --delegate-proxy" if cryptography_imported else "",
+                 delegate_proxy_long_help if cryptography_imported else ""))
 @common_options
 @endpoint_id_arg
 @click.option("--web", is_flag=True, default=False,
               help=("Use web activation. Mutually exclusive with --myproxy"
                     "{}.".format(" and --delegate-proxy"
-                                 if m2crypto_imported else "")))
+                                 if cryptography_imported else "")))
 @click.option("--no-browser", is_flag=True, default=False,
               help=("If using --web, Give a url to manually follow instead of "
                     "opening your default web browser. Implied if the CLI "
@@ -78,18 +78,18 @@ delegate_proxy_long_help = """
 @click.option("--myproxy", is_flag=True, default=False,
               help=("Use myproxy activation. Mutually exclusive with --web"
                     "{}.".format(" and --delegate-proxy"
-                                 if m2crypto_imported else "")))
+                                 if cryptography_imported else "")))
 @click.option("--myproxy-username", "-U",
               help=("Give a username to use with --myproxy. "
                     "Overrides any default myproxy username set in config."))
 @click.option("--myproxy-password", "-P", cls=HiddenOption)
 @click.option("--delegate-proxy", metavar="X.509_PEM_FILE",
-              cls=(click.Option if m2crypto_imported else HiddenOption),
+              cls=(click.Option if cryptography_imported else HiddenOption),
               help=("Use delegate proxy activation, takes an X.509 "
                     "certificate in pem format as an argument. Mutually "
                     "exclusive with --web and --myproxy."))
 @click.option("--proxy-lifetime", type=int, default=None,
-              cls=(click.Option if m2crypto_imported else HiddenOption),
+              cls=(click.Option if cryptography_imported else HiddenOption),
               help=("Set a lifetime in hours for the proxy generated with "
                     "--delegate-proxy. [default: 12]"))
 @click.option("--no-autoactivate", is_flag=True, default=False,
@@ -121,9 +121,9 @@ def endpoint_activate(endpoint_id, myproxy, myproxy_username, myproxy_password,
         raise click.UsageError("--no-browser requires --web.")
     if proxy_lifetime and not delegate_proxy:
         raise click.UsageError("--proxy-lifetime requires --delegate-proxy.")
-    if delegate_proxy and not m2crypto_imported:
-            raise click.ClickException(
-                "Missing M2Crypto dependency required for --delegate-proxy, ")
+    if delegate_proxy and not cryptography_imported:
+            raise click.ClickException("Missing cryptography dependency "
+                                       "required for --delegate-proxy, ")
 
     # check if endpoint is already activated unless --force
     if not force:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     ],
 
     extras_require={
-        'delegate-proxy': ['M2Crypto==0.26.0']
+        'delegate-proxy': ['cryptography>=1.8.1,<2.0.0']
     },
 
     entry_points={


### PR DESCRIPTION
Hopefully this will make our dependencies less painful.

This should address #311 since cryptography uses one function to parse all private key types, and I switched to using a regex to parse the PEM files to make use of this. Haven't tested yet, and don't know what would happen if someone gave us a non RSA private key.

Includes some security updates, the old code was using SHA1, and X.509 v2 (yet still managed to add extensions somehow?) new code is using SHA256 and X.509 v3

I added a sentence about `pip install globus_cli[delegate-proxy]` to the activation adoc, do we want to add this to our install page as well?