### PR TITLE
Improve utf-8 handling and add encoding tests

### DIFF
--- a/globus_cli/commands/bookmark/helpers.py
+++ b/globus_cli/commands/bookmark/helpers.py
@@ -31,8 +31,8 @@ def resolve_id_or_name(client, bookmark_id_or_name):
                        if bookmark_row['name'] == bookmark_id_or_name)
 
         except StopIteration:
-            safeprint('No bookmark found for "{}"'.format(bookmark_id_or_name),
-                      write_to_stderr=True)
+            safeprint(u'No bookmark found for "{}"'.format(
+                      bookmark_id_or_name), write_to_stderr=True)
             click.get_current_context().exit(1)
 
     return res

--- a/globus_cli/commands/endpoint/permission/list.py
+++ b/globus_cli/commands/endpoint/permission/list.py
@@ -22,7 +22,7 @@ def list_command(endpoint_id):
         if rule['principal_type'] == 'identity':
             return lookup_identity_name(principal)
         elif rule['principal_type'] == 'group':
-            return ('https://www.globus.org/app/groups/{}'
+            return (u'https://www.globus.org/app/groups/{}'
                     ).format(principal)
         else:
             principal = rule['principal_type']

--- a/globus_cli/commands/endpoint/permission/show.py
+++ b/globus_cli/commands/endpoint/permission/show.py
@@ -10,7 +10,7 @@ def _shared_with_keyfunc(rule):
     if rule['principal_type'] == 'identity':
         return lookup_identity_name(rule['principal'])
     elif rule['principal_type'] == 'group':
-        return ('https://www.globus.org/app/groups/{}'
+        return (u'https://www.globus.org/app/groups/{}'
                 .format(rule['principal']))
     else:
         return rule['principal_type']

--- a/globus_cli/commands/endpoint/server/list.py
+++ b/globus_cli/commands/endpoint/server/list.py
@@ -19,7 +19,7 @@ def server_list(endpoint_id):
     endpoint = client.get_endpoint(endpoint_id)
 
     if endpoint['host_endpoint_id']:  # not GCS -- this is a share endpoint
-        raise click.UsageError(dedent("""\
+        raise click.UsageError(dedent(u"""\
             {id} ({0}) is a share and does not have servers.
 
             To see details of the share, use

--- a/globus_cli/commands/login.py
+++ b/globus_cli/commands/login.py
@@ -27,7 +27,7 @@ Logout of the Globus CLI with
   globus logout
 """)
 
-_LOGIN_EPILOG = ("""\
+_LOGIN_EPILOG = (u"""\
 
 You have successfully logged in to the Globus CLI as {}
 """) + _SHARED_EPILOG

--- a/globus_cli/commands/logout.py
+++ b/globus_cli/commands/logout.py
@@ -46,8 +46,8 @@ def logout_command():
     if not username:
         safeprint(("Your username is not set. You may not be logged in. "
                    "Attempting logout anyway...\n"))
-    safeprint('Logging out of Globus{}\n'.format(' as ' + username
-                                                 if username else ''))
+    safeprint(u'Logging out of Globus{}\n'.format(u' as ' + username
+                                                  if username else ''))
 
     # build the NativeApp client object
     native_client = internal_auth_client()

--- a/globus_cli/commands/task/cancel.py
+++ b/globus_cli/commands/task/cancel.py
@@ -53,7 +53,7 @@ def cancel_task(all, task_id):
         def _custom_text(res):
             for (i, (task_id, data)) in enumerate(cancellation_iterator(),
                                                   start=1):
-                safeprint('{} ({} of {}): {}'
+                safeprint(u'{} ({} of {}): {}'
                           .format(task_id, i, task_count, data['message']))
 
         # FIXME: this is kind of an abuse of formatted_print because the

--- a/globus_cli/parsing/excepthook.py
+++ b/globus_cli/parsing/excepthook.py
@@ -152,5 +152,5 @@ def custom_except_hook(exc_info):
         # or NotImplementedError bubbled all the way up here: just print it
         # out, basically
         else:
-            safeprint('{}: {}'.format(exception_type.__name__, exception))
+            safeprint(u'{}: {}'.format(exception_type.__name__, exception))
             sys.exit(1)

--- a/globus_cli/safeio/errors.py
+++ b/globus_cli/safeio/errors.py
@@ -1,41 +1,44 @@
 import json
-from six import string_types
 
+from globus_sdk.base import safe_stringify
 from globus_cli.helpers import outformat_is_json
 from globus_cli.safeio.write import safeprint
 
 
 class PrintableErrorField(object):
     """
-    A glorified tuple with a kwarg in its constructor
+    A glorified tuple with a kwarg in its constructor.
+    Coerces name and value fields to unicode for output consistency
     """
     TEXT_PREFIX = 'Globus CLI Error:'
 
     def __init__(self, name, value, multiline=False):
-        self.name = name
-        self.value = value
+        self.name = safe_stringify(name)
+        self.value = safe_stringify(value)
         self.multiline = multiline
+        self._format_value()
 
     @property
     def _text_prefix_len(self):
         return len(self.TEXT_PREFIX)
 
-    def __str__(self):
+    def _format_value(self):
         """
-        str(PrintableErrorField) is good for textmode printing
+        formats self.value to be good for textmode printing
+        self.value must be unicode before this is called, and will remain so
         """
         name = self.name + ':'
-        if not self.multiline or not isinstance(self.value, string_types) or \
-                '\n' not in self.value:
-            return '{0} {1}'.format(name.ljust(self._text_prefix_len),
-                                    self.value)
+        if not self.multiline or '\n' not in self.value:
+            self.value = u'{0} {1}'.format(name.ljust(self._text_prefix_len),
+                                           self.value)
         else:
             spacer = '\n' + ' '*(self._text_prefix_len + 1)
-            return '{0}{1}{2}'.format(
+            self.value = u'{0}{1}{2}'.format(
                 name, spacer, spacer.join(self.value.split('\n')))
 
 
 def write_error_info(error_name, fields, message=None):
+
     if outformat_is_json():
         # dictify joined tuple lists and dump to json string
         message = json.dumps(
@@ -43,11 +46,10 @@ def write_error_info(error_name, fields, message=None):
                 [('error_name', error_name)] +
                 [(f.name, f.value) for f in fields]),
             indent=2)
-
     if not message:
-        message = 'A{0} {1} Occurred.\n{2}'.format(
+        message = u'A{0} {1} Occurred.\n{2}'.format(
             "n" if error_name[0] in "aeiouAEIOU" else "",
-            error_name, '\n'.join(str(f) for f in fields))
-        message = '{0} {1}'.format(PrintableErrorField.TEXT_PREFIX, message)
+            error_name, '\n'.join(f.value for f in fields))
+        message = u'{0} {1}'.format(PrintableErrorField.TEXT_PREFIX, message)
 
     safeprint(message, write_to_stderr=True)

--- a/globus_cli/safeio/output_formatter.py
+++ b/globus_cli/safeio/output_formatter.py
@@ -69,8 +69,8 @@ def colon_formatted_print(data, named_fields):
     maxlen = max(len(n) for n, f in named_fields) + 1
     for name, field in named_fields:
         field_keyfunc = _key_to_keyfunc(field)
-        safeprint('{} {}'.format((name + ':').ljust(maxlen),
-                                 field_keyfunc(data)))
+        safeprint(u'{} {}'.format((name + u':').ljust(maxlen),
+                                  field_keyfunc(data)))
 
 
 def print_table(iterable, headers_and_keys, print_headers=True):
@@ -106,7 +106,7 @@ def print_table(iterable, headers_and_keys, print_headers=True):
     widths = [max(w, len(h)) for w, h in zip(widths, headers)]
 
     # create a format string based on column widths
-    format_str = six.u(' | '.join('{:' + str(w) + '}' for w in widths))
+    format_str = u' | '.join(u'{:' + str(w) + u'}' for w in widths)
 
     def none_to_null(val):
         if val is None:

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,196 @@
+# -*- coding: utf8 -*-
+
+from random import getrandbits
+import unittest
+import six
+import json
+
+from tests.framework.cli_testcase import CliTestCase
+from tests.framework.constants import GO_EP1_ID
+
+
+class EncodingTests(CliTestCase):
+
+    def dir_operations(self, input_name, expected_name=None):
+        """
+        Given an input directory name, makes the directory to test inputs,
+        ls's the directory to test outputs and output formats,
+        attempts to remake the directory to test error outputs,
+        and finally deletes the directory for cleanup.
+        """
+        # mkdir
+        # name randomized to prevent collision
+        rand = str(getrandbits(128))
+        dir_name = input_name + rand
+        expected = (expected_name or input_name) + rand
+        # if given a unicode name, run a unicode string
+        if isinstance(input_name, six.text_type):
+            make_output = self.run_line(
+                u"globus mkdir {}:~/{}".format(GO_EP1_ID, dir_name))
+        # if given a byte string name, run a byte string
+        else:
+            make_output = self.run_line(
+                b"globus mkdir {}:~/{}".format(GO_EP1_ID, dir_name))
+
+        self.assertIn("The directory was created successfully", make_output)
+
+        # confirm the dir can be seen. Confirms simple, long, verbose,
+        # and json output all handle the encoding.
+        ls_output = self.run_line(u"globus ls {}:~/".format(GO_EP1_ID))
+        self.assertIn(expected, ls_output)
+
+        long_output = self.run_line(
+            u"globus ls -l {}:~/".format(GO_EP1_ID))
+        self.assertIn(expected, long_output)
+        self.assertIn("Filename", long_output)
+
+        json_output = json.loads(
+            self.run_line(
+                u"globus ls -F json {}:~/".format(GO_EP1_ID)))
+        self.assertIn(expected, [i["name"] for i in json_output["DATA"]])
+
+        # attempt to make the dir again to test error output:
+        # if given a unicode name, run a unicode string
+        if isinstance(input_name, six.text_type):
+            make2_output = self.run_line(
+                u"globus mkdir {}:~/{}".format(GO_EP1_ID, dir_name),
+                assert_exit_code=1)
+        # if given a byte string name, run a byte string
+        else:
+            make2_output = self.run_line(
+                b"globus mkdir {}:~/{}".format(GO_EP1_ID, dir_name),
+                assert_exit_code=1)
+        self.assertIn("Path already exists", make2_output)
+        self.assertIn(expected, make2_output)
+
+        # delete for cleanup:
+        # if given a unicode name, run a unicode string
+        if isinstance(input_name, six.text_type):
+            delete_output = self.run_line(
+                u"globus delete -r {}:~/{}".format(GO_EP1_ID, dir_name))
+        # if given a byte string name, run a byte string
+        else:
+            delete_output = self.run_line(
+                b"globus delete -r {}:~/{}".format(GO_EP1_ID, dir_name))
+
+        self.assertIn("The delete has been accepted", delete_output)
+
+    def ep_operations(self, input_name, expected_name=None):
+        """
+        Given an input_name, creates, updates, gets, and deletes an endpoint
+        using the input_name as a display_name. If an expected_name is given,
+        confirms output matches that name rather than the input_name.
+        """
+        # if given a unicode name, run a unicode string
+        if isinstance(input_name, six.text_type):
+            create_output = json.loads(self.run_line(
+                u"globus endpoint create -F json --server {}".format(
+                    input_name)))
+        # if given a byte string name, run a byte string
+        else:
+            create_output = json.loads(self.run_line(
+                b"globus endpoint create -F json --server {}".format(
+                    input_name)))
+        self.assertEqual(create_output["code"], "Created")
+        self.assertEqual(create_output["code"], "Created")
+        ep_id = create_output["id"]
+
+        # confirm endpoint show sees ep
+        show_output = self.run_line("globus endpoint show {}".format(ep_id))
+        self.assertIn((expected_name or input_name), show_output)
+
+        # update
+        # if given a unicode name, run a unicode string
+        if isinstance(input_name, six.text_type):
+            update_output = self.run_line(
+                u"globus endpoint update {} --description {}".format(
+                    ep_id, input_name))
+        # if given a byte string name, run a byte string
+        else:
+            update_output = self.run_line(
+                b"globus endpoint update {} --description {}".format(
+                    ep_id, input_name))
+        self.assertIn("updated successfully", update_output)
+
+        # confirm show sees updated description
+        show_output = json.loads(self.run_line(
+            "globus endpoint show {} -F json".format(ep_id)))
+        self.assertEqual((expected_name or input_name),
+                         show_output["description"])
+
+        # delete
+        delete_output = self.run_line(
+            "globus endpoint delete {}".format(ep_id))
+        self.assertIn("deleted successfully", delete_output)
+
+    def test_quote_escaping(self):
+        """
+        Tests operations with an escaped quote inside quotes that should be
+        seen as one literal quote character by the shell
+        """
+        name = r'"\""'
+        self.dir_operations(name, expected_name='"')
+        self.ep_operations(name, expected_name='"')
+
+    def test_ascii_url_encoding(self):
+        """
+        Tests operations with an ASCII name that includes ' ' and '%"
+        characters that will need to be encoded for use in a url.
+        """
+        name = '"a% b"'
+        self.dir_operations(name, expected_name="a% b")
+        self.ep_operations(name, expected_name="a% b")
+
+    def test_non_ascii_utf8(self):
+        """
+        Tests operations with a UTF-8 name containing non ASCII characters with
+        code points requiring multiple bytes.
+        """
+        name = u"テスト"
+        self.dir_operations(name)
+        self.ep_operations(name)
+
+    @unittest.skipIf(six.PY3, "test run with Python 3")
+    def test_non_ascii_utf8_bytes(self):
+        """
+        Tests operations with a byte string encoded from non ASCII UTF-8.
+        This test is only run on Python 2 as bytes are not strings in Python 3.
+        """
+        uni_name = u"テスト"
+        byte_name = uni_name.encode("utf8")
+        # we expect uni_name back since the API returns unicode strings
+        self.dir_operations(byte_name, expected_name=uni_name)
+        self.ep_operations(byte_name, expected_name=uni_name)
+
+    def test_latin1(self):
+        """
+        Tests operations with latin-1 name that is not valid UTF-8.
+        """
+        # the encoding for 'é' in latin-1 is a continuation byte in utf-8
+        byte_name = b"\xe9"  # é's latin-1 encoding
+        name = byte_name.decode("latin-1")
+        with self.assertRaises(UnicodeDecodeError):
+            byte_name.decode("utf-8")
+
+        self.dir_operations(name)
+        self.ep_operations(name)
+
+    @unittest.skipIf(six.PY3, "test run with Python 3")
+    def test_invalid_utf8_bytes(self):
+        """
+        Tests operations with byte string that can be decoded with
+        latin-1 but not with UTF-8. Confirms that this raises a
+        UnicodeDecodeError, as the SDK/APIs can't handle decoding non UTF-8.
+        This test is only run on Python 2 as bytes are not strings in Python 3.
+        """
+        # the encoding for 'é' in latin-1 is a continuation byte in utf-8
+        byte_name = b"\xe9"  # é's latin-1 encoding
+
+        make_output = self.run_line("globus mkdir {}:~/{}".format(
+            GO_EP1_ID, byte_name), assert_exit_code=1)
+        self.assertIn("UnicodeDecodeError", make_output)
+
+        create_output = self.run_line(
+                "globus endpoint create --server {}".format(
+                    byte_name), assert_exit_code=1)
+        self.assertIn("UnicodeDecodeError", create_output)


### PR DESCRIPTION
Resolves #65

Click is very good at handling byte string/unicode conversion issues, but recommends against importing unicode literals from future in modules that import click (and gives a warning if you do so). I doubt unicode literals would break anything since our APIs only use unicode for text, but I figured better to be safe and used the `u""` marking to make any potentially unsafe format strings unicode.

The only places that needed additional changes to handle non-ascii strings were the test framework and the `PrintableErrorField` which I re-wrote a little to `safe_stringify` inputs and not use `__str__` to make sure everything was unicode internally.

The tests are mostly re-written versions of the SDK encoding tests, but I added some additional error handling tests and a test on escaping quotation marks.

I also did some manual testing with ubunutu terminal using `en_US.UTF-8` encoding to make sure the click test runner wasn't playing significantly nicer than a real shell.