### PR TITLE
Show full diff on test failure

### DIFF
--- a/tests/integration/test_jmespath_output.py
+++ b/tests/integration/test_jmespath_output.py
@@ -16,6 +16,8 @@ class JMESPathTests(CliTestCase):
         Runs some simple fetch operations and confirms that `--jmespath '@'`
         doesn't change the output (but also that it overrides --format TEXT)
         """
+        self.maxDiff = None
+
         output = self.run_line(
             "globus endpoint show {} -Fjson".format(GO_EP1_ID))
         jmespathoutput = self.run_line(


### PR DESCRIPTION
I've seen a handful of failures on this test but the diff is truncated so you can't tell what's causing it (I suspect it might be `expire_time` getting reset from a concurrent test run).