### PR TITLE
v1.1.1

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -1,6 +1,23 @@
 = CLI Changelog
 
 
+== 1.1.1
+
+Enhancements:
+
+* Use the `cryptography` package instead of `M2Crypto` for the
+`delegate-proxy` feature.
+** Note: If you are using the `delegate-proxy` feature and
+previously installed the CLI along with `M2Crypto`, you
+will need to activate the CLI's virtualenv and install
+the `cryptography` dependency:
+```
+source $HOME/.globus-cli-virtualenv/bin/activate
+pip install globus-cli[delegate-proxy] --upgrade
+deactivate
+```
+
+
 == 1.1.0
 
 Features:
@@ -22,7 +39,7 @@ Enhancements:
 (https://github.com/globus/globus-cli/pull/289[289])
 * Display additional fields with 'globus task show'.
 (https://github.com/globus/globus-cli/pull/301[301])
-* Make conflicting filters mutually exclusive in 'globus task event-list 
+* Make conflicting filters mutually exclusive in 'globus task event-list'
 (https://github.com/globus/globus-cli/pull/294[294])
 
 Bugfixes:

--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -2,7 +2,7 @@ from distutils.version import LooseVersion
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # app name to send as part of SDK requests
 app_name = 'Globus CLI v{}'.format(__version__)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version=version,
     packages=find_packages(),
     install_requires=[
-        'globus-sdk==1.1.0',
+        'globus-sdk==1.1.1',
         'click>=6.6,<7.0',
         'jmespath==0.9.2',
         'configobj>=5.0.6,<6.0.0',


### PR DESCRIPTION
* Replace `M2Crypto` with `cryptography` (delegate proxy support).
* Bump SDK to v1.1.1

@ranantha We're going to hold this release pending possibly communication to our existing delegate proxy users about the switch.