### PR TITLE
Support provisioning flag for get-identities calls

### DIFF
--- a/globus_cli/commands/endpoint/permission/create.py
+++ b/globus_cli/commands/endpoint/permission/create.py
@@ -13,7 +13,8 @@ from globus_cli.services.transfer import get_client, assemble_generic_doc
 @click.command('create', help=('Create an access control rule, allowing new '
                                'permissions'))
 @common_options
-@security_principal_opts(allow_anonymous=True, allow_all_authenticated=True)
+@security_principal_opts(
+    allow_anonymous=True, allow_all_authenticated=True, allow_provision=True)
 @click.option('--permissions', required=True,
               type=CaseInsensitiveChoice(('r', 'rw')),
               help='Permissions to add. Read-Only or Read/Write')
@@ -34,6 +35,13 @@ def create_command(principal, permissions, endpoint_plus_path):
 
     if principal_type == 'identity':
         principal_val = maybe_lookup_identity_id(principal_val)
+        if not principal_val:
+            raise click.UsageError(
+                'Identity does not exist. '
+                'Use --provision-identity to auto-provision an identity.')
+    elif principal_type == 'provision-identity':
+        principal_val = maybe_lookup_identity_id(principal_val, provision=True)
+        principal_type = 'identity'
 
     rule_data = assemble_generic_doc(
         'access', permissions=permissions, principal=principal_val,

--- a/globus_cli/commands/endpoint/permission/list.py
+++ b/globus_cli/commands/endpoint/permission/list.py
@@ -20,13 +20,17 @@ def list_command(endpoint_id):
     def principal_str(rule):
         principal = rule['principal']
         if rule['principal_type'] == 'identity':
-            return lookup_identity_name(principal)
+            username = lookup_identity_name(principal)
+
+            return username or principal
         elif rule['principal_type'] == 'group':
             return (u'https://www.globus.org/app/groups/{}'
                     ).format(principal)
         else:
             principal = rule['principal_type']
+
         return principal
+
     formatted_print(
         rules, fields=[('Rule ID', 'id'), ('Permissions', 'permissions'),
                        ('Shared With', principal_str), ('Path', 'path')])

--- a/globus_cli/commands/endpoint/role/create.py
+++ b/globus_cli/commands/endpoint/role/create.py
@@ -13,7 +13,7 @@ from globus_cli.services.transfer import get_client, assemble_generic_doc
 @click.command('create', help='Create a role on an endpoint')
 @common_options
 @endpoint_id_arg
-@security_principal_opts
+@security_principal_opts(allow_provision=True)
 @click.option('--role', required=True,
               type=CaseInsensitiveChoice(
                   ('administrator', 'access_manager', 'activity_manager',
@@ -29,6 +29,13 @@ def role_create(role, principal, endpoint_id):
 
     if principal_type == 'identity':
         principal_val = maybe_lookup_identity_id(principal_val)
+        if not principal_val:
+            raise click.UsageError(
+                'Identity does not exist. '
+                'Use --provision-identity to auto-provision an identity.')
+    elif principal_type == 'provision-identity':
+        principal_val = maybe_lookup_identity_id(principal_val, provision=True)
+        principal_type = 'identity'
 
     role_doc = assemble_generic_doc(
         'role', principal_type=principal_type, principal=principal_val,

--- a/globus_cli/commands/endpoint/role/list.py
+++ b/globus_cli/commands/endpoint/role/list.py
@@ -11,8 +11,8 @@ from globus_cli.services.transfer import get_client
 def principal_str(role):
     principal = role['principal']
     if role['principal_type'] == 'identity':
-        principal = lookup_identity_name(principal)
-    return principal
+        username = lookup_identity_name(principal)
+    return username or principal
 
 
 @click.command('list', help='List of assigned roles on an endpoint')


### PR DESCRIPTION
Closes #326
Closes #328 

* Adds option `--provision-identity` to create endpoint role and permission commands, mutually exclusive with the `--identity` option.
* Fixes error condition during a list operation where Transfer has a role or permission "principal" that does not yet exist in Auth (Transfer allows roles/permissions to be created for arbitrary UUIDs).