### PR TITLE
Mock config file for testing

### DIFF
--- a/tests/framework/cli_testcase.py
+++ b/tests/framework/cli_testcase.py
@@ -58,6 +58,10 @@ def default_test_config(*args, **kwargs):
     """
     user_data = get_user_data()["clitester1a"]
 
+    # create a ConfgObj from a dict of testing constants. a ConfigObj created
+    # this way will not be tied to a config file on disk, meaning that
+    # ConfigObj.filename = None and ConfigObj.write() returns a string without
+    # writing anything to disk.
     return ConfigObj({"cli": {
         AUTH_RT_OPTNAME: CLITESTER1A_AUTH_RT,
         AUTH_AT_OPTNAME: "",

--- a/tests/framework/cli_testcase.py
+++ b/tests/framework/cli_testcase.py
@@ -1,8 +1,13 @@
 import unittest
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
 import six
 import shlex
 from click.testing import CliRunner
 from datetime import datetime, timedelta
+from configobj import ConfigObj
 
 import globus_sdk
 
@@ -11,7 +16,7 @@ from globus_cli.config import (
     AUTH_RT_OPTNAME, AUTH_AT_OPTNAME, AUTH_AT_EXPIRES_OPTNAME,
     TRANSFER_RT_OPTNAME, TRANSFER_AT_OPTNAME, TRANSFER_AT_EXPIRES_OPTNAME,
     WHOAMI_ID_OPTNAME, WHOAMI_USERNAME_OPTNAME, WHOAMI_NAME_OPTNAME,
-    WHOAMI_EMAIL_OPTNAME, get_config_obj)
+    WHOAMI_EMAIL_OPTNAME)
 from globus_cli.services.transfer import get_client
 from globus_cli.services.auth import get_auth_client
 
@@ -46,12 +51,14 @@ def clean_sharing():
         tc.submit_delete(ddata)
 
 
-def write_test_config(conf):
+def default_test_config(*args, **kwargs):
     """
-    Writes known constants and refresh tokens into config for testing
+    Returns a ConfigObj with the clitester's refresh tokens and whoami info
+    as if the clitester was logged in and a call to get_config_obj was made.
     """
     user_data = get_user_data()["clitester1a"]
-    testing_constants = {
+
+    return ConfigObj({"cli": {
         AUTH_RT_OPTNAME: CLITESTER1A_AUTH_RT,
         AUTH_AT_OPTNAME: "",
         AUTH_AT_EXPIRES_OPTNAME: 0,
@@ -62,9 +69,8 @@ def write_test_config(conf):
         WHOAMI_USERNAME_OPTNAME: user_data["username"],
         WHOAMI_NAME_OPTNAME: user_data["name"],
         WHOAMI_EMAIL_OPTNAME: user_data["email"]
-    }
-    conf["cli"] = testing_constants
-    conf.write()
+        }
+    })
 
 
 class CliTestCase(unittest.TestCase):
@@ -78,37 +84,39 @@ class CliTestCase(unittest.TestCase):
         self._runner = CliRunner()
 
     @classmethod
+    @patch("globus_cli.config.get_config_obj", new=default_test_config)
     def setUpClass(self):
         """
-        Stores any existing config data in the cli environment of .globus.cfg
-        Then replaces that data with known values for testing
-        Creates a transfer client and an auth client for any direct SDK calls
+        Gets a TransferClient and AuthClient for direct sdk calls
         Cleans any old sharing data created by previous test runs
         """
-        self.conf = get_config_obj()
-        try:
-            self.stored_config = self.conf["cli"]
-        except KeyError:
-            self.stored_config = {}
-        write_test_config(self.conf)
         self.tc = get_client()
         self.ac = get_auth_client()
-
         clean_sharing()
 
-    @classmethod
-    def tearDownClass(self):
+    @patch("globus_cli.config.get_config_obj")
+    def run_line(self, line, mock_config, config=None,
+                 assert_exit_code=0, batch_input=None):
         """
-        Restores original values of the cli environment of .globus.cfg
-        """
-        self.conf["cli"] = self.stored_config
-        self.conf.write()
+        Uses the CliRunner to run the given command line.
 
-    def run_line(self, line, assert_exit_code=0, batch_input=None):
+        Any calls to get_config_obj during the test are patched to
+        return a ConfigObj with given config dict. If no config dict is given,
+        defaults to default_test_config_obj defined above.
+
+        Asserts that the exit_code is equal to the given assert_exit_code,
+        and if that exit_code is 0 prevents click from catching exceptions
+        for easier debugging.
+
+        Any given batch_input is passed as input to stdin.
         """
-        Uses the CliRunner to run the given command line,
-        Asserts that the exit_code is equal to the given value
-        """
+        # mock out calls to get_config_obj to return given config
+        # if none given default to default test config values
+        if config is None:
+            mock_config.return_value = default_test_config()
+        else:
+            mock_config.return_value = ConfigObj(config)
+
         # split line into args and confirm line starts with "globus"
         # python2 shlex can't handle non ascii unicode
         if six.PY2 and isinstance(line, six.text_type):
@@ -132,18 +140,3 @@ class CliTestCase(unittest.TestCase):
                                      assert_exit_code, result.output))))
         # return the output for further testing
         return result.output
-
-    def run_line_no_auth(self, line, assert_exit_code=0, batch_input=None):
-        """
-        Wrapper around run_line that wipes the cli environment of .globus.cfg
-        Before running, then restores test values after run is complete.
-        """
-        # wipe cli environment
-        self.conf["cli"] = {}
-        self.conf.write()
-        # run the line in blank environment
-        ret = self.run_line(line, assert_exit_code=assert_exit_code,
-                            batch_input=batch_input)
-        # reset the test environment and return the result
-        write_test_config(self.conf)
-        return ret

--- a/tests/manual_cleanup.py
+++ b/tests/manual_cleanup.py
@@ -1,7 +1,10 @@
-from globus_cli.config import get_config_obj
 from globus_cli.services.transfer import get_client as get_tc
+from tests.framework.cli_testcase import default_test_config
 
-from tests.framework.cli_testcase import write_test_config
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
 
 
 def cleanup_bookmarks(tc):
@@ -9,16 +12,10 @@ def cleanup_bookmarks(tc):
         tc.delete_bookmark(bm['id'])
 
 
+@patch("globus_cli.config.get_config_obj", new=default_test_config)
 def main():
-    conf = get_config_obj()
-    stored_conf = conf['cli']
-    write_test_config(conf)
-    try:
-        tc = get_tc()
-        cleanup_bookmarks(tc)
-    finally:
-        conf['cli'] = stored_conf
-        conf.write()
+    tc = get_tc()
+    cleanup_bookmarks(tc)
 
 
 if __name__ == '__main__':

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -56,19 +56,20 @@ class BasicTests(CliTestCase):
 
     def test_whoami_no_auth(self):
         """
-        Runs whoami without auth to confirm no_auth successfully setup
+        Runs whoami with config set to be empty, confirms no login seen.
         """
-        output = self.run_line_no_auth("globus whoami", assert_exit_code=1)
+        output = self.run_line("globus whoami", config={}, assert_exit_code=1)
         self.assertIn("No login information available", output)
 
     def test_auth_call_no_auth(self):
         """
-        Runs get-identities without auth, confirms No Authentication CLI error.
+        Runs get-identities with config set to be empty,
+        confirms No Authentication CLI error.
         """
-        output = self.run_line_no_auth(
+        output = self.run_line(
             "globus get-identities " +
             get_user_data()["clitester1a"]["username"],
-            assert_exit_code=1)
+            config={}, assert_exit_code=1)
         self.assertIn("No Authentication provided.", output)
 
     def test_auth_call(self):
@@ -83,10 +84,11 @@ class BasicTests(CliTestCase):
 
     def test_transfer_call_no_auth(self):
         """
-        Runs ls without auth, confirms No Authentication CLI error.
+        Runs ls with config set to be empty,
+        confirms No Authentication CLI error.
         """
-        output = self.run_line_no_auth("globus ls " + str(GO_EP1_ID),
-                                       assert_exit_code=1)
+        output = self.run_line("globus ls " + str(GO_EP1_ID),
+                               config={}, assert_exit_code=1)
         self.assertIn("No Authentication provided.", output)
 
     def test_transfer_call(self):

--- a/tests/unit/test_bookmark_commands.py
+++ b/tests/unit/test_bookmark_commands.py
@@ -4,8 +4,6 @@ import logging
 
 from globus_sdk import GlobusAPIError, NetworkError
 
-from globus_cli.services.transfer import get_client
-
 from tests.framework.constants import GO_EP1_ID
 from tests.framework.cli_testcase import CliTestCase
 
@@ -45,7 +43,6 @@ class BookmarkTests(CliTestCase):
     def setUp(self):
         super(BookmarkTests, self).setUp()
 
-        self.tc = get_client()
         self.created_bookmark_names = set()
 
         # use try-catch to ensure that cleanup this runs even if setUp crashes

--- a/tests/unit/test_login_command.py
+++ b/tests/unit/test_login_command.py
@@ -5,12 +5,13 @@ except ImportError:
 
 import globus_sdk
 
-from tests.framework.cli_testcase import CliTestCase
+from tests.framework.cli_testcase import CliTestCase, default_test_config
 
 from globus_cli.config import AUTH_RT_OPTNAME, TRANSFER_RT_OPTNAME
 
 
-class EndpointCreateTests(CliTestCase):
+class LoginCommandTests(CliTestCase):
+
     @mock.patch('globus_cli.commands.login.internal_auth_client')
     def test_login_validates_token(self, get_client):
         ac = mock.MagicMock(spec=globus_sdk.NativeAppAuthClient)
@@ -18,7 +19,8 @@ class EndpointCreateTests(CliTestCase):
 
         self.run_line("globus login")
 
-        a_rt = self.conf['cli'][AUTH_RT_OPTNAME]
-        t_rt = self.conf['cli'][TRANSFER_RT_OPTNAME]
+        conf = default_test_config()
+        a_rt = conf['cli'][AUTH_RT_OPTNAME]
+        t_rt = conf['cli'][TRANSFER_RT_OPTNAME]
         ac.oauth2_validate_token.assert_any_call(a_rt)
         ac.oauth2_validate_token.assert_any_call(t_rt)


### PR DESCRIPTION
As discussed, mocks out the whole config layer by patching calls to `get_config_obj`.

This should make it more difficult to accidentally revoke the testing tokens, and adds the ability to specify config per call of run_line for further testing of login/logout later.