### PR TITLE
Rate limited BFS for --recursive ls

### DIFF
--- a/globus_cli/commands/ls.py
+++ b/globus_cli/commands/ls.py
@@ -60,19 +60,20 @@ def ls_command(endpoint_plus_path, recursive_depth_limit,
         else:
             formatted_path = path
 
-        # if the item has a path field, it is recursive, and we want
-        # to display the relative path from the start of the ls.
-        if item.get("path"):
+        # if we are doing a recursive ls we want to display the relative path
+        # from the start of the ls.
+        if recursive:
 
             # if the ls command has a starting path,
             # give everything relative to that path
             if formatted_path:
                 relative_path = re.match(u".*{}/(.*{})".format(
-                    formatted_path, item["name"]), item["path"]).group(1)
+                    re.escape(formatted_path), re.escape(item["name"])),
+                    item["path"]).group(1)
             # otherwise give everything after the first /~/ or /
             else:
                 relative_path = re.match(u"(/~)*/(.*{})".format(
-                    item["name"]), item["path"]).group(2)
+                    re.escape(item["name"])), item["path"]).group(2)
 
             return relative_path + final_slash
         else:

--- a/globus_cli/services/recursive_ls.py
+++ b/globus_cli/services/recursive_ls.py
@@ -1,0 +1,129 @@
+# TDOD: Remove this file when endpoints natively support recursive ls
+
+import logging
+import time
+from collections import deque
+
+from globus_sdk.response import GlobusResponse
+from globus_sdk.transfer.paging import PaginatedResource
+
+logger = logging.getLogger(__name__)
+
+# constants for controlling rate limiting
+SLEEP_FREQUENCY = 25
+SLEEP_LEN = 1
+
+
+class RecursiveLsResponse(PaginatedResource):
+    """
+    Response class for recursive_operation_ls
+    Uses PaginatedResource logic for iterating over potentially very
+    large file systems without keeping the whole filesystem in memory,
+    but rather than using Globus paging uses an internal queue
+    for BFS of the filesystem.
+    Rate limits calls to prevent getting back connection errors.
+    """
+    def __init__(self, client, endpoint_id,
+                 max_depth, filter_after_first, ls_params):
+        """
+        **Parameters**
+          ``client``
+            A `TransferClient`` used for making the operation_ls calls.
+          ``endpoint_id``
+            The endpoint that will be recursively ls'ed.
+          ``max_depth``
+            The maximum depth the recursive ls will go into the file system.
+          ``filter_after_first``
+            If True, any filter in ``ls_params`` will be applied to all calls
+            If False, any filter in ``ls_params`` will only be applied to the
+            first ls.
+          ``ls_params``
+            Query params sent to operation_ls, see operation_ls for more
+            details.
+        """
+        logger.info("Creating RecursiveLsResponse on path {} of endpoint {}"
+                    .format(ls_params.get("path"), endpoint_id))
+
+        self.client = client
+        self.endpoint_id = endpoint_id
+        self.ls_params = ls_params
+        self.max_depth = max_depth
+        self.filter_after_first = filter_after_first
+        self.filtering = True
+        self.ls_count = 0
+
+        # queue of (path, depth) tuples.
+        self.queue = deque()
+        # initialized with the start path (if any) and a depth of 0
+        self.queue.append((self.ls_params.get("path"), 0))
+
+        # call the iterable_func method to convert it to a generator expression
+        self.generator = self.iterable_func()
+
+        # grab the first element out of the internal iteration function
+        # because this could raise a StopIteration exception, we need to be
+        # careful and make sure that such a condition is respected (and
+        # replicated as an iterable of length 0)
+        try:
+            self.first_elem = next(self.generator)
+        except StopIteration:
+            # express this internally as "generator is null" -- just need some
+            # way of making sure that it's clear
+            self.generator = None
+
+    def iterable_func(self):
+        """
+        An internal function which has generator semantics. Defined using the
+        `yield` syntax.
+        Used to grab the first element during class initialization, and
+        subsequently on calls to `next()` to get the remaining elements.
+        We rely on the implicit StopIteration built into this type of function
+        to propagate through the final `next()` call.
+        """
+        # BFS is not done until the queue is empty
+        while self.queue:
+            logger.debug(("recursive_operation_ls BFS queue not empty, "
+                          "getting next path now."))
+
+            # rate limit based on number of ls calls we have made
+            self.ls_count += 1
+            if self.ls_count % SLEEP_FREQUENCY == 0:
+                logger.debug(("recursive_operation_ls sleeping {} seconds to "
+                              "rate limit itself.".format(SLEEP_LEN)))
+                time.sleep(SLEEP_LEN)
+
+            # get path and current depth from the queue
+            path, depth = self.queue.pop()
+
+            # set the target path to the popped path if it exists
+            if path:
+                self.ls_params["path"] = path
+
+            # if filter_after_first is False, stop filtering after the first
+            # ls call has been made
+            if not self.filter_after_first:
+                if self.filtering:
+                    self.filtering = False
+                else:
+                    try:
+                        self.ls_params.pop("filter")
+                    except KeyError:
+                        pass
+
+            # do the operation_ls with the updated params
+            res = self.client.operation_ls(self.endpoint_id, **self.ls_params)
+            res_data = res["DATA"]
+
+            # for each item in the response data include the item's path with
+            # the response data since top level fields are no longer visible,
+            # and yield the item
+            for item in res_data:
+                item["path"] = res["path"] + item["name"]
+                yield GlobusResponse(item)
+
+            # if we aren't at the depth limit, add dir entries to the queue.
+            # data is reversed to maintain any "orderby" ordering
+            if depth < self.max_depth:
+                self.queue.extend([(i["path"], depth + 1)
+                                   for i in reversed(res_data)
+                                   if i["type"] == "dir"])

--- a/globus_cli/services/transfer.py
+++ b/globus_cli/services/transfer.py
@@ -12,11 +12,13 @@ except ImportError:
 
 from globus_sdk import TransferClient, RefreshTokenAuthorizer
 from globus_sdk.exc import NetworkError
+from globus_sdk.base import safe_stringify
 
 from globus_cli import version
 from globus_cli.safeio import safeprint
 from globus_cli.config import (
     get_transfer_tokens, internal_auth_client, set_transfer_access_token)
+from globus_cli.services.recursive_ls import RecursiveLsResponse
 
 
 class RetryingTransferClient(TransferClient):
@@ -58,6 +60,45 @@ class RetryingTransferClient(TransferClient):
     def submit_delete(self, *args, **kwargs):
         return self.retry(super(
             RetryingTransferClient, self).submit_delete, *args, **kwargs)
+
+    # TDOD: Remove this function when endpoints natively support recursive ls
+    def recursive_operation_ls(self, endpoint_id,
+                               depth=3, filter_after_first=True, **params):
+        """
+        Makes recursive calls to ``GET /operation/endpoint/<endpoint_id>/ls``
+        Does not preserve access to top level operation_ls fields, but
+        adds a "path" field for every item that represents the full
+        path to that item.
+        :rtype: iterable of :class:`GlobusResponse
+                <globus_sdk.response.GlobusResponse>`
+        **Parameters**
+            ``endpoint_id`` (*string*)
+              The endpoint being recursively ls'ed. If no "path" is given in
+              params, the start path is determined by this endpoint.
+            ``depth`` (*int*)
+              The maximum file depth the recursive ls will go to.
+            ``filter_after_first`` (*bool*)
+              If False, any "filter" in params will only be applied to the
+              first, top level ls, all results beyond that will be unfiltered.
+            ``params``
+              Parameters that will be passed through as query params.
+        **Examples**
+        >>> tc = globus_sdk.TransferClient(...)
+        >>> for entry in tc.recursive_operation_ls(ep_id, path="/~/project1/"):
+        >>>     print(entry["path"], entry["type"])
+        **External Documentation**
+        See
+        `List Directory Contents \
+        <https://docs.globus.org/api/transfer/file_operations/#list_directory_contents>`_
+        in the REST documentation for details, but note that top level data
+        fields are no longer available and an additional per item
+        "path" field is added.
+        """
+        endpoint_id = safe_stringify(endpoint_id)
+        self.logger.info("TransferClient.recursive_operation_ls({}, {}, {})"
+                         .format(endpoint_id, depth, params))
+        return RecursiveLsResponse(self, endpoint_id,
+                                   depth, filter_after_first, params)
 
 
 def _update_access_tokens(token_response):

--- a/tests/unit/test_ls.py
+++ b/tests/unit/test_ls.py
@@ -40,4 +40,4 @@ class LsTests(CliTestCase):
         """
         output = self.run_line("globus ls -r -F json {}:/".format(GO_EP1_ID))
         self.assertIn('"DATA":', output)
-        self.assertIn('"path": "/share/godata/file1.txt"', output)
+        self.assertIn('"name": "share/godata/file1.txt"', output)

--- a/tests/unit/test_ls.py
+++ b/tests/unit/test_ls.py
@@ -1,0 +1,43 @@
+from tests.framework.cli_testcase import CliTestCase
+from tests.framework.constants import GO_EP1_ID
+
+
+class LsTests(CliTestCase):
+    """
+    Tests globus ls command
+    """
+
+    def test_path(self):
+        """
+        Does an ls on EP1:/, confirms expected results.
+        """
+        path = "/"
+        output = self.run_line("globus ls {}:{}".format(GO_EP1_ID, path))
+
+        expected = ["home/", "mnt/", "not shareable/", "share/"]
+        for item in expected:
+            self.assertIn(item, output)
+
+    def test_recursive(self):
+        """
+        Confirms --recursive ls on EP1:/share/ finds file1.txt
+        """
+        output = self.run_line("globus ls -r {}:/share/".format(GO_EP1_ID))
+        self.assertIn("file1.txt", output)
+
+    def test_depth(self):
+        """
+        Confirms setting depth to 1 on a --recursive ls of EP1:/
+        finds godata but not file1.txt
+        """
+        output = self.run_line(("globus ls -r --recursive-depth-limit 1 {}:/"
+                                .format(GO_EP1_ID)))
+        self.assertNotIn("file1.txt", output)
+
+    def test_recursive_json(self):
+        """
+        Confirms -F json works with the RecursiveLsResponse
+        """
+        output = self.run_line("globus ls -r -F json {}:/".format(GO_EP1_ID))
+        self.assertIn('"DATA":', output)
+        self.assertIn('"path": "/share/godata/file1.txt"', output)


### PR DESCRIPTION
Ports https://github.com/globus/globus-sdk-python/pull/214 into the CLI as suggested on that PR.

This should be replaced whenever Transfer eventually supports native recursive ls on endpoints, but for now this should resolve #46
