### PR TITLE
Update Travis builds to run on Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+dist: trusty
+
 language: python
 python:
   - "2.7"
@@ -6,16 +8,12 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  # allow failures on CPython dev and pypy
+  # allow failures on CPython dev
   # we want to be warned about these, but they aen't critical
   - "3.7-dev"
-  - "pypy"
-  - "pypy3"
 matrix:
   allow_failures:
     - python: "3.7-dev"
-    - python: "pypy"
-    - python: "pypy3"
 cache: pip
 script:
   - make travis


### PR DESCRIPTION
Per [a recent update](https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2) Travis' new Ubuntu 14.04 infrastructure is rolling out.
It's very unclear from their blog entries whether or not this applies to our builds (`sudo: false`), but I'm guessing that _something_ changed.

See if this builds correctly, and if so, let's switch over?