### PR TITLE
Managed endpoint options

### DIFF
--- a/adoc/include/endpoint_options.adoc
+++ b/adoc/include/endpoint_options.adoc
@@ -45,7 +45,7 @@ Set this endpoint to be (in)visible to other users searching for endpoints.
 (Globus Connect Server endpoints only, all Globus Connect Personal endpoints 
 are private and all shared endpoints are public)
 
-*--myproxy-dn* 'DOMANIN_NAME'::
+*--myproxy-dn* 'DOMAIN_NAME'::
 
 Set the MyProxy Server domain name for this endpoint.
 (Globus Connect Server endpoints only)
@@ -65,6 +65,18 @@ Set the OAuth Server URI for this endpoint
 Manually set this endpoint's latitude and longitude with two comma
 separated floats. Overrides automatic location approximation.
 (Globus Connect Server endpoints only)
+
+*--managed/--no-managed*::
+
+(Un)set this endpoint as a managed endpoint. If setting, the user must be
+a subscription manager, and the user's default subscription ID will be used.
+If the user has more than one subscription ID, --subscription-id must be used
+instead to specify one of them. Mutually exclusive with --subscription-id.
+
+*--subscription-id* 'SUBSCRIPTION_ID'::
+
+Set the endpoint as managed with the given subscription ID. Mutually
+exclusive with --managed/--no-managed.
 
 *--network-use* '[ normal | minimal | aggressive | custom ]'::
 

--- a/adoc/include/endpoint_options.adoc
+++ b/adoc/include/endpoint_options.adoc
@@ -71,12 +71,13 @@ separated floats. Overrides automatic location approximation.
 (Un)set this endpoint as a managed endpoint. If setting, the user must be
 a subscription manager, and the user's default subscription ID will be used.
 If the user has more than one subscription ID, --subscription-id must be used
-instead to specify one of them. Mutually exclusive with --subscription-id.
+instead to specify one of them. --no-managed is mutually exclusive with
+--subscription-id.
 
 *--subscription-id* 'SUBSCRIPTION_ID'::
 
 Set the endpoint as managed with the given subscription ID. Mutually
-exclusive with --managed/--no-managed.
+exclusive with --no-managed.
 
 *--network-use* '[ normal | minimal | aggressive | custom ]'::
 

--- a/globus_cli/commands/endpoint/update.py
+++ b/globus_cli/commands/endpoint/update.py
@@ -33,6 +33,6 @@ def endpoint_update(**kwargs):
         endpoint_type, get_res["subscription_id"], kwargs)
 
     # make the update
-    ep_doc = assemble_generic_doc('endpoint', **kwargs)
+    ep_doc = assemble_generic_doc('endpoint', include_nones=True, **kwargs)
     res = client.update_endpoint(endpoint_id, ep_doc)
     formatted_print(res, text_format=FORMAT_TEXT_RAW, response_key='message')

--- a/globus_cli/commands/endpoint/update.py
+++ b/globus_cli/commands/endpoint/update.py
@@ -33,6 +33,6 @@ def endpoint_update(**kwargs):
         endpoint_type, get_res["subscription_id"], kwargs)
 
     # make the update
-    ep_doc = assemble_generic_doc('endpoint', include_nones=True, **kwargs)
+    ep_doc = assemble_generic_doc('endpoint', **kwargs)
     res = client.update_endpoint(endpoint_id, ep_doc)
     formatted_print(res, text_format=FORMAT_TEXT_RAW, response_key='message')

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -9,6 +9,8 @@ from globus_cli.parsing.endpoint_plus_path import (
 from globus_cli.parsing.hidden_option import HiddenOption
 from globus_cli.parsing.iso_time import ISOTimeType
 
+from globus_cli.parsing.explicit_null import EXPLICIT_NULL
+
 from globus_cli.parsing.shared_options import (
     common_options, endpoint_id_arg, task_id_arg, task_submission_options,
     endpoint_create_and_update_params,
@@ -33,6 +35,8 @@ __all__ = [
 
     'HiddenOption',
     'ISOTimeType',
+
+    'EXPLICIT_NULL',
 
     'common_options',
     # Transfer options

--- a/globus_cli/parsing/explicit_null.py
+++ b/globus_cli/parsing/explicit_null.py
@@ -1,0 +1,7 @@
+__all__ = ['EXPLICIT_NULL']
+
+
+# this object is a sentinel value used to disambiguate values which are being
+# intentionally nulled from values which are incidentally `None` because no
+# argument was provided
+EXPLICIT_NULL = object()

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -250,12 +250,13 @@ def validate_endpoint_create_and_update_params(endpoint_type, managed, params):
     managed_flag = params.get("managed")
     if managed_flag is not None:
         params.pop("managed")
-        if params.get("subscription_id"):
-            raise click.UsageError("Cannot specify --subscription-id and use "
-                                   "the --managed/--no-managed option.")
         if managed_flag:
-            params["subscription_id"] = "DEFAULT"
+            params["subscription_id"] = (params.get("subscription_id") or
+                                         "DEFAULT")
         else:
+            if params.get("subscription_id"):
+                raise click.UsageError("Cannot specify --subscription-id and "
+                                       "use the --no-managed option.")
             params["subscription_id"] = EXPLICIT_NULL
 
 

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -7,6 +7,7 @@ from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
 from globus_cli.parsing.detect_and_decorate import detect_and_decorate
 from globus_cli.parsing.location import LocationType
 from globus_cli.parsing.iso_time import ISOTimeType
+from globus_cli.parsing.explicit_null import EXPLICIT_NULL
 
 
 def common_options(*args, **kwargs):
@@ -243,12 +244,6 @@ def validate_endpoint_create_and_update_params(endpoint_type, managed, params):
                     ("Option --{} can only be used with managed "
                      "endpoints".format(option.replace("_", "-"))))
 
-    # remove any options set to None so include_nones can be set to
-    # true for endpoint update (allows nulling out fields)
-    for key, val in list(params.items()):
-        if val is None:
-            del params[key]
-
     # make sure --(no-)managed and --subscription-id are mutually exclusive
     # if --managed given pass DEFAULT as the subscription_id
     # if --no-managed given, pass None
@@ -261,7 +256,7 @@ def validate_endpoint_create_and_update_params(endpoint_type, managed, params):
         if managed_flag:
             params["subscription_id"] = "DEFAULT"
         else:
-            params["subscription_id"] = None
+            params["subscription_id"] = EXPLICIT_NULL
 
 
 def task_id_arg(*args, **kwargs):

--- a/globus_cli/services/transfer.py
+++ b/globus_cli/services/transfer.py
@@ -18,6 +18,7 @@ from globus_cli import version
 from globus_cli.safeio import safeprint
 from globus_cli.config import (
     get_transfer_tokens, internal_auth_client, set_transfer_access_token)
+from globus_cli.parsing import EXPLICIT_NULL
 from globus_cli.services.recursive_ls import RecursiveLsResponse
 
 
@@ -138,12 +139,15 @@ def iterable_response_to_dict(iterator):
     return output_dict
 
 
-def assemble_generic_doc(datatype, include_nones=False, **kwargs):
+def assemble_generic_doc(datatype, **kwargs):
     doc = {'DATA_TYPE': datatype}
     for key, val in kwargs.items():
         if isinstance(val, uuid.UUID):
             val = str(val)
-        if include_nones or val is not None:
+
+        if val == EXPLICIT_NULL:
+            doc[key] = None
+        elif val is not None:
             doc[key] = val
     return doc
 

--- a/globus_cli/services/transfer.py
+++ b/globus_cli/services/transfer.py
@@ -138,12 +138,12 @@ def iterable_response_to_dict(iterator):
     return output_dict
 
 
-def assemble_generic_doc(datatype, **kwargs):
+def assemble_generic_doc(datatype, include_nones=False, **kwargs):
     doc = {'DATA_TYPE': datatype}
     for key, val in kwargs.items():
         if isinstance(val, uuid.UUID):
             val = str(val)
-        if val is not None:
+        if include_nones or val is not None:
             doc[key] = val
     return doc
 

--- a/tests/unit/test_ls.py
+++ b/tests/unit/test_ls.py
@@ -38,6 +38,7 @@ class LsTests(CliTestCase):
         """
         Confirms -F json works with the RecursiveLsResponse
         """
-        output = self.run_line("globus ls -r -F json {}:/".format(GO_EP1_ID))
+        output = self.run_line(
+            "globus ls -r -F json {}:/share".format(GO_EP1_ID))
         self.assertIn('"DATA":', output)
-        self.assertIn('"name": "share/godata/file1.txt"', output)
+        self.assertIn('"name": "godata/file1.txt"', output)


### PR DESCRIPTION
Resolves #134 as we are no longer blocked as of transfer 5.6

Adds `--managed/--no-managed` and un-hides `--subscription-id` from endpoint create and update.
I made`--managed/--no-managed` and `--subscription-id` mutually exclusive as that seemed the least likely to cause confusion.

`--managed` passes the magic "DEFAULT" value as the subscription id as discussed on slack.

`--no-managed` passes `None` which required a workaround since `assemble_generic_doc` removed all fields with a value of `None`. We may want to allow passing None to remove other fields as well?

Unit tests aren't feasible without giving public access to a subscription ID, but all of my manual tests worked as expected.