### PR TITLE
Set encoding=utf-8 on ConfigObj

### DIFF
--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -84,7 +84,7 @@ def get_config_obj(system=False):
     else:
         path = os.path.expanduser("~/.globus.cfg")
 
-    return ConfigObj(path)
+    return ConfigObj(path, encoding='utf-8')
 
 
 def lookup_option(option, section='cli', environment=None):

--- a/globus_cli/safeio/output_formatter.py
+++ b/globus_cli/safeio/output_formatter.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import six
 


### PR DESCRIPTION
This is used for loading and writing `~/.globus.cfg`
Setting the encoding allows ConfigObj to correctly handle unicode strings and does not conflict with existing file contents in ascii-only files.
Tested manually -- it's not clear at present how this should be added to the testsuite, since tests currently run against _real_ configuration data.