### PR TITLE
Fix testsuite 400s

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-exclude = .git,__pycache__,.eggs,dist,venv,.venv,venv27,virtualenv,docs,build,docs-source
+exclude = .git,__pycache__,.eggs,dist,venv,.venv,venv27,.venv3,venv3,virtualenv,docs,build,docs-source

--- a/tests/unit/test_bookmark_commands.py
+++ b/tests/unit/test_bookmark_commands.py
@@ -53,8 +53,9 @@ class BookmarkTests(CliTestCase):
                  'path': '/home/',
                  'name': self.bm1name})
             self.bm1id = res['id']
-        finally:
+        except (GlobusAPIError, NetworkError):
             self._clean()
+            raise
 
     def tearDown(self):
         self._clean()

--- a/tests/unit/test_endpoint_create.py
+++ b/tests/unit/test_endpoint_create.py
@@ -140,7 +140,8 @@ class EndpointCreateTests(CliTestCase):
         # options with the same option value and expected value
         same_value_dict = [
             {"opt": "--myproxy-dn", "key": "myproxy_dn", "val": "/dn"},
-            {"opt": "--myproxy-server", "key": "myproxy_server", "val": "srv"},
+            {"opt": "--myproxy-server", "key": "myproxy_server",
+             "val": "srv.example.com"},
         ]
         # options that have differing option values and expected values
         diff_value_dict = [
@@ -174,7 +175,8 @@ class EndpointCreateTests(CliTestCase):
         Confirms invalid options are caught at the CLI level rather than API
         """
         options = ["--public", "--private", "--myproxy-dn /dn",
-                   "--myproxy-server mpsrv", "--oauth-server oasrv",
+                   "--myproxy-server mpsrv.example.com",
+                   "--oauth-server oasrv.example.com",
                    "--location 1,1"]
         for opt in options:
             for ep_type in ["--shared {}:/~/".format(GO_EP1_ID),

--- a/tests/unit/test_endpoint_update.py
+++ b/tests/unit/test_endpoint_update.py
@@ -81,7 +81,8 @@ class EndpointCreateTests(CliTestCase):
         # options with the same option value and expected value
         same_value_dict = [
             {"opt": "--myproxy-dn", "key": "myproxy_dn", "val": "/dn"},
-            {"opt": "--myproxy-server", "key": "myproxy_server", "val": "srv"},
+            {"opt": "--myproxy-server", "key": "myproxy_server",
+             "val": "srv.example.com"},
         ]
         # options that have differing option values and expected values
         diff_value_dict = [
@@ -113,7 +114,8 @@ class EndpointCreateTests(CliTestCase):
         Confirms invalid options are caught at the CLI level rather than API
         """
         options = ["--public", "--private", "--myproxy-dn /dn",
-                   "--myproxy-server mpsrv", "--oauth-server oasrv",
+                   "--myproxy-server mpsrv.example.com",
+                   "--oauth-server oasrv.example.com",
                    "--location 1,1"]
         for opt in options:
             for ep_id in [self.shared_ep, self.personal_ep]:


### PR DESCRIPTION
Transfer didn't used to validate the format of some servername fields, but it has started to. Put the hostnames all under `example.com` to pass validation.

Also, the use of a `try-finally` to fix linting was a misreading of the prior logic. `finally` runs even if the `try` succeeds, of course, but `self._clean()` should only run if things fail -- `tearDown` handles running it otherwise.

Fixing these two issues _should_ get us a passing testsuite.