### PR TITLE
Cert validity timestamps now use UTC

### DIFF
--- a/globus_cli/helpers/delegate_proxy.py
+++ b/globus_cli/helpers/delegate_proxy.py
@@ -147,9 +147,9 @@ def create_proxy_cert(loaded_cert, loaded_private_key,
     builder = builder.serial_number(serial)
 
     # set the new proxy as valid from now until lifetime_hours have passed
-    builder = builder.not_valid_before(datetime.datetime.today())
+    builder = builder.not_valid_before(datetime.datetime.utcnow())
     builder = builder.not_valid_after(
-        datetime.datetime.today() + datetime.timedelta(hours=lifetime_hours))
+        datetime.datetime.utcnow() + datetime.timedelta(hours=lifetime_hours))
 
     # set the public key of the new proxy to the given public key
     builder = builder.public_key(loaded_public_key)


### PR DESCRIPTION
If you live in GMT-plus-something land (Europe or Asia) the certs generated by create_proxy_cert() will not be valid for some hours because it inserts the local time. But GMT+N is for UTC "The Future". Having a "not yet valid" cert sucks really hard. Now it will use UTC to generate the cert and everything is rainbows.