### PR TITLE
Avoid user confusion around --network-use=custom

### DIFF
--- a/adoc/include/endpoint_options.adoc
+++ b/adoc/include/endpoint_options.adoc
@@ -82,25 +82,25 @@ exclusive with --no-managed.
 *--network-use* '[ normal | minimal | aggressive | custom ]'::
 
 Set this endpoint's network use level. If using custom, this endpoint's max
-and preferred concurrency must be set. (Managed endpoints only) 
+and preferred concurrency and parallelism must be set. (Managed endpoints only) 
 (Globus Connect Server endpoints only)
 
 *--max-concurrency* 'INT'::
 
-Set this endpoint's max concurrency
+Set this endpoint's max concurrency; requires --network-use=custom
 (Managed endpoints only) (Globus Connect Server endpoints only)
 
 *--preferred-concurrency* 'INT'::
 
-Set this endpoint's preferred concurrency
+Set this endpoint's preferred concurrency; requires --network-use=custom
 (Managed endpoints only) (Globus Connect Server endpoints only)
 
 *--max-parallelism* 'INT'::
 
-Set this endpoint's max parallelism
+Set this endpoint's max parallelism; requires --network-use=custom
 (Managed endpoints only) (Globus Connect Server endpoints only)
 
 *--preferred-parallelism* 'INT'::
 
-Set this endpoint's preferred parallelism
+Set this endpoint's preferred parallelism; requires --network-use=custom
 (Managed endpoints only) (Globus Connect Server endpoints only)

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -188,23 +188,28 @@ def endpoint_create_and_update_params(*args, **kwargs):
             "--network-use", default=None,
             type=click.Choice(["normal", "minimal", "aggressive", "custom"]),
             help=("Set the endpoint's network use level. If using custom, "
-                  "the endpoint's max and preferred concurrency must be set "
+                  "the endpoint's max and preferred concurrency and "
+                  "parallelism must be set "
                   "(Managed endpoints only) (Globus Connect Server only)"))(f)
         f = click.option(
             "--max-concurrency", type=int, default=None,
-            help=("Set the endpoint's max concurrency "
+            help=("Set the endpoint's max concurrency; "
+                  "requires --network-use=custom "
                   "(Managed endpoints only) (Globus Connect Server only)"))(f)
         f = click.option(
             "--preferred-concurrency", type=int, default=None,
-            help=("Set the endpoint's preferred concurrency "
+            help=("Set the endpoint's preferred concurrency; "
+                  "requires --network-use=custom "
                   "(Managed endpoints only) (Globus Connect Server only)"))(f)
         f = click.option(
             "--max-parallelism", type=int, default=None,
-            help=("Set the endpoint's max parallelism "
+            help=("Set the endpoint's max parallelism; "
+                  "requires --network-use=custom "
                   "(Managed endpoints only) (Globus Connect Server only)"))(f)
         f = click.option(
             "--preferred-parallelism", type=int, default=None,
-            help=("Set the endpoint's preferred parallelism "
+            help=("Set the endpoint's preferred parallelism; "
+                  "requires --network-use=custom "
                   "(Managed endpoints only) (Globus Connect Server only)"))(f)
 
         return f

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -244,6 +244,33 @@ def validate_endpoint_create_and_update_params(endpoint_type, managed, params):
                     ("Option --{} can only be used with managed "
                      "endpoints".format(option.replace("_", "-"))))
 
+    # because the Transfer service doesn't do network use level updates in a
+    # patchy way, *both* endpoint `POST`s *and* `PUT`s must either use
+    # - `network_use='custom'` with *every* other parameter specified, or
+    # - a preset/absent `network_use` with *no* other parameter specified (in
+    #   this case, Transfer will accept but ignore the others parameters if
+    #   given, leading to user confusion if we don't do this validation check)
+    custom_network_use_params = ('max_concurrency', 'preferred_concurrency',
+                                 'max_parallelism', 'preferred_parallelism')
+    if params['network_use'] == 'custom':
+        for option in custom_network_use_params:
+            if params[option] is None:
+                raise click.UsageError(
+                    "When using --network-use=custom, you must specify all "
+                    "{} parameters: {}".
+                    format(len(custom_network_use_params),
+                           ", ".join("--" + option.replace("_", "-")
+                                     for option in custom_network_use_params))
+                )
+    else:
+        for option in custom_network_use_params:
+            if params[option] is not None:
+                raise click.UsageError(
+                    "The {} options require you use --network-use=custom.".
+                    format("/".join("--" + option.replace("_", "-")
+                                    for option in custom_network_use_params))
+                )
+
     # make sure --(no-)managed and --subscription-id are mutually exclusive
     # if --managed given pass DEFAULT as the subscription_id
     # if --no-managed given, pass None

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -246,23 +246,15 @@ def validate_endpoint_create_and_update_params(endpoint_type, managed, params):
 
     # because the Transfer service doesn't do network use level updates in a
     # patchy way, *both* endpoint `POST`s *and* `PUT`s must either use
-    # - `network_use='custom'` with *every* other parameter specified, or
-    # - a preset/absent `network_use` with *no* other parameter specified (in
-    #   this case, Transfer will accept but ignore the others parameters if
-    #   given, leading to user confusion if we don't do this validation check)
+    # - `network_use='custom'` with *every* other parameter specified (which
+    #   is validated by the service), or
+    # - a preset/absent `network_use` with *no* other parameter specified
+    #   (which is *not* validated by the service; in this case, Transfer will
+    #   accept but ignore the others parameters if given, leading to user
+    #   confusion if we don't do this validation check)
     custom_network_use_params = ('max_concurrency', 'preferred_concurrency',
                                  'max_parallelism', 'preferred_parallelism')
-    if params['network_use'] == 'custom':
-        for option in custom_network_use_params:
-            if params[option] is None:
-                raise click.UsageError(
-                    "When using --network-use=custom, you must specify all "
-                    "{} parameters: {}".
-                    format(len(custom_network_use_params),
-                           ", ".join("--" + option.replace("_", "-")
-                                     for option in custom_network_use_params))
-                )
-    else:
+    if params['network_use'] != 'custom':
         for option in custom_network_use_params:
             if params[option] is not None:
                 raise click.UsageError(


### PR DESCRIPTION
Submissions around the endpoint network performance parameters are tricky and can lead to user confusion if we do not validate that the set of parameters used will actually be accepted/persisted by the Transfer service.

cc @ranantha 
cc @karlito-go

For updates, I'm not passing the old `network_use` value (like is done with `managed`) as the Transfer service doesn't do patchy updates on `network_use` -- if you want to set the `network_use` fields, you need to do them altogether -- if we wanted to make this so the user could specify fewer parameters, we could do so, it would probably just mean some munging in the update function before this validation one gets called.