### PR TITLE
Make setup.py error early on py26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,14 @@
 import os
+import sys
 from setuptools import setup, find_packages
+
+
+if sys.version_info < (2, 7):
+    raise NotImplementedError("""\n
+##############################################################
+# globus-cli does not support python versions older than 2.7 #
+##############################################################""")
+
 
 # single source of truth for package version
 version_ns = {}


### PR DESCRIPTION
Prevents potentially confusing messages from loading and executing the version.py (which blows up on 2.6 for daring to use a format string).

Closes #359

---

Error prior to the change:
```
$ pip install -e globus-cli
Obtaining file:///home/sirosen/dev/globus/globus-cli
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/sirosen/dev/globus/globus-cli/setup.py", line 7, in <module>
        exec(f.read(), version_ns)
      File "<string>", line 8, in <module>
    ValueError: zero length field name in format
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /home/sirosen/dev/globus/globus-cli/
```

Error after the change:
```
$ pip install -e globus-cli
Obtaining file:///home/sirosen/dev/globus/globus-cli
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/sirosen/dev/globus/globus-cli/setup.py", line 10, in <module>
        ##############################################################""")
    NotImplementedError:
    
    ##############################################################
    # globus-cli does not support python versions older than 2.7 #
    ##############################################################
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /home/sirosen/dev/globus/globus-cli/
```