### PR TITLE
Fix zsh compdef to not reinit completion

### DIFF
--- a/shell_completion/zsh_complete.sh
+++ b/shell_completion/zsh_complete.sh
@@ -5,7 +5,4 @@ _globus() {
         eval "$(env COMMANDLINE="${words[1,$CURRENT]}" globus --shell-complete ZSH)"
     fi
 }
-if [[ "$(basename "${(%):-%x}")" != "_globus" ]]; then
-    autoload -U compinit && compinit
-    compdef _globus globus
-fi
+compdef _globus globus


### PR DESCRIPTION
Leftover from early experimentation with zsh completion, the compinit directive dumps any completion directives loaded thusfar. That makes it unsafe to include at the end of your config.