### PR TITLE
Add --skip-activation-check option

### DIFF
--- a/adoc/include/task_submission_options.adoc
+++ b/adoc/include/task_submission_options.adoc
@@ -22,3 +22,10 @@ a task with the same submission id in case of unreliable networks.
 Note that this is not the same id as the task's id once it is submitted.
 If not specified the Globus CLI will still generate a submission id and safely
 resubmit tasks on network errors.
+
+*--skip-activation-check*::
+
+Submit the task even if one or more of the target endpoints are not currently
+activated. Once all target endpoints have been activated the task will begin
+normally. If this option is given, auto-activation will not be attempted
+on the target endpoints.

--- a/globus_cli/commands/delete.py
+++ b/globus_cli/commands/delete.py
@@ -28,7 +28,8 @@ from globus_cli.services.transfer import get_client, autoactivate
 @click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
                 type=ENDPOINT_PLUS_OPTPATH)
 def delete_command(batch, ignore_missing, recursive, endpoint_plus_path,
-                   label, submission_id, dry_run, deadline):
+                   label, submission_id, dry_run, deadline,
+                   skip_activation_check):
     """
     Executor for `globus delete`
     """
@@ -38,14 +39,18 @@ def delete_command(batch, ignore_missing, recursive, endpoint_plus_path,
             'delete requires either a PATH OR --batch')
 
     client = get_client()
-    autoactivate(client, endpoint_id, if_expires_in=60)
+
+    # attempt to activate unless --skip-activation-check is given
+    if not skip_activation_check:
+        autoactivate(client, endpoint_id, if_expires_in=60)
 
     delete_data = DeleteData(client, endpoint_id,
                              label=label,
                              recursive=recursive,
                              ignore_missing=ignore_missing,
                              submission_id=submission_id,
-                             deadline=deadline)
+                             deadline=deadline,
+                             skip_activation_check=skip_activation_check)
 
     if batch:
         # although this sophisticated structure (like that in transfer)

--- a/globus_cli/commands/transfer.py
+++ b/globus_cli/commands/transfer.py
@@ -94,7 +94,7 @@ from globus_cli.services.transfer import get_client, autoactivate
                 type=ENDPOINT_PLUS_OPTPATH)
 def transfer_command(batch, sync_level, recursive, destination, source, label,
                      preserve_mtime, verify_checksum, encrypt, submission_id,
-                     dry_run, delete, deadline):
+                     dry_run, delete, deadline, skip_activation_check):
     """
     Executor for `globus transfer`
     """
@@ -118,7 +118,7 @@ def transfer_command(batch, sync_level, recursive, destination, source, label,
         label=label, sync_level=sync_level, verify_checksum=verify_checksum,
         preserve_timestamp=preserve_mtime, encrypt_data=encrypt,
         submission_id=submission_id, delete_destination_extra=delete,
-        deadline=deadline)
+        deadline=deadline, skip_activation_check=skip_activation_check)
 
     if batch:
         @click.command()
@@ -151,8 +151,10 @@ def transfer_command(batch, sync_level, recursive, destination, source, label,
         return
 
     # autoactivate after parsing all args and putting things together
-    autoactivate(client, source_endpoint, if_expires_in=60)
-    autoactivate(client, dest_endpoint, if_expires_in=60)
+    # skip this if skip-activation-check is given
+    if not skip_activation_check:
+        autoactivate(client, source_endpoint, if_expires_in=60)
+        autoactivate(client, dest_endpoint, if_expires_in=60)
 
     res = client.submit_transfer(transfer_data)
     formatted_print(res, text_format=FORMAT_TEXT_RECORD,

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -325,9 +325,12 @@ def task_submission_options(f):
             "presence of network failures."))(f)
     f = click.option(
         "--label", default=None, help="Set a label for this task.")(f)
-    f = f = click.option(
+    f = click.option(
         "--deadline", default=None, type=ISOTimeType(),
         help="Set a deadline for this to be canceled if not completed by.")(f)
+    f = click.option('--skip-activation-check', is_flag=True, help=(
+            "Submit the task even if the endpoint(s) "
+            "aren't currently activated."))(f)
 
     return f
 


### PR DESCRIPTION
Resolves #352 

This functionality can be tested automatically without re-visiting the current inability of the test suite to test against any non auto-activatable endpoints, but manual tests worked as expected.