### PR TITLE
`globus delete` prompt on trailing globs

### DIFF
--- a/adoc/delete.1.adoc
+++ b/adoc/delete.1.adoc
@@ -18,7 +18,7 @@ The *globus delete* command submits an asynchronous task that deletes files
 and/or directories on the target endpoint.
 
 *globus delete* has two modes. Single target, which deletes one
-file or one directory, and batch, which takes in several lines to delete 
+file or one directory, and batch, which takes in several lines to delete
 multiple files or directories. See "Batch Input" below for more information.
 
 Symbolic links are never followed - only unlinked (deleted).
@@ -29,12 +29,12 @@ include::include/cli_autoactivate.adoc[]
 
 == Batch Input
 
-If you give a SOURCE_PATH without the --batch flag, you will submit a 
+If you give a SOURCE_PATH without the --batch flag, you will submit a
 single-file or single-directory delete task. This has
 behavior similar to `cp` and `cp -r`, across endpoints.
 
 Using `--batch`, *globus delete* can submit a task which deletes
-multiple files or directories. Lines are taken from stdin, respecting quotes, 
+multiple files or directories. Lines are taken from stdin, respecting quotes,
 and every line is treated as a path to a file or directory to delete.
 
 Lines are of the form
@@ -69,6 +69,13 @@ if using batch input.
 
 Ignore nonexistent files and directories. The task will succeed even if given
 paths do not exist.
+
+*--star-silent, --unsafe*::
+
+Don't prompt when the trailing character is a "\*". Implicit in *--batch*.
++
+By default, 'globus delete $ep_id:~/foo*' will prompt before deleting if used
+in an interactive context.
 
 include::include/task_submission_options.adoc[]
 

--- a/globus_cli/safeio/__init__.py
+++ b/globus_cli/safeio/__init__.py
@@ -5,6 +5,8 @@ from globus_cli.safeio.output_formatter import (
 
     FORMAT_SILENT, FORMAT_JSON,
     FORMAT_TEXT_TABLE, FORMAT_TEXT_RECORD, FORMAT_TEXT_RAW)
+from globus_cli.safeio.check_pty import (
+    out_is_terminal, err_is_terminal, term_is_interactive)
 
 __all__ = [
     'safeprint',
@@ -17,5 +19,9 @@ __all__ = [
     'FORMAT_JSON',
     'FORMAT_TEXT_TABLE',
     'FORMAT_TEXT_RECORD',
-    'FORMAT_TEXT_RAW'
+    'FORMAT_TEXT_RAW',
+
+    'out_is_terminal',
+    'err_is_terminal',
+    'term_is_interactive',
 ]

--- a/globus_cli/safeio/check_pty.py
+++ b/globus_cli/safeio/check_pty.py
@@ -1,0 +1,14 @@
+import sys
+import os
+
+
+def out_is_terminal():
+    return sys.stdout.isatty()
+
+
+def err_is_terminal():
+    return sys.stderr.isatty()
+
+
+def term_is_interactive():
+    return os.getenv('PS1') is not None


### PR DESCRIPTION
I've often complained that `--unsafe` is underspecified for us to do anything useful. But I did note in the past that ZSH has a sane, easy-to-replicate behavior of only caring about trailing wildcards.

When used for an interactive command, `globus delete`, given an endpoint-plus-path on the command-line, will prompt before submitting a task with a trailing "*".
`--star-silent, --unsafe` can be used to suppress this behavior, resulting in no prompt.

Interactivity is checked explicitly, ensuring that stderr, where the prompt will be printed, is a pty. Add a small module to safeio for handling the pty checks on stderr, stdout (though we only use one here).

Closes #129

@jaswilli, @corpulentcoffee, I think this is an okay change? I'm not too frightened of maintaining this prompt long term.