### PR TITLE
Add --notify-{email,message} options to ACL create

### DIFF
--- a/adoc/endpoint_permission_create.1.adoc
+++ b/adoc/endpoint_permission_create.1.adoc
@@ -12,7 +12,7 @@ globus endpoint permission create - Create an access control rule
 
 == DESCRIPTION
 
-The *globus endpoint permission create* creates a new access control on the 
+The *globus endpoint permission create* creates a new access control on the
 the target endpoint granting users new permissions on the given path.
 
 The target endpoint must be a shared endpoint or an s3 endpoint, as only these
@@ -36,13 +36,22 @@ Give this permission to anyone who has logged in.
 
 Give this permission to anyone even if they aren't logged in.
 
-*--group* 'GROUP_ID'::                
+*--group* 'GROUP_ID'::
 
 Give this permission to anyone in the given group.
 
 *--identity* 'IDENTITY_ID_OR_NAME'::
 
 Give this permission to a specific identity in Globus Auth.
+
+*--notify-email* 'EMAIL_ADDRESS'::
+
+An email address to notify that the permission has been added.
+
+*--notify-message* 'TEXT'::
+
+A custom message to add to email notifications.
+
 
 include::include/common_options.adoc[]
 

--- a/globus_cli/commands/endpoint/permission/create.py
+++ b/globus_cli/commands/endpoint/permission/create.py
@@ -18,9 +18,15 @@ from globus_cli.services.transfer import get_client, assemble_generic_doc
 @click.option('--permissions', required=True,
               type=CaseInsensitiveChoice(('r', 'rw')),
               help='Permissions to add. Read-Only or Read/Write')
+@click.option('--notify-email', metavar='EMAIL_ADDRESS',
+              help=('An email address to notify that '
+                    'the permission has been added'))
+@click.option('--notify-message', metavar='MESSAGE',
+              help='A custom message to add to email notifications')
 @click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_REQPATH.metavar,
                 type=ENDPOINT_PLUS_REQPATH)
-def create_command(principal, permissions, endpoint_plus_path):
+def create_command(principal, permissions, endpoint_plus_path,
+                   notify_email, notify_message):
     """
     Executor for `globus endpoint permission create`
     """
@@ -43,9 +49,13 @@ def create_command(principal, permissions, endpoint_plus_path):
         principal_val = maybe_lookup_identity_id(principal_val, provision=True)
         principal_type = 'identity'
 
+    if not notify_email:
+        notify_message = None
+
     rule_data = assemble_generic_doc(
         'access', permissions=permissions, principal=principal_val,
-        principal_type=principal_type, path=path)
+        principal_type=principal_type, path=path,
+        notify_email=notify_email, notify_message=notify_message)
 
     res = client.add_endpoint_acl_rule(endpoint_id, rule_data)
     formatted_print(res, text_format=FORMAT_TEXT_RECORD,


### PR DESCRIPTION
`globus endpoint permission create` now has options to use `--notify-email` (an address) and `--notify-message` (a text message to embed).