### PR TITLE
Add globus endpoint local-id command

### DIFF
--- a/globus_cli/commands/endpoint/commands.py
+++ b/globus_cli/commands/endpoint/commands.py
@@ -14,6 +14,7 @@ from globus_cli.commands.endpoint.is_activated import endpoint_is_activated
 from globus_cli.commands.endpoint.deactivate import endpoint_deactivate
 from globus_cli.commands.endpoint.my_shared_endpoint_list import (
     my_shared_endpoint_list)
+from globus_cli.commands.endpoint.local_id import local_id
 
 
 @globus_group(name='endpoint', help='Manage Globus endpoint definitions')
@@ -38,3 +39,4 @@ endpoint_command.add_command(endpoint_is_activated)
 endpoint_command.add_command(endpoint_deactivate)
 
 endpoint_command.add_command(my_shared_endpoint_list)
+endpoint_command.add_command(local_id)

--- a/globus_cli/commands/endpoint/local_id.py
+++ b/globus_cli/commands/endpoint/local_id.py
@@ -1,0 +1,33 @@
+import click
+
+from globus_sdk import LocalGlobusConnectPersonal
+
+from globus_cli.safeio import safeprint
+from globus_cli.parsing import common_options, one_use_option
+
+
+@click.command(
+    'local-id',
+    help='Display UUID of locally installed endpoint')
+@common_options(no_format_option=True, no_map_http_status_option=True)
+@one_use_option(
+    "--personal",
+    is_flag=True,
+    default=True,
+    help='Use local Globus Connect Personal endpoint (default) ')
+def local_id(personal):
+    """
+    Executor for `globus endpoint local-id`
+    """
+    if personal:
+        try:
+            ep_id = LocalGlobusConnectPersonal().endpoint_id
+        except IOError as e:
+            safeprint(e, write_to_stderr=True)
+            click.get_current_context().exit(1)
+
+        if ep_id is not None:
+            safeprint(ep_id)
+        else:
+            safeprint('No Globus Connect Personal installation found.')
+            click.get_current_context().exit(1)


### PR DESCRIPTION
Closes #371 

I don't feel strongly about the name of the command. Suggestions welcome.

```
(venv) jason-mbp:globus-cli jtw$ globus endpoint local-gcp-uuid
No Globus Connect Personal installation found.
```

```
(venv) jason-mbp:globus-cli jtw$ globus endpoint local-gcp-uuid
62a5c95a-1b5b-11e8-b6eb-0ac6873fc732
```