### PR TITLE
Add --filter option to `globus ls`

### DIFF
--- a/adoc/ls.1.adoc
+++ b/adoc/ls.1.adoc
@@ -43,6 +43,23 @@ rate limits.
 Set the depth limit when using the --recursive option. Defaults to 3 if not
 given.
 
+*--filter* 'FILTER_PATTERN'::
+
+Filter results to filenames matching the given pattern.
++
+Filter patterns must start with `=`, `~`, `!`, or `!~`
+If none of these are given, `=` will be used
++
+`=` does exact matching
++
+`~` does regex matching, supporting globs (*)
++
+`!` does inverse `=` matching
++
+`!~` does inverse `~` matching
++
+See the examples section for various forms of usage.
+
 include::include/common_options.adoc[]
 
 
@@ -52,14 +69,37 @@ List files and dirs in your default directory on an endpoint.
 
 ----
 $ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
-$ ls $ep_id
+$ globus ls $ep_id
 ----
 
 List files and dirs on a specific path on an endpoint.
 
 ----
 $ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
-$ ls $ep_id:/share/godata/
+$ globus ls $ep_id:/share/godata/
+----
+
+List files and dirs on a specific path on an endpoint, filtering in various
+ways.
+
+----
+$ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
+$ globus ls $ep_id:/share/godata/ --filter '~*.txt'  # all txt files
+$ globus ls $ep_id:/share/godata/ --filter '!~file1.*'  # not starting in "file1."
+$ globus ls $ep_id:/share/godata/ --filter '~*ile3.tx*'  # anything with "ile3.tx"
+$ globus ls $ep_id:/share/godata/ --filter '=file2.txt'  # only "file2.txt"
+$ globus ls $ep_id:/share/godata/ --filter 'file2.txt'  # same as '=file2.txt'
+$ globus ls $ep_id:/share/godata/ --filter '!=file2.txt'  # anything but "file2.txt"
+----
+
+Compare a grep with a `globus ls --filter`. These two are the same, but the
+filter will be faster because it doesn't require that filenames which are
+filtered out are returned to the CLI:
+
+----
+$ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
+$ globus ls $ep_id:/share/godata/ | egrep '*.txt'  # done with grep, okay
+$ globus ls $ep_id:/share/godata/ --filter '~*.txt'  # done with --filter, better
 ----
 
 

--- a/adoc/ls.1.adoc
+++ b/adoc/ls.1.adoc
@@ -47,7 +47,7 @@ given.
 
 Filter results to filenames matching the given pattern.
 +
-Filter patterns must start with `=`, `~`, `!`, or `!~`
+Filter patterns must start with `=`, `~`, `!`, or `!~` +
 If none of these are given, `=` will be used
 +
 `=` does exact matching
@@ -98,7 +98,7 @@ filtered out are returned to the CLI:
 
 ----
 $ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
-$ globus ls $ep_id:/share/godata/ | egrep '*.txt'  # done with grep, okay
+$ globus ls $ep_id:/share/godata/ | egrep '.*\.txt$'  # done with grep, okay
 $ globus ls $ep_id:/share/godata/ --filter '~*.txt'  # done with --filter, better
 ----
 

--- a/globus_cli/commands/ls.py
+++ b/globus_cli/commands/ls.py
@@ -64,14 +64,22 @@ def ls_command(endpoint_plus_path, recursive_depth_limit,
     if path:
         ls_params["path"] = path
     if filter_val:
-        # these chars have special meaning in the LS API's filter clause
-        if ':' in filter_val or '/' in filter_val:
-            raise click.UsageError('--filter cannot contain ":" or "/"')
+        # this char has special meaning in the LS API's filter clause
+        # can't be part of the pattern (but we don't support globbing across
+        # dir structures anyway)
+        if '/' in filter_val:
+            raise click.UsageError('--filter cannot contain "/"')
         # format into a simple filter clause which operates on filenames
         ls_params['filter'] = 'name:{}'.format(filter_val)
 
     # get the `ls` result
     if recursive:
+        # NOTE:
+        # --recursive and --filter have an interplay that some users may find
+        # surprising
+        # if we're asked to change or "improve" the behavior in the future, we
+        # could do so with "type:dir" or "type:file" filters added in, and
+        # potentially work out some viable behavior based on what people want
         res = client.recursive_operation_ls(
             endpoint_id, depth=recursive_depth_limit, **ls_params)
     else:

--- a/globus_cli/commands/ls.py
+++ b/globus_cli/commands/ls.py
@@ -7,16 +7,38 @@ from globus_cli.services.transfer import (
     get_client, autoactivate, iterable_response_to_dict)
 
 
-@click.command('ls', help='List the contents of a directory on an endpoint',
+@click.command('ls', help=("""\
+List the contents of a directory on an endpoint
+
+\b
+Filtering
+===
+
+--filter takes "filter patterns" subject to the following rules.
+
+\b
+Filter patterns must start with "=", "~", "!", or "!~"
+If none of these are given, "=" will be used
+
+\b
+"=" does exact matching
+"~" does regex matching, supporting globs (*)
+"!" does inverse "=" matching
+"!~" does inverse "~" matching
+
+\b
+"~*.txt" matches all .txt files, for example"""),
                short_help='List endpoint directory contents')
 @common_options
 @click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
                 type=ENDPOINT_PLUS_OPTPATH)
-@click.option('--all', '-a', is_flag=True,
+@click.option('--all', '-a', 'show_hidden', is_flag=True,
               help=('Show files and directories that start with `.`'))
-@click.option('--long', '-l', is_flag=True,
+@click.option('--long', '-l', 'long_output', is_flag=True,
               help=('For text output only. Do long form output, kind '
                     'of like `ls -l`'))
+@click.option('--filter', 'filter_val', metavar='FILTER_PATTERN',
+              help="Filter results to filenames matching the given pattern.")
 @click.option('--recursive', '-r', is_flag=True, show_default=True,
               help=('Do a recursive listing, up to the depth limit. '
                     'Similar to `ls -R`'))
@@ -26,7 +48,7 @@ from globus_cli.services.transfer import (
                     '`--recursive` listings. A value of 0 indicates that '
                     'this should behave like a non-recursive `ls`'))
 def ls_command(endpoint_plus_path, recursive_depth_limit,
-               recursive, long, all):
+               recursive, long_output, show_hidden, filter_val):
     """
     Executor for `globus ls`
     """
@@ -38,9 +60,15 @@ def ls_command(endpoint_plus_path, recursive_depth_limit,
     autoactivate(client, endpoint_id, if_expires_in=60)
 
     # create the query paramaters to send to operation_ls
-    ls_params = {"show_hidden": int(all)}
+    ls_params = {"show_hidden": int(show_hidden)}
     if path:
         ls_params["path"] = path
+    if filter_val:
+        # these chars have special meaning in the LS API's filter clause
+        if ':' in filter_val or '/' in filter_val:
+            raise click.UsageError('--filter cannot contain ":" or "/"')
+        # format into a simple filter clause which operates on filenames
+        ls_params['filter'] = 'name:{}'.format(filter_val)
 
     # get the `ls` result
     if recursive:
@@ -58,6 +86,8 @@ def ls_command(endpoint_plus_path, recursive_depth_limit,
                      ('Group', 'group'), ('Size', 'size'),
                      ('Last Modified', 'last_modified'), ('File Type', 'type'),
                      ('Filename', cleaned_item_name)],
-        simple_text=(None if long or is_verbose() or outformat_is_json() else
-                     "\n".join(cleaned_item_name(x) for x in res)),
+        simple_text=(
+            None
+            if long_output or is_verbose() or outformat_is_json() else
+            "\n".join(cleaned_item_name(x) for x in res)),
         json_converter=iterable_response_to_dict)


### PR DESCRIPTION
`--filter` allows for the use of wildcards, so people can match on things like `~*.tiff` or `!~exemptme-*`.
Rather than trying to handle escaped `:` and `/` characters, just reject these outright.

Updates `globus ls -h` to print a helpdoc explaining the different
`--filter` options -- basically document the various API filter behaviors.

Includes doc updates and examples.

Closes #349, #192