### PR TITLE
Improvements and fixes to completion

### DIFF
--- a/globus_cli/parsing/main_command_decorator.py
+++ b/globus_cli/parsing/main_command_decorator.py
@@ -10,7 +10,8 @@ import sys
 import click
 
 from globus_cli.parsing.custom_group import GlobusCommandGroup
-from globus_cli.parsing.shell_completion import shell_complete_option
+from globus_cli.parsing.shell_completion import (
+    shell_complete_option, print_completer_option)
 from globus_cli.parsing.excepthook import custom_except_hook
 from globus_cli.parsing.shared_options import common_options
 
@@ -33,4 +34,5 @@ def globus_main_func(f):
     f = click.group('globus', cls=TopLevelGroup)(f)
     f = common_options(f)
     f = shell_complete_option(f)
+    f = print_completer_option(f)
     return f

--- a/globus_cli/parsing/shell_completion.py
+++ b/globus_cli/parsing/shell_completion.py
@@ -77,6 +77,13 @@ def get_completion_context(args):
 
 
 def get_all_choices(completed_args, cur, quoted):
+    """
+    This is the main completion function.
+    Inputs:
+    - completed_args: a list of already-completed arguments
+    - cur: the current "word in progress" or None
+    - quoted: is cur part of a quoted string?
+    """
     ctx = get_completion_context(completed_args)
     if not ctx:
         return []
@@ -122,12 +129,13 @@ def get_all_choices(completed_args, cur, quoted):
             # skip hidden options
             if isinstance(param, HiddenOption):
                 continue
-            for opt in param.opts:
-                # only add long-opts, never short opts to completion, unless
-                # the cur appears to be a short opt already
-                if opt.startswith('--') or (
-                        len(cur) > 1 and cur[1] != '-'):
-                    choices.append((opt, param.help))
+            for optset in (param.opts, param.secondary_opts):
+                for opt in optset:
+                    # only add long-opts, never short opts to completion,
+                    # unless the cur appears to be a short opt already
+                    if opt.startswith('--') or (
+                            len(cur) > 1 and cur[1] != '-'):
+                        choices.append((opt, param.help))
     # and if it's a multicommand we see, get the list of subcommands
     elif isinstance(ctx.command, click.MultiCommand) and not quoted:
         choices = [(cmdname, ctx.command.get_command(ctx, cmdname).short_help)

--- a/globus_cli/parsing/shell_completion.py
+++ b/globus_cli/parsing/shell_completion.py
@@ -187,8 +187,12 @@ def do_zsh_complete():
         completed_args = comp_words
 
     def clean_help(helpstr):
-        """
-        Replace ' with '"'"'
+        r"""
+        Replace
+            " with \"
+            ' with '"'"'
+            ` with \`
+            $ with \$
 
         Because we'll put these single quote chars in '...'
         quotation, we need to do
@@ -196,7 +200,11 @@ def do_zsh_complete():
         "'" -- single quote string (will concatenate in ZSH)
         '   -- start single quotes again
         """
-        return helpstr.replace("'", "'\"'\"'")
+        return (helpstr
+                .replace('"', '\\"')
+                .replace("'", "'\"'\"'")
+                .replace("`", "\\`")
+                .replace("$", "\\$"))
 
     choices = get_all_choices(completed_args, cur, quoted)
     choices = ['{}\\:"{}"'.format(name, clean_help(helpstr))

--- a/globus_cli/parsing/shell_completion.py
+++ b/globus_cli/parsing/shell_completion.py
@@ -143,14 +143,20 @@ def get_all_choices(completed_args, cur, quoted):
 
 
 def do_bash_complete():
-    comp_words, quoted = safe_split_line(os.environ['COMP_WORDS'])
-    cur_index = int(os.environ['COMP_CWORD'])
-    try:
-        cur = comp_words[cur_index]
-        completed_args = comp_words[1:-1]
-    except IndexError:
+    comp_line = os.environ.get('COMP_LINE', '')
+    comp_words, quoted = safe_split_line(comp_line)
+    cur_index = int(os.environ.get('COMP_POINT', len(comp_line)))
+
+    # now, figure out the current word in the line by "parsing"
+    # the chunk of it up to cur_index
+    partial_comp_words, _ = safe_split_line(comp_line[:cur_index])
+    cur = partial_comp_words[-1]
+
+    if comp_line[-1].isspace():
         cur = None
         completed_args = comp_words[1:]
+    else:
+        completed_args = comp_words[1:-1]
 
     choices = [name for (name, helpstr) in
                get_all_choices(completed_args, cur, quoted)]

--- a/shell_completion/bash_complete.sh
+++ b/shell_completion/bash_complete.sh
@@ -1,13 +1,2 @@
-_globus_completion() {
-    local IFS=$'\t'
-    if type globus > /dev/null;
-    then
-        COMPREPLY=( $( env COMP_LINE="$COMP_LINE" COMP_POINT="$COMP_POINT" \
-                       globus --shell-complete BASH ) )
-    else
-        COMPREPLY=( )
-    fi
-    return 0
-}
-
-complete -F _globus_completion -o nospace globus;
+# temporary shim -- remove me after release of shell completion
+eval "$(globus --bash-completer)"

--- a/shell_completion/bash_complete.sh
+++ b/shell_completion/bash_complete.sh
@@ -2,8 +2,7 @@ _globus_completion() {
     local IFS=$'\t'
     if type globus > /dev/null;
     then
-        COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                       COMP_CWORD="$COMP_CWORD" \
+        COMPREPLY=( $( env COMP_LINE="$COMP_LINE" COMP_POINT="$COMP_POINT" \
                        globus --shell-complete BASH ) )
     else
         COMPREPLY=( )
@@ -11,4 +10,4 @@ _globus_completion() {
     return 0
 }
 
-complete -F _globus_completion -o default globus;
+complete -F _globus_completion -o nospace globus;

--- a/shell_completion/zsh_complete.sh
+++ b/shell_completion/zsh_complete.sh
@@ -1,8 +1,2 @@
-#compdef globus
-_globus() {
-    if type globus > /dev/null;
-    then
-        eval "$(env COMMANDLINE="${words[1,$CURRENT]}" globus --shell-complete ZSH)"
-    fi
-}
-compdef _globus globus
+# temporary shim -- remove me after release of shell completion
+eval "$(globus --zsh-completer)"


### PR DESCRIPTION
This doesn't quite resolve #386 , as that requires a full release and documentation updates, but this is the main body of code for it.

- Add descriptions of flags and commands to zsh completion.
  zsh and other newer, hipper shells support "help strings" of some kind attached to completion results. For now, we just have zsh support, because I care.
  This is cool -- it makes our completion look very showy and professional in zsh.

- Fix bash completion handling of `globus --format=text endp<tab>`
  Switching from `COMP_WORDS` to `COMP_LINE` basically solves this -- by default, bash splits `=` incorrectly and breaks completion.

- Add `Parameter.secondary_opts` to completion choices.
  Click sorts out `--foo/--no-foo` flag declarations into `Parameter.opts` and `Parameter.secondary_opts`, so we need to collect both sets of options for completion.

- Replace completer scripts with `eval "$(...)"` pattern of completion usage. Convert current scripts to shims.

One unfortunate thing: I wanted to have `globus --completer` and `globus --completer zsh`, but this doesn't work that well. Instead, we have `--completer` and `--zsh-completer`, since that gives us distinct options (and therefore no parsing conflict). `--bash-completer` is an alias of `--completer`.