### PR TITLE
Allow delete of Endpoint Servers by hostname, uri

### DIFF
--- a/globus_cli/commands/endpoint/server/delete.py
+++ b/globus_cli/commands/endpoint/server/delete.py
@@ -1,30 +1,29 @@
 from textwrap import dedent
 import click
 
-from globus_cli.parsing import (
-    common_options, endpoint_id_arg, CaseInsensitiveChoice)
+from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RAW
 
 from globus_cli.services.transfer import get_client, get_endpoint_w_server_list
 
 
-def _spec_to_matches(server_list, server_spec, style):
+def _spec_to_matches(server_list, server_spec, mode):
     """
-    style is in {uri, hostname, hostname_port}
+    mode is in {uri, hostname, hostname_port}
 
     A list of matching server docs.
     Should usually be 0 or 1 matches. Multiple matches are possible though.
     """
-    assert style in ('uri', 'hostname', 'hostname_port')
+    assert mode in ('uri', 'hostname', 'hostname_port')
 
     def match(server_doc):
-        if style == 'hostname':
+        if mode == 'hostname':
             return server_spec == server_doc['hostname']
-        elif style == 'hostname_port':
+        elif mode == 'hostname_port':
             return (server_spec == '{}:{}'.format(
                         server_doc['hostname'],
                         server_doc['port']))
-        elif style == 'uri':
+        elif mode == 'uri':
             return (server_spec == '{}://{}:{}'.format(
                         server_doc['scheme'],
                         server_doc['hostname'],
@@ -37,38 +36,43 @@ def _spec_to_matches(server_list, server_spec, style):
             if match(server_doc)]
 
 
-@click.command('delete', help='Delete a server belonging to an endpoint')
+def _detect_mode(server):
+    try:
+        int(server)
+        return 'id'
+    except ValueError:
+        pass
+
+    if '://' in server:
+        return 'uri'
+
+    if ':' in server:
+        return 'hostname_port'
+
+    return 'hostname'
+
+
+@click.command('delete', help="""\
+    Delete a server belonging to an endpoint
+
+    SERVER may be a server ID, HOSTNAME, HOSTNAME:PORT, or URI
+    ( SCHEME://HOSTNAME:PORT )
+    """)
 @common_options
 @endpoint_id_arg
 @click.argument('server')
-@click.option('--mode', default='id',
-              type=CaseInsensitiveChoice(('id', 'hostname', 'uri')),
-              help=("""\
-    How to interpret the 'server' argument. If multiple servers match, an error
-    will be thrown.
-
-    \b
-    id: the server ID, as shown in 'globus endpoint server list' (default)
-
-    hostname: the hostname of the server. May also include the port in
-    HOSTNAME:PORT notation
-
-    uri: the full server uri, in the form of SCHEME://HOSTNAME:PORT
-    """))
-def server_delete(endpoint_id, server, mode):
+def server_delete(endpoint_id, server):
     """
     Executor for `globus endpoint server show`
     """
     client = get_client()
 
-    if mode != 'id':
-        style = mode
-        if mode == 'hostname' and ':' in server:
-            style = 'hostname_port'
+    mode = _detect_mode(server)
 
+    if mode != 'id':
         endpoint, server_list = get_endpoint_w_server_list(endpoint_id)
 
-        matches = _spec_to_matches(server_list, server, style)
+        matches = _spec_to_matches(server_list, server, mode)
         if not matches:
             raise click.UsageError('No server was found matching "{}"'
                                    .format(server))

--- a/globus_cli/commands/endpoint/server/delete.py
+++ b/globus_cli/commands/endpoint/server/delete.py
@@ -1,21 +1,86 @@
+from textwrap import dedent
 import click
 
-from globus_cli.parsing import common_options, endpoint_id_arg, server_id_arg
+from globus_cli.parsing import (
+    common_options, endpoint_id_arg, CaseInsensitiveChoice)
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RAW
 
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import get_client, get_endpoint_w_server_list
+
+
+def _spec_to_matches(server_list, server_spec, style):
+    """
+    style is in {uri, hostname, hostname_port}
+
+    A list of matching server docs.
+    Should usually be 0 or 1 matches. Multiple matches are possible though.
+    """
+    assert style in ('uri', 'hostname', 'hostname_port')
+
+    def match(server_doc):
+        if style == 'hostname':
+            return server_spec == server_doc['hostname']
+        elif style == 'hostname_port':
+            return (server_spec == '{}:{}'.format(
+                        server_doc['hostname'],
+                        server_doc['port']))
+        elif style == 'uri':
+            return (server_spec == '{}://{}:{}'.format(
+                        server_doc['scheme'],
+                        server_doc['hostname'],
+                        server_doc['port']))
+        else:
+            raise NotImplementedError(
+                'Unreachable error! Something is very wrong.')
+
+    return [server_doc for server_doc in server_list
+            if match(server_doc)]
 
 
 @click.command('delete', help='Delete a server belonging to an endpoint')
 @common_options
 @endpoint_id_arg
-@server_id_arg
-def server_delete(endpoint_id, server_id):
+@click.argument('server')
+@click.option('--mode', default='id',
+              type=CaseInsensitiveChoice(('id', 'hostname', 'uri')),
+              help=("""\
+    How to interpret the 'server' argument. If multiple servers match, an error
+    will be thrown.
+
+    \b
+    id: the server ID, as shown in 'globus endpoint server list' (default)
+
+    hostname: the hostname of the server. May also include the port in
+    HOSTNAME:PORT notation
+
+    uri: the full server uri, in the form of SCHEME://HOSTNAME:PORT
+    """))
+def server_delete(endpoint_id, server, mode):
     """
     Executor for `globus endpoint server show`
     """
     client = get_client()
-    server_doc = client.delete_endpoint_server(endpoint_id, server_id)
 
-    formatted_print(server_doc, text_format=FORMAT_TEXT_RAW,
+    if mode != 'id':
+        style = mode
+        if mode == 'hostname' and ':' in server:
+            style = 'hostname_port'
+
+        endpoint, server_list = get_endpoint_w_server_list(endpoint_id)
+
+        matches = _spec_to_matches(server_list, server, style)
+        if not matches:
+            raise click.UsageError('No server was found matching "{}"'
+                                   .format(server))
+        elif len(matches) > 1:
+            raise click.UsageError(dedent("""\
+                Multiple servers matched "{}":
+                    {}
+            """).format(server, [x['id'] for x in server_list]))
+        else:
+            server = matches[0]['id']
+
+    response = client.delete_endpoint_server(endpoint_id, server)
+
+    formatted_print(response, text_format=FORMAT_TEXT_RAW,
                     response_key='message')

--- a/globus_cli/commands/endpoint/server/list.py
+++ b/globus_cli/commands/endpoint/server/list.py
@@ -1,10 +1,9 @@
-from textwrap import dedent
 import click
 
 from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.safeio import (
     formatted_print, FORMAT_TEXT_RECORD, FORMAT_TEXT_TABLE)
-from globus_cli.services.transfer import (display_name_or_cname, get_client)
+from globus_cli.services.transfer import get_endpoint_w_server_list
 
 
 @click.command('list', help='List all servers belonging to an endpoint')
@@ -14,30 +13,16 @@ def server_list(endpoint_id):
     """
     Executor for `globus endpoint server list`
     """
-    client = get_client()
+    # raises usage error on shares for us
+    endpoint, server_list = get_endpoint_w_server_list(endpoint_id)
 
-    endpoint = client.get_endpoint(endpoint_id)
-
-    if endpoint['host_endpoint_id']:  # not GCS -- this is a share endpoint
-        raise click.UsageError(dedent(u"""\
-            {id} ({0}) is a share and does not have servers.
-
-            To see details of the share, use
-                globus endpoint show {id}
-
-            To list the servers on the share's host endpoint, use
-                globus endpoint server list {host_endpoint_id}
-        """).format(display_name_or_cname(endpoint), **endpoint.data))
-
-    if endpoint['s3_url']:  # not GCS -- this is an S3 endpoint
-        res = {'s3_url': endpoint['s3_url']}
+    if server_list == 'S3':  # not GCS -- this is an S3 endpoint
+        server_list = {'s3_url': endpoint['s3_url']}
         fields = [("S3 URL", 's3_url')]
         text_format = FORMAT_TEXT_RECORD
-    else:
-        # regular GCS host endpoint; use Transfer's server list API
-        res = client.endpoint_server_list(endpoint_id)
+    else:  # regular GCS host endpoint
         fields = (('ID', 'id'),
                   ('URI', lambda s: (s['uri'] or
                                      "none (Globus Connect Personal)")))
         text_format = FORMAT_TEXT_TABLE
-    formatted_print(res, text_format=text_format, fields=fields)
+    formatted_print(server_list, text_format=text_format, fields=fields)

--- a/tests/unit/test_endpoint_servers.py
+++ b/tests/unit/test_endpoint_servers.py
@@ -1,0 +1,98 @@
+import json
+
+from tests.framework.cli_testcase import CliTestCase
+
+
+class EndpointServerTests(CliTestCase):
+    def setUp(self):
+        """
+        Creates a list for tracking assets for cleanup
+        """
+        super(EndpointServerTests, self).setUp()
+        self.gcs_id, self.gcp_id = None, None
+
+    def tearDown(self):
+        """
+        Deletes all endpoints created during testing
+        """
+        super(EndpointServerTests, self).tearDown()
+        for x in (self.gcs_id, self.gcp_id):
+            if x:
+                self.tc.delete_endpoint(x)
+
+    def _mk_gcs(self):
+        output = self.run_line("globus endpoint create endpointservertest_gcs "
+                               "--server -F json")
+        res = json.loads(output)
+        self.gcs_id = res['id']
+
+    def _mk_gcp(self):
+        output = self.run_line("globus endpoint create endpointservertest_gcs "
+                               "--personal -F json")
+        res = json.loads(output)
+        self.gcp_id = res['id']
+
+    def _add_server(self, epid, use_json=False):
+        return self.run_line(
+            "globus endpoint server add {} --hostname foo.com{}"
+            .format(epid, '' if not use_json else ' -Fjson'))
+
+    def test_gcs_server_add(self):
+        self._mk_gcs()
+        output = self._add_server(self.gcs_id)
+        self.assertIn('Server added to endpoint successfully', output)
+
+    def test_gcs_server_list(self):
+        self._mk_gcs()
+        self._add_server(self.gcs_id)
+        output = self.run_line(
+            "globus endpoint server list {}"
+            .format(self.gcs_id))
+        self.assertIn('gsiftp://foo.com:2811', output)
+
+    def test_gcp_server_list(self):
+        self._mk_gcs()
+        self._add_server(self.gcs_id)
+        output = self.run_line(
+            "globus endpoint server list {}"
+            .format(self.gcs_id))
+        self.assertIn('gsiftp://foo.com:2811', output)
+
+    def _create_and_delete_server(self, mode):
+        assert mode in ('id', 'hostname', 'hostname_port', 'uri')
+
+        self._mk_gcs()
+        add_server_out = json.loads(
+            self._add_server(self.gcs_id, use_json=True))
+
+        if mode == 'id':
+            server = add_server_out['id']
+        elif mode == 'hostname':
+            server = 'foo.com'
+        elif mode == 'hostname_port':
+            server = 'foo.com:2811'
+        elif mode == 'uri':
+            server = 'gsiftp://foo.com:2811'
+        else:
+            raise NotImplementedError
+
+        output = self.run_line(
+            "globus endpoint server delete {} {}"
+            .format(self.gcs_id, server))
+        self.assertIn('Server deleted successfully', output)
+        output = self.run_line(
+            "globus endpoint server list {}"
+            .format(self.gcs_id))
+        self.assertNotIn('gsiftp://foo.com:2811', output)
+
+    def test_server_delete_by_id(self):
+        self._create_and_delete_server('id')
+
+    def test_server_delete_by_hostname(self):
+        self._create_and_delete_server('hostname')
+
+    def test_server_delete_by_hostname_port(self):
+        self._create_and_delete_server('hostname_port')
+
+    def test_server_delete_by_uri(self):
+        self._create_and_delete_server('uri')


### PR DESCRIPTION
Backwards compatible.
Prior usage:
`globus endpoint server delete EPID SERVER_ID`
New usage:
`globus endpoint server delete EPID SERVER [--mode id|hostname|uri]`

The `--mode` defaults to "id", meaning `SERVER` is a server ID.
`mode=hostname` means that `SERVER` is a `HOSTNAME` or `HOSTNAME:PORT` (easy enough to check).
`mode=uri` means that `SERVER` is `SCHEME://HOSTNAME:PORT`

I considered making the `--mode` determined by whether or not `SERVER` is an int or contains `://`.
This seems potentially fragile and I don't think it gets us significant benefit -- the caller already knows what they're passing, after all.

As a necessary step, refactor some of `endpoint server list` into a useful helper. I made the signature on it a little funky (returns string or response object depending on results) but I don't think it's so weird as to been unconscionable.

Thoughts much appreciated.

Contributes towards #388