### PR TITLE
Install cryptography by default

### DIFF
--- a/globus_cli/helpers/delegate_proxy.py
+++ b/globus_cli/helpers/delegate_proxy.py
@@ -3,13 +3,10 @@ import os
 import datetime
 import re
 import six
-try:
-    from cryptography import x509
-    from cryptography.hazmat.primitives import serialization, hashes
-    from cryptography.hazmat.backends import default_backend
-    cryptography_imported = True
-except ImportError:
-    cryptography_imported = False
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.backends import default_backend
 
 
 def fill_delegate_proxy_activation_requirements(requirements_data, cred_file,
@@ -20,10 +17,6 @@ def fill_delegate_proxy_activation_requirements(requirements_data, cred_file,
     requirements, uses the key and the credentials to make a proxy credential,
     and returns the requirements data with the proxy chain filled in.
     """
-    # cannot proceed without cryptography
-    if not cryptography_imported:
-        raise ImportError("Unable to import cryptography")
-
     # get the public key from the activation requirements
     for data in requirements_data["DATA"]:
         if data["type"] == "delegate_proxy" and data["name"] == "public_key":

--- a/globus_cli/services/transfer.py
+++ b/globus_cli/services/transfer.py
@@ -5,13 +5,6 @@ import click
 
 from textwrap import dedent
 
-try:
-    import cryptography
-    # slightly hacky way of preventing flake8 from complaining
-    cryptography_imported = bool(cryptography)
-except ImportError:
-    cryptography_imported = False
-
 from globus_sdk import TransferClient, RefreshTokenAuthorizer
 from globus_sdk.exc import NetworkError
 from globus_sdk.base import safe_stringify
@@ -205,12 +198,12 @@ def activation_requirements_help_text(res, ep_id):
         ("For delegate proxy activation use:\n"
          "'globus endpoint activate --delegate-proxy "
          "X.509_PEM_FILE {}'\n".format(ep_id)
-         if "delegate_proxy" in methods and cryptography_imported else ""),
+         if "delegate_proxy" in methods else ""),
 
         ("Delegate proxy activation requires an additional dependency on "
          "cryptography. See the docs for details:\n"
          "https://docs.globus.org/cli/reference/endpoint_activate/\n"
-         if "delegate_proxy" in methods and not cryptography_imported else ""),
+         if "delegate_proxy" in methods else ""),
     ]
 
     return "".join(lines)

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,20 @@ setup(
         'jmespath==0.9.2',
         'configobj>=5.0.6,<6.0.0',
         'requests>=2.0.0,<3.0.0',
-        'six>=1.10.0,<2.0.0'
+        'six>=1.10.0,<2.0.0',
+        # cryptography has unusual versioning and compatibility rules:
+        # https://cryptography.io/en/latest/api-stability/
+        # we trust the two next major versions, per the Deprecation policy
+        #
+        # as new versions of cryptography are released, we may need to update
+        # this requirement
+        'cryptography>=1.8.1,<2.5.0'
     ],
 
     extras_require={
-        'delegate-proxy': ['cryptography>=1.8.1,<2.0.0']
+        # deprecated, but do not remove -- doing so would break installs which
+        # are already using this extra
+        'delegate-proxy': []
     },
 
     entry_points={

--- a/tests/unit/test_delegate_proxy.py
+++ b/tests/unit/test_delegate_proxy.py
@@ -1,52 +1,9 @@
-import unittest
-try:
-    import cryptography
-    # slightly hacky way of preventing flake8 from complaining
-    cryptography_imported = bool(cryptography)
-except ImportError:
-    cryptography_imported = False
-
 from globus_cli.helpers import fill_delegate_proxy_activation_requirements
 from tests.framework.cli_testcase import CliTestCase
-from tests.framework.constants import GO_EP1_ID, PUBLIC_KEY
+from tests.framework.constants import PUBLIC_KEY
 
 
 class DelegateProxyTests(CliTestCase):
-
-    @unittest.skipIf(cryptography_imported, "cryptography was imported")
-    def test_cryptography_not_imported(self):
-        """
-        Confirms --delegate-proxy doesn't appear in activate help text
-        if cryptography is not available. Confirms error if option is attempted
-        to be used anyways.
-        """
-        output = self.run_line("globus endpoint activate --help")
-        self.assertNotIn("--delegate-proxy", output)
-
-        output = self.run_line((
-            "globus endpoint activate {} --delegate-proxy cert.pem"
-            .format(GO_EP1_ID)), assert_exit_code=1)
-        self.assertIn("Missing cryptography dependency", output)
-
-    @unittest.skipIf(not cryptography_imported, "cryptography not imported")
-    def test_cryptography_imported(self):
-        """
-        Confirms --delegate-proxy does appear in activate help text if
-        cryptography was successfully imported.
-        Confirms the tutorial endpoints cannot use delegate_proxy activation.
-        """
-        output = self.run_line("globus endpoint activate --help")
-        self.assertIn("--delegate-proxy", output)
-
-        # --force and --no-autoactivate are used to prevent the endpoint being
-        # seen as not needing activation
-        output = self.run_line((
-            "globus endpoint activate {} --delegate-proxy cert.pem "
-            "--no-autoactivate --force".format(GO_EP1_ID)), assert_exit_code=1)
-        self.assertIn(
-            "this endpoint does not support Delegate Proxy activation", output)
-
-    @unittest.skipIf(not cryptography_imported, "cryptography not imported")
     def test_fill_delegate_proxy_activation_requirements(self):
         """
         Uses the public key from constants to form a fake activation
@@ -77,7 +34,6 @@ class DelegateProxyTests(CliTestCase):
         self.assertIn("-----END CERTIFICATE-----",
                       filled_requirements["DATA"][1]["value"])
 
-    @unittest.skipIf(not cryptography_imported, "cryptography not imported")
     def test_bad_x509(self):
         """
         Uses the public key from constants to form a fake activation


### PR DESCRIPTION
Deprecate delegate-proxy extra install target (but leave it, empty).
Make all cryptography-conditional code non-conditional because cryptography is now always-on.

@aaschaer, I must apologize for unwinding much of your hard work on making everything work nicely when cryptography is absent, but I think it's for the Greater Good.

In #351 I noted that the SDK, via pyjwt, is already installing `cryptography>1.4`, so our constraint (`cryptography>=1.8.1,<2.0.0`) is safe.
However, it turns out that our way of specifying the cryptography version is wrong!
`cryptography` doesn't use semver and guarantees compatibility: https://cryptography.io/en/latest/api-stability/

~So I'm changing this to `cryptography>=1.8.1` in this PR, with a comment about its oddity~
Update cryptography dependency to `>=2.0.0,<2.5.0`


Because this is a fairly major and potentially dangerous change, I'd like everyone to explicitly approve before merging.

Closes #351

EDIT: Changed the specified `cryptography` version. Comment below explains why.