### PR TITLE
Fix invocation of `pip` to follow guidance

### DIFF
--- a/globus_cli/commands/update.py
+++ b/globus_cli/commands/update.py
@@ -1,9 +1,21 @@
+import sys
+import subprocess
 import atexit
 import click
 
 from globus_cli.safeio import safeprint
 from globus_cli.version import get_versions
 from globus_cli.parsing import common_options, HiddenOption
+
+
+def _call_pip(*args):
+    """
+    Invoke pip *safely* and in the *supported* way:
+    https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program
+    """
+    all_args = [sys.executable, '-m', 'pip'] + list(args)
+    print('> {}'.format(' '.join(all_args)))
+    subprocess.check_call(all_args)
 
 
 @click.command('update', help='Update the Globus CLI to its latest version')
@@ -43,6 +55,7 @@ def update_command(yes, development, development_version):
     #   kind of nasty (even if "they're asking for it")
     try:
         import pip
+        assert pip
     except ImportError:
         safeprint("`globus update` requires pip. "
                   "Please install pip and try again")
@@ -111,4 +124,4 @@ def update_command(yes, development, development_version):
     # atexit method. Anything outside of atexit methods remains safe!
     @atexit.register
     def do_upgrade():
-        pip.main(['install', '--upgrade', target_version])
+        _call_pip('install', '--upgrade', target_version)

--- a/globus_cli/commands/update.py
+++ b/globus_cli/commands/update.py
@@ -18,6 +18,25 @@ def _call_pip(*args):
     subprocess.check_call(all_args)
 
 
+def _check_pip_installed():
+    """
+    Invoke `pip --version` and make sure it doesn't error.
+    Use check_output to capture stdout and stderr
+
+    Invokes pip by the same manner that we plan to in _call_pip()
+
+    Don't bother trying to reuse _call_pip to do this... Finnicky and not worth
+    the effort.
+    """
+    try:
+        subprocess.check_output(
+            [sys.executable, '-m', 'pip', '--version'],
+            stderr=subprocess.STDOUT)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
 @click.command('update', help='Update the Globus CLI to its latest version')
 @common_options(no_format_option=True, no_map_http_status_option=True)
 @click.option('--yes', is_flag=True,
@@ -53,10 +72,7 @@ def update_command(yes, development, development_version):
     #   of the CLI which can't import its installing `pip`. If we depend on
     #   pip, anyone doing this is forced to get two copies of pip, which seems
     #   kind of nasty (even if "they're asking for it")
-    try:
-        import pip
-        assert pip
-    except ImportError:
+    if not _check_pip_installed():
         safeprint("`globus update` requires pip. "
                   "Please install pip and try again")
         click.get_current_context().exit(1)


### PR DESCRIPTION
The `pip` documentation explicitly states that calling `pip.main()` is not allowed, and that calling via `subprocess` + `sys.executable` *is* the officially supported mode of use for invoking `pip` within a running python process.

We still `import pip` and assert that `pip` can be found so that we can error out early and provide good feedback when pip is missing.
Otherwise, we'd get to the point of execution and error -- at that point, it's a bit too late to provide a good error message.

I tested under python2.7 and python3.5 by editing the version number in local source to `1.0.0`, doing a `pip install -U .`, and then `globus update`. That seems to be the easiest way to test `globus update` that I've found.
Be careful that you don't have any eggs or other sdist build artifacts lying around -- they can confuse `pip install`.

Closes #395