### PR TITLE
Add `globus rm` command

### DIFF
--- a/globus_cli/commands/delete.py
+++ b/globus_cli/commands/delete.py
@@ -5,7 +5,7 @@ from globus_sdk import DeleteData
 
 from globus_cli.parsing import (
     common_options, task_submission_options, TaskPath, ENDPOINT_PLUS_OPTPATH,
-    shlex_process_stdin)
+    shlex_process_stdin, delete_and_rm_options)
 from globus_cli.safeio import (
     safeprint, formatted_print, FORMAT_TEXT_RECORD,
     err_is_terminal, term_is_interactive)
@@ -18,18 +18,7 @@ from globus_cli.services.transfer import get_client, autoactivate
                      'asynchronous task.'))
 @common_options
 @task_submission_options
-@click.option(
-    '--recursive', '-r', is_flag=True, help='Recursively delete dirs')
-@click.option('--ignore-missing', '-f', is_flag=True,
-              help="Don't throw errors if the file or dir is absent")
-@click.option('--star-silent', '--unsafe', 'star_silent', is_flag=True,
-              help=("Don't prompt when the trailing character is a \"*\". "
-                    "Implicit in --batch"))
-@click.option('--batch', is_flag=True,
-              help=('Accept a batch of paths on stdin (i.e. run in '
-                    'batchmode). Uses ENDPOINT_ID as passed on the '
-                    'commandline. Any commandline PATH given will be used as '
-                    'a prefix to all paths given'))
+@delete_and_rm_options
 @click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_OPTPATH.metavar,
                 type=ENDPOINT_PLUS_OPTPATH)
 def delete_command(batch, ignore_missing, star_silent, recursive,

--- a/globus_cli/commands/main.py
+++ b/globus_cli/commands/main.py
@@ -12,6 +12,7 @@ from globus_cli.commands.whoami import whoami_command
 from globus_cli.commands.get_identities import get_identities_command
 from globus_cli.commands.ls import ls_command
 from globus_cli.commands.delete import delete_command
+from globus_cli.commands.rm import rm_command
 from globus_cli.commands.transfer import transfer_command
 from globus_cli.commands.mkdir import mkdir_command
 from globus_cli.commands.rename import rename_command
@@ -40,6 +41,7 @@ main.add_command(ls_command)
 main.add_command(mkdir_command)
 main.add_command(rename_command)
 main.add_command(delete_command)
+main.add_command(rm_command)
 main.add_command(transfer_command)
 
 main.add_command(endpoint_command)

--- a/globus_cli/commands/rm.py
+++ b/globus_cli/commands/rm.py
@@ -1,0 +1,79 @@
+import click
+
+from globus_sdk import DeleteData
+
+
+from globus_cli.parsing import (
+    common_options, task_submission_options, ENDPOINT_PLUS_REQPATH,
+    delete_and_rm_options, synchronous_task_wait_options)
+from globus_cli.safeio import (
+    safeprint, formatted_print,
+    err_is_terminal, term_is_interactive)
+
+from globus_cli.services.transfer import (
+    get_client, autoactivate, task_wait_with_io)
+
+
+@click.command("rm", short_help="Delete a single file or directory",
+               help=("Submit a Delete Task to delete a single file or "
+                     "directory, and then block and wait for it to "
+                     "complete."))
+@common_options
+@task_submission_options
+@delete_and_rm_options(supports_batch=False)
+@synchronous_task_wait_options
+@click.argument('endpoint_plus_path', metavar=ENDPOINT_PLUS_REQPATH.metavar,
+                type=ENDPOINT_PLUS_REQPATH)
+def rm_command(ignore_missing, star_silent, recursive,
+               endpoint_plus_path, label, submission_id, dry_run, deadline,
+               skip_activation_check, notify,
+               meow, heartbeat, polling_interval, timeout):
+    """
+    Executor for `globus rm`
+    """
+    endpoint_id, path = endpoint_plus_path
+
+    client = get_client()
+
+    # attempt to activate unless --skip-activation-check is given
+    if not skip_activation_check:
+        autoactivate(client, endpoint_id, if_expires_in=60)
+
+    delete_data = DeleteData(client, endpoint_id,
+                             label=label,
+                             recursive=recursive,
+                             ignore_missing=ignore_missing,
+                             submission_id=submission_id,
+                             deadline=deadline,
+                             skip_activation_check=skip_activation_check,
+                             **notify)
+
+    if not star_silent and path.endswith('*'):
+        # not intuitive, but `click.confirm(abort=True)` prints to stdout
+        # unnecessarily, which we don't really want...
+        # only do this check if stderr is a pty
+        if (err_is_terminal() and
+            term_is_interactive() and
+            not click.confirm(
+                'Are you sure you want to delete all files matching "{}"?'
+                .format(path), err=True)):
+            safeprint('Aborted.', write_to_stderr=True)
+            click.get_current_context().exit(1)
+    delete_data.add_item(path)
+
+    if dry_run:
+        formatted_print(delete_data, response_key='DATA',
+                        fields=[('Path', 'path')])
+        # exit safely
+        return
+
+    # Print task submission to stderr so that `-Fjson` is still correctly
+    # respected, as it will be by `task wait`
+    res = client.submit_delete(delete_data)
+    task_id = res['task_id']
+    safeprint('Delete task submitted under ID "{}"'.format(task_id),
+              write_to_stderr=True)
+
+    # do a `task wait` equivalent, including printing and correct exit status
+    task_wait_with_io(meow, heartbeat, polling_interval, timeout, task_id,
+                      client=client)

--- a/globus_cli/commands/task/wait.py
+++ b/globus_cli/commands/task/wait.py
@@ -1,95 +1,17 @@
 import click
-import sys
 
-from globus_cli.safeio import safeprint
-from globus_cli.parsing import HiddenOption, common_options, task_id_arg
-from globus_cli.safeio import formatted_print, FORMAT_SILENT
+from globus_cli.parsing import (
+    common_options, task_id_arg, synchronous_task_wait_options)
 
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import task_wait_with_io
 
 
 @click.command('wait', help='Wait for a task to complete')
 @common_options
 @task_id_arg
-@click.option('--timeout', type=int, metavar='N',
-              help=('Wait N seconds. If the task does not terminate by '
-                    'then, or terminates with an unsuccessful status, '
-                    'exit with status 1'))
-@click.option('--polling-interval', default=1, type=int, show_default=True,
-              help='Number of seconds between task status checks.')
-@click.option('--heartbeat', '-H', is_flag=True,
-              help=('Every polling interval, print "." to stdout to '
-                    'indicate that task wait is till active'))
-@click.option('--meow', is_flag=True, cls=HiddenOption)
+@synchronous_task_wait_options
 def task_wait(meow, heartbeat, polling_interval, timeout, task_id):
     """
     Executor for `globus task wait`
     """
-    if polling_interval < 1:
-        raise click.UsageError(
-            '--polling-interval={0} was less than minimum of {1}'
-            .format(polling_interval, 1))
-
-    client = get_client()
-
-    def timed_out(waited_time):
-        if timeout is None:
-            return False
-        else:
-            return waited_time >= timeout
-
-    def check_completed():
-        completed = client.task_wait(task_id, timeout=polling_interval,
-                                     polling_interval=polling_interval)
-        if completed:
-            if heartbeat:
-                safeprint('', write_to_stderr=True)
-            # meowing tasks wake up!
-            if meow:
-                safeprint("""\
-                  _..
-  /}_{\           /.-'
- ( a a )-.___...-'/
- ==._.==         ;
-      \ i _..._ /,
-      {_;/   {_//""", write_to_stderr=True)
-
-            # TODO: possibly update TransferClient.task_wait so that we don't
-            # need to do an extra fetch to get the task status after completion
-            res = client.get_task(task_id)
-            formatted_print(res, text_format=FORMAT_SILENT)
-
-            status = res['status']
-            if status == 'SUCCEEDED':
-                click.get_current_context().exit(0)
-            else:
-                click.get_current_context().exit(1)
-
-        return completed
-
-    # Tasks start out sleepy
-    if meow:
-        safeprint("""\
-   |\      _,,,---,,_
-   /,`.-'`'    -.  ;-;;,_
-  |,4-  ) )-,_..;\ (  `'-'
- '---''(_/--'  `-'\_)""", write_to_stderr=True)
-
-    waited_time = 0
-    while (not timed_out(waited_time) and
-           not check_completed()):
-        if heartbeat:
-            safeprint('.', write_to_stderr=True, newline=False)
-            sys.stderr.flush()
-
-        waited_time += polling_interval
-
-    # add a trailing newline to heartbeats if we fail
-    if heartbeat:
-        safeprint('', write_to_stderr=True)
-
-    # output json if requested, but nothing for text mode
-    res = client.get_task(task_id)
-    formatted_print(res, text_format=FORMAT_SILENT)
-
-    click.get_current_context().exit(1)
+    task_wait_with_io(meow, heartbeat, polling_interval, timeout, task_id)

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -13,6 +13,7 @@ from globus_cli.parsing.explicit_null import EXPLICIT_NULL
 
 from globus_cli.parsing.shared_options import (
     common_options, endpoint_id_arg, task_id_arg, task_submission_options,
+    delete_and_rm_options, synchronous_task_wait_options,
     endpoint_create_and_update_params,
     validate_endpoint_create_and_update_params,
     role_id_arg, server_id_arg, server_add_and_update_opts,
@@ -41,6 +42,7 @@ __all__ = [
     'common_options',
     # Transfer options
     'endpoint_id_arg', 'task_id_arg', 'task_submission_options',
+    'delete_and_rm_options', 'synchronous_task_wait_options',
     'endpoint_create_and_update_params',
     'validate_endpoint_create_and_update_params',
     'role_id_arg', 'server_id_arg', 'server_add_and_update_opts',

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -4,6 +4,7 @@ from globus_cli.parsing.command_state import (
     format_option, debug_option, map_http_status_option, verbose_option)
 from globus_cli.parsing.version_option import version_option
 from globus_cli.parsing.case_insensitive_choice import CaseInsensitiveChoice
+from globus_cli.parsing.hidden_option import HiddenOption
 from globus_cli.parsing.detect_and_decorate import detect_and_decorate
 from globus_cli.parsing.location import LocationType
 from globus_cli.parsing.iso_time import ISOTimeType
@@ -403,6 +404,61 @@ def task_submission_options(f):
             "Submit the task even if the endpoint(s) "
             "aren't currently activated."))(f)
 
+    return f
+
+
+def delete_and_rm_options(*args, **kwargs):
+    """
+    Options which apply both to `globus delete` and `globus rm`
+    """
+    def inner_decorator(f, supports_batch=True):
+        f = click.option(
+            '--recursive', '-r', is_flag=True,
+            help='Recursively delete dirs')(f)
+        f = click.option(
+            '--ignore-missing', '-f', is_flag=True,
+            help="Don't throw errors if the file or dir is absent")(f)
+        f = click.option(
+            '--star-silent', '--unsafe', 'star_silent', is_flag=True,
+            help=("Don't prompt when the trailing character is a \"*\"." +
+                  (" Implicit in --batch" if supports_batch else "")))(f)
+        if supports_batch:
+            f = click.option(
+                '--batch', is_flag=True,
+                help=('Accept a batch of paths on stdin (i.e. run in '
+                      'batchmode). Uses ENDPOINT_ID as passed on the '
+                      'commandline. Any commandline PATH given will be used '
+                      'as a prefix to all paths given'))(f)
+        return f
+
+    return detect_and_decorate(inner_decorator, args, kwargs)
+
+
+def synchronous_task_wait_options(f):
+    def polling_interval_callback(ctx, param, value):
+        if not value:
+            return None
+
+        if value < 1:
+            raise click.UsageError(
+                '--polling-interval={0} was less than minimum of {1}'
+                .format(value, 1))
+
+        return value
+
+    f = click.option('--timeout', type=int, metavar='N',
+                     help=('Wait N seconds. If the Task does not terminate by '
+                           'then, or terminates with an unsuccessful status, '
+                           'exit with status 1'))(f)
+    f = click.option(
+        '--polling-interval', default=1, type=int, show_default=True,
+        callback=polling_interval_callback,
+        help='Number of seconds between Task status checks.')(f)
+    f = click.option(
+        '--heartbeat', '-H', is_flag=True,
+        help=('Every polling interval, print "." to stdout to '
+              'indicate that task wait is till active'))(f)
+    f = click.option('--meow', is_flag=True, cls=HiddenOption)(f)
     return f
 
 

--- a/globus_cli/services/transfer.py
+++ b/globus_cli/services/transfer.py
@@ -1,6 +1,7 @@
 import uuid
 import random
 import time
+import sys
 import click
 
 from textwrap import dedent
@@ -10,7 +11,7 @@ from globus_sdk.exc import NetworkError
 from globus_sdk.base import safe_stringify
 
 from globus_cli import version
-from globus_cli.safeio import safeprint
+from globus_cli.safeio import safeprint, formatted_print, FORMAT_SILENT
 from globus_cli.config import (
     get_transfer_tokens, internal_auth_client, set_transfer_access_token)
 from globus_cli.parsing import EXPLICIT_NULL
@@ -264,6 +265,81 @@ def get_endpoint_w_server_list(endpoint_id):
 
     else:
         return (endpoint, client.endpoint_server_list(endpoint_id))
+
+
+def task_wait_with_io(meow, heartbeat, polling_interval, timeout, task_id,
+                      client=None):
+    """
+    Options are the core "task wait" options, including the `--meow` easter
+    egg.
+
+    This does the core "task wait" loop, including all of the IO.
+    It *does exit* on behalf of the caller. (We can enhance with a
+    `noabort=True` param or somesuch in the future if necessary.)
+    """
+    client = client or get_client()
+
+    def timed_out(waited_time):
+        if timeout is None:
+            return False
+        else:
+            return waited_time >= timeout
+
+    def check_completed():
+        completed = client.task_wait(task_id, timeout=polling_interval,
+                                     polling_interval=polling_interval)
+        if completed:
+            if heartbeat:
+                safeprint('', write_to_stderr=True)
+            # meowing tasks wake up!
+            if meow:
+                safeprint("""\
+                  _..
+  /}_{\           /.-'
+ ( a a )-.___...-'/
+ ==._.==         ;
+      \ i _..._ /,
+      {_;/   {_//""", write_to_stderr=True)
+
+            # TODO: possibly update TransferClient.task_wait so that we don't
+            # need to do an extra fetch to get the task status after completion
+            res = client.get_task(task_id)
+            formatted_print(res, text_format=FORMAT_SILENT)
+
+            status = res['status']
+            if status == 'SUCCEEDED':
+                click.get_current_context().exit(0)
+            else:
+                click.get_current_context().exit(1)
+
+        return completed
+
+    # Tasks start out sleepy
+    if meow:
+        safeprint("""\
+   |\      _,,,---,,_
+   /,`.-'`'    -.  ;-;;,_
+  |,4-  ) )-,_..;\ (  `'-'
+ '---''(_/--'  `-'\_)""", write_to_stderr=True)
+
+    waited_time = 0
+    while (not timed_out(waited_time) and
+           not check_completed()):
+        if heartbeat:
+            safeprint('.', write_to_stderr=True, newline=False)
+            sys.stderr.flush()
+
+        waited_time += polling_interval
+
+    # add a trailing newline to heartbeats if we fail
+    if heartbeat:
+        safeprint('', write_to_stderr=True)
+
+    # output json if requested, but nothing for text mode
+    res = client.get_task(task_id)
+    formatted_print(res, text_format=FORMAT_SILENT)
+
+    click.get_current_context().exit(1)
 
 
 ENDPOINT_LIST_FIELDS = (('ID', 'id'), ('Owner', 'owner_string'),

--- a/tests/unit/test_rm.py
+++ b/tests/unit/test_rm.py
@@ -1,0 +1,124 @@
+from random import getrandbits
+import json
+
+from tests.framework.cli_testcase import CliTestCase
+from tests.framework.constants import GO_EP1_ID
+
+
+class RMTests(CliTestCase):
+
+    def test_recursive(self):
+        """
+        Makes a dir on ep1, then --recursive rm's it.
+        Confirms delete task was successful.
+        """
+        # name randomized to prevent collision
+        path = "/~/rm_dir-{}".format(str(getrandbits(128)))
+        self.tc.operation_mkdir(GO_EP1_ID, path)
+
+        output = self.run_line(
+            "globus rm -r -F json {}:{}".format(GO_EP1_ID, path))
+        res = json.loads(output)
+        self.assertEqual(res["status"], "SUCCEEDED")
+
+    def test_no_file(self):
+        """
+        Attempts to remove a non-existant file. Confirms exit code 1
+        """
+        path = "/~/nofilehere.txt"
+        self.run_line(
+            "globus rm {}:{}".format(GO_EP1_ID, path), assert_exit_code=1)
+
+    def test_ignore_missing(self):
+        """
+        Attempts to remove a non-existant file path, with --ignore-missing.
+        Confirms exit code 0 and silent output.
+        """
+        path = "/~/nofilehere.txt"
+        output = self.run_line("globus rm -f {}:{}".format(GO_EP1_ID, path))
+        self.assertEqual(output, "")
+
+    def test_pattern_globbing(self):
+        """
+        Makes 3 dirs with the same prefix, and uses * globbing to rm them all.
+        Confirms delete task was successful and removed 3 dirs.
+        """
+        # mark all dirs with a random generated prefix to prevent collision
+        rand = str(getrandbits(128))
+        for i in range(3):
+            path = "/~/rm_dir{}-{}".format(rand, i)
+            self.tc.operation_mkdir(GO_EP1_ID, path)
+
+        # remove all dirs with the prefix
+        glob = "rm_dir{}*".format(rand)
+        output = self.run_line(
+            "globus rm -r -F json {}:{}".format(GO_EP1_ID, glob))
+        res = json.loads(output)
+        self.assertEqual(res["status"], "SUCCEEDED")
+
+        # confirm no dirs with the prefix exist on the endpoint
+        filter_string = "name:~rm_dir{}*".format(rand)
+        ls_doc = self.tc.operation_ls(GO_EP1_ID, filter=filter_string)
+        for item in ls_doc:
+            self.assertTrue(False)
+
+    def test_wild_globbing(self):
+        """
+        Makes 3 dirs with the same prefix, and uses ? globbing to rm them all.
+        Confirms delete task was successful and removed 3 dirs.
+        """
+        # mark all dirs with a random generated prefix to prevent collision
+        rand = str(getrandbits(128))
+        for i in range(3):
+            path = "/~/rm_dir{}-{}".format(rand, i)
+            self.tc.operation_mkdir(GO_EP1_ID, path)
+
+        # remove all dirs with the prefix
+        glob = "rm_dir{}-?".format(rand)
+        output = self.run_line(
+            "globus rm -r -F json {}:{}".format(GO_EP1_ID, glob))
+        res = json.loads(output)
+        self.assertEqual(res["status"], "SUCCEEDED")
+
+        # confirm no dirs with the prefix exist on the endpoint
+        filter_string = "name:~rm_dir{}*".format(rand)
+        ls_doc = self.tc.operation_ls(GO_EP1_ID, filter=filter_string)
+        for item in ls_doc:
+            self.assertTrue(False)
+
+    def test_bracket_globbing(self):
+        """
+        Makes 3 dirs with the same prefix, and uses [] globbing to rm them all.
+        Confirms delete task was successful and removed 3 dirs.
+        """
+        # mark all dirs with a random generated prefix to prevent collision
+        rand = str(getrandbits(128))
+        for i in range(3):
+            path = "/~/rm_dir{}-{}".format(rand, i)
+            self.tc.operation_mkdir(GO_EP1_ID, path)
+
+        # remove all dirs with the prefix
+        glob = "rm_dir{}-[012]".format(rand)
+        output = self.run_line(
+            "globus rm -r -F json {}:{}".format(GO_EP1_ID, glob))
+        res = json.loads(output)
+        self.assertEqual(res["status"], "SUCCEEDED")
+
+        # confirm no dirs with the prefix exist on the endpoint
+        filter_string = "name:~rm_dir{}*".format(rand)
+        ls_doc = self.tc.operation_ls(GO_EP1_ID, filter=filter_string)
+        for item in ls_doc:
+            self.assertTrue(False)
+
+    def test_timeout(self):
+        """
+        Attempts to remove a path we are not allowed to remove,
+        confirms rm times out and exits 1 after given timeout.
+        """
+        timeout = 2
+        path = "/share/godata/file1.txt"
+        output = self.run_line(
+            "globus rm -r --timeout {} {}:{}".format(timeout, GO_EP1_ID, path),
+            assert_exit_code=1)
+        self.assertIn(("Task has yet to complete "
+                       "after {} seconds.".format(timeout)), output)


### PR DESCRIPTION
`globus rm` features all of the behaviors of `globus delete` except for `--batch` mode, and *all* of the behaviors of `globus task wait`.
Especially the most important one. If you've seen the source, you know which one.

Like `globus task wait`, we'll happily abuse stderr for all of our cosmetic IO and let stdout only be used when `-Fjson` is asked for. (In other words, the pretty text output is always "").

Refactor of support went as follows:
- Make options for `globus delete` and `globus task wait` into "shared option" decorators in globus_cli.parsing
- Move the main loop and all IO capabilities of `globus task wait` into globus_cli.services.transfer , including the exiting behaviors
- Allow for a big DRY violation between `globus delete` and `globus rm` -- is there a clean and obvious way of resolving this?

Closes #196

I stand by the opinion I voiced in #288 , but this seems safe for now and apparently folks really want it.

It may be possible to reorganize to deduplicate the code between `globus rm` and `globus delete`. However, unless anyone objects, such deduplication isn't necessary prior to our merging and releasing this.

Pulled in the tests which Aaron had previously written. Unless I'm misreading, they're all still good/valid tests, with some very mild tweaking.

I'd like to try to squeeze this into the next CLI release, so that we can close out any "parity" discussion prior to GlobusWorld.