### PR TITLE
Fix header on 'globus rm' doc page

### DIFF
--- a/adoc/rm.1.adoc
+++ b/adoc/rm.1.adoc
@@ -1,4 +1,4 @@
-= GLOBUS DELETE(1)
+= GLOBUS RM(1)
 
 == NAME
 


### PR DESCRIPTION
I noticed that the header for this page was wrong when looking at the docs site:
https://docs.globus.org/cli/reference/rm/

Titles are also hooked into the menuing logic used to build the doc site, so the right-hand menu shows `globus delete` twice.

Once this is merged, I'll open a PR to get it into the docs site.