### PR TITLE
Add support for `--format=unix`

### DIFF
--- a/adoc/include/format_option.adoc
+++ b/adoc/include/format_option.adoc
@@ -1,3 +1,22 @@
-*-F, --format* '[json|text]'::
+*-F, --format* '[json|text|unix]'::
 
 Set the output format for stdout. Defaults to "text".
++
+*TEXT* output is human-friendly textual output, usually in table or
+record-oriented format.
+In some cases, *TEXT* format is intentionally kept simple to support naive use
+of commands within a subshell, but it is not generally guaranteed to be
+parseable.
++
+*JSON* output will produce raw JSON data from underlying Globus services.
+This data is useful for using the CLI as part of a programmatic process, or for
+deciding on valid *--jmespath* queries.
++
+*UNIX* output will produce a line-by-line serialization of the result data
+(which would be visible with *JSON*).
+This is very suitable for use in pipelines with `grep`, `sort`, and other
+standard unix tools.
++
+Whenever you request *--format=UNIX*, you should also be using a *--jmespath*
+query to select the exact fields that you want.
+This better guarantees the consistency of output contents and ordering.

--- a/globus_cli/commands/ls.py
+++ b/globus_cli/commands/ls.py
@@ -2,7 +2,7 @@ import click
 
 from globus_cli.parsing import common_options, ENDPOINT_PLUS_OPTPATH
 from globus_cli.safeio import formatted_print
-from globus_cli.helpers import is_verbose, outformat_is_json
+from globus_cli.helpers import is_verbose, outformat_is_text
 from globus_cli.services.transfer import (
     get_client, autoactivate, iterable_response_to_dict)
 
@@ -96,6 +96,6 @@ def ls_command(endpoint_plus_path, recursive_depth_limit,
                      ('Filename', cleaned_item_name)],
         simple_text=(
             None
-            if long_output or is_verbose() or outformat_is_json() else
+            if long_output or is_verbose() or not outformat_is_text() else
             "\n".join(cleaned_item_name(x) for x in res)),
         json_converter=iterable_response_to_dict)

--- a/globus_cli/helpers/__init__.py
+++ b/globus_cli/helpers/__init__.py
@@ -1,5 +1,6 @@
 from globus_cli.helpers.options import (
-    outformat_is_json, outformat_is_text, verbosity, is_verbose,
+    outformat_is_json, outformat_is_text, outformat_is_unix,
+    verbosity, is_verbose,
     get_jmespath_expression)
 from globus_cli.helpers.version import print_version
 from globus_cli.helpers.local_server import (
@@ -11,7 +12,7 @@ from globus_cli.helpers.delegate_proxy import (
 __all__ = [
     'print_version',
 
-    'outformat_is_json', 'outformat_is_text',
+    'outformat_is_json', 'outformat_is_text', 'outformat_is_unix',
     'get_jmespath_expression',
 
     "verbosity", "is_verbose",

--- a/globus_cli/helpers/options.py
+++ b/globus_cli/helpers/options.py
@@ -12,6 +12,15 @@ def outformat_is_json():
     return state.outformat_is_json()
 
 
+def outformat_is_unix():
+    """
+    Only safe to call within a click context.
+    """
+    ctx = click.get_current_context()
+    state = ctx.ensure_object(CommandState)
+    return state.outformat_is_unix()
+
+
 def outformat_is_text():
     """
     Only safe to call within a click context.

--- a/globus_cli/safeio/awscli_text.py
+++ b/globus_cli/safeio/awscli_text.py
@@ -1,0 +1,146 @@
+# pulled from the AWSCLI and modified by Globus
+
+# Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+
+#     http://aws.amazon.com/apache2.0/
+
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+# START Globus changes
+import errno
+import json
+import sys
+
+# AWSCLI defines a vendored version of 'six'
+# we're going to use the stock/standard one and it should have all of the
+# same/correct behaviors
+import six
+# END Globus changes
+
+
+def format_text(data, stream):
+    _format_text(data, stream)
+
+
+def _format_text(item, stream, identifier=None, scalar_keys=None):
+    if isinstance(item, dict):
+        _format_dict(scalar_keys, item, identifier, stream)
+    elif isinstance(item, list):
+        _format_list(item, identifier, stream)
+    else:
+        # If it's not a list or a dict, we just write the scalar
+        # value out directly.
+        stream.write(six.text_type(item))
+        stream.write('\n')
+
+
+def _format_list(item, identifier, stream):
+    if not item:
+        return
+    if any(isinstance(el, dict) for el in item):
+        all_keys = _all_scalar_keys(item)
+        for element in item:
+            _format_text(element, stream=stream, identifier=identifier,
+                         scalar_keys=all_keys)
+    elif any(isinstance(el, list) for el in item):
+        scalar_elements, non_scalars = _partition_list(item)
+        if scalar_elements:
+            _format_scalar_list(scalar_elements, identifier, stream)
+        for non_scalar in non_scalars:
+            _format_text(non_scalar, stream=stream,
+                         identifier=identifier)
+    else:
+        _format_scalar_list(item, identifier, stream)
+
+
+def _partition_list(item):
+    scalars = []
+    non_scalars = []
+    for element in item:
+        if isinstance(element, (list, dict)):
+            non_scalars.append(element)
+        else:
+            scalars.append(element)
+    return scalars, non_scalars
+
+
+def _format_scalar_list(elements, identifier, stream):
+    if identifier is not None:
+        for item in elements:
+            stream.write('%s\t%s\n' % (identifier.upper(),
+                                       item))
+    else:
+        # For a bare list, just print the contents.
+        stream.write('\t'.join([six.text_type(item) for item in elements]))
+        stream.write('\n')
+
+
+def _format_dict(scalar_keys, item, identifier, stream):
+    scalars, non_scalars = _partition_dict(item, scalar_keys=scalar_keys)
+    if scalars:
+        if identifier is not None:
+            scalars.insert(0, identifier.upper())
+        stream.write('\t'.join(scalars))
+        stream.write('\n')
+    for new_identifier, non_scalar in non_scalars:
+        _format_text(item=non_scalar, stream=stream,
+                     identifier=new_identifier)
+
+
+def _all_scalar_keys(list_of_dicts):
+    keys_seen = set()
+    for item_dict in list_of_dicts:
+        for key, value in item_dict.items():
+            if not isinstance(value, (dict, list)):
+                keys_seen.add(key)
+    return list(sorted(keys_seen))
+
+
+def _partition_dict(item_dict, scalar_keys):
+    # Given a dictionary, partition it into two list based on the
+    # values associated with the keys.
+    # {'foo': 'scalar', 'bar': 'scalar', 'baz': ['not, 'scalar']}
+    # scalar = [('foo', 'scalar'), ('bar', 'scalar')]
+    # non_scalar = [('baz', ['not', 'scalar'])]
+    scalar = []
+    non_scalar = []
+    if scalar_keys is None:
+        # scalar_keys can have more than just the keys in the item_dict,
+        # but if user does not provide scalar_keys, we'll grab the keys
+        # from the current item_dict
+        for key, value in sorted(item_dict.items()):
+            if isinstance(value, (dict, list)):
+                non_scalar.append((key, value))
+            else:
+                scalar.append(six.text_type(value))
+    else:
+        for key in scalar_keys:
+            scalar.append(six.text_type(item_dict.get(key, '')))
+        remaining_keys = sorted(set(item_dict.keys()) - set(scalar_keys))
+        for remaining_key in remaining_keys:
+            non_scalar.append((remaining_key, item_dict[remaining_key]))
+    return scalar, non_scalar
+
+
+# START Globus changes
+def unix_formatted_print(data):
+    format_text(data, sys.stdout)
+    try:
+        sys.stdout.flush()
+    except IOError as err:
+        if err.errno is errno.EPIPE:
+            pass
+        else:
+            raise
+
+
+if __name__ == '__main__':
+    unix_formatted_print(json.load(sys.stdin))
+# END Globus changes


### PR DESCRIPTION
Pull in the awscli `--output=text` formatter, modify it very slightly to make it usable, clearly marking modifications, and setup `--format=unix` to pass `--jmespath` processed data through this transform.
(It's Apache2 licensed, and we discussed that we're comfortable with this usage.)

`--format=unix` is not guaranteed to be pretty and friendly, and with certain nesting structures can actually be quite a mess. But it is *consistent* and *good enough*.

The data is output as TSV, and we're okay with that. Fields containing tabs may expand in nasty ways -- but that's pretty rare and people shouldn't do that anyway. If you need really careful data handling, use the SDK or the `-Fjson` output.

This needs some thorough testing and documentation before it can be released, and I plan to add that to this PR before we consider merging it. However, preliminary review would help.

I've already found at least one case in which this fails
```
globus task list -Funix --jq 'DATA[*].[task_id, status, event_link]'
```
which suggests that I'm somehow misapplying the awscli text module.