### PR TITLE
Ensure that JSON string output is a *JSON* string

### DIFF
--- a/globus_cli/safeio/output_formatter.py
+++ b/globus_cli/safeio/output_formatter.py
@@ -69,10 +69,7 @@ def _jmespath_preprocess(res):
 
 def print_json_response(res):
     res = _jmespath_preprocess(res)
-
-    if not isinstance(res, six.string_types):
-        res = json.dumps(res, indent=2, separators=(',', ': '))
-
+    res = json.dumps(res, indent=2, separators=(',', ': '))
     safeprint(res)
 
 


### PR DESCRIPTION
Don't make quoting of string output conditional. This is a behavioral change and therefore wrong.

Should I add a test for this as well? e.g. `globus whoami --jmespath 'Username'` and make sure it's quoted?