### PR TITLE
Make JSON output use `sort_keys` to force ordering

### DIFF
--- a/globus_cli/safeio/output_formatter.py
+++ b/globus_cli/safeio/output_formatter.py
@@ -69,7 +69,7 @@ def _jmespath_preprocess(res):
 
 def print_json_response(res):
     res = _jmespath_preprocess(res)
-    res = json.dumps(res, indent=2, separators=(',', ': '))
+    res = json.dumps(res, indent=2, separators=(',', ': '), sort_keys=True)
     safeprint(res)
 
 


### PR DESCRIPTION
When dumping an object to JSON output, use `sort_keys` to ensure that ordering is consistent.

This doesn't need to be a documented part of the interface for the CLI, that we use sorted JSON output, but it results in more consistent behavior. Nobody *should* be relying on the order of the output, but
this way, if they *are*, we'll be able to give them better behavior.