### PR TITLE
Add several examples of `--format=UNIX` to docs

### DIFF
--- a/adoc/bookmark_create.1.adoc
+++ b/adoc/bookmark_create.1.adoc
@@ -43,5 +43,14 @@ Create a bookmark named 'mybookmark':
 $ globus bookmark create 'ddb59aef-6d04-11e5-ba46-22000b92c6ec:/~/' mybookmark
 ----
 
+Take a specific field from the JSON output and format it into unix-friendly
+output by using '--jmespath' and '--format=UNIX':
+
+----
+$ globus bookmark create \
+    'ddb59aef-6d04-11e5-ba46-22000b92c6ec:/~/' mybookmark \
+     -F unix --jmespath 'id'
+----
+
 
 include::include/exit_status.adoc[]

--- a/adoc/bookmark_list.1.adoc
+++ b/adoc/bookmark_list.1.adoc
@@ -32,5 +32,12 @@ When textual output is requested, the following fields are displayed:
 $ globus bookmark list
 ----
 
+Format specific fields in the bookmark list into unix-friendly columnar
+output:
+
+----
+$ globus bookmark list --jmespath='DATA[*].[name, endpoint_id]' --format=unix
+----
+
 
 include::include/exit_status.adoc[]

--- a/adoc/bookmark_rename.1.adoc
+++ b/adoc/bookmark_rename.1.adoc
@@ -27,7 +27,7 @@ success message.
 Rename a bookmark named "oldname" to "newname":
 
 ----
-$ globus bookmark delete oldname newname
+$ globus bookmark rename oldname newname
 ----
 
 

--- a/adoc/delete.1.adoc
+++ b/adoc/delete.1.adoc
@@ -109,4 +109,15 @@ $ globus delete $ep_id --batch --recursive
 <EOF>
 ----
 
+Submit a deletion task and get back the task ID for use in `globus task wait`:
+
+----
+$ ep_id=ddb59af0-6d04-11e5-ba46-22000b92c6ec
+$ task_id="$(globus delete $ep_id:~/mydir --recursive \
+    --jmespath 'task_id' --format unix)"
+$ echo "Waiting on $task_id"
+$ globus task wait "$task_id"
+----
+
+
 include::include/exit_status.adoc[]

--- a/adoc/endpoint_is_activated.1.adoc
+++ b/adoc/endpoint_is_activated.1.adoc
@@ -14,7 +14,7 @@ globus endpoint is-activated - Check if an endpoint is activated
 
 The *globus endpoint is-activated* command checks if an endpoint is already
 activated or requires activation to be used. If the endpoint is not activated
-a link will be given for web activation, or you can use 
+a link will be given for web activation, or you can use
 *globus endpoint activate* to activate the endpoint.
 
 == OPTIONS
@@ -27,6 +27,39 @@ include::include/common_options.adoc[]
 ----
 $ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
 $ globus endpoint is-activated $ep_id
+----
+
+Check *globus endpoint is-activated* as part of a script:
+
+----
+ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
+globus endpoint is-activated $ep_id
+if [ $? -ne 0 ]; then
+    echo "$ep_id is not activated! This script cannot run!"
+    exit 1
+fi
+# ... more stuff using $ep_id below ...
+----
+
+Use `is-activated` to get and parse activation requirements, finding out the
+expiration time, but only for endpoints which are activated. Uses '--jmespath'
+to select fields, exit status to indicate that the endpoint is or is not
+activated, and '--format=UNIX' to get nice, unix-friendly output.
+
+----
+ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
+output="$(globus endpoint is-activated "$ep_id" \
+    --jmespath expires_in --format unix)"
+if [ $? -eq 0 ]; then
+    if [ "$output" -eq "-1" ]; then
+        echo "$ep_id is activated forever. Activation never expires."
+    else
+        echo "$ep_id activation expires in $output seconds"
+    fi
+else
+    echo "$ep_id not activated"
+    exit 1
+fi
 ----
 
 

--- a/adoc/include/jmespath_option.adoc
+++ b/adoc/include/jmespath_option.adoc
@@ -1,8 +1,10 @@
 *--jq, --jmespath* 'EXPR'::
 
-Supply a JMESPath expression to apply to json output.
-Takes precedence over any specified '--format' and forces the format to be json
-processed by this expression.
+Supply a JMESPath expression to apply to JSON output.
++
+This option is compatible with '--format=JSON' and '--format=UNIX'.
+If '--format=TEXT' is specified, output will be rendered as if '--format=JSON'
+had been specified instead.
 +
 A full specification of the JMESPath language for querying JSON structures may
 be found at https://jmespath.org/

--- a/adoc/ls.1.adoc
+++ b/adoc/ls.1.adoc
@@ -65,19 +65,38 @@ include::include/common_options.adoc[]
 
 == EXAMPLES
 
-List files and dirs in your default directory on an endpoint.
+List files and dirs in your default directory on an endpoint
 
 ----
 $ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
 $ globus ls $ep_id
 ----
 
-List files and dirs on a specific path on an endpoint.
+List files and dirs on a specific path on an endpoint
 
 ----
 $ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
 $ globus ls $ep_id:/share/godata/
 ----
+
+Do a *globus ls* requesting JSON formatted output
+
+----
+$ globus ls $ep_id:/share/godata/ --format=JSON
+----
+
+Take specific fields from the JSON output and format them into unix-friendly
+columnar output using '--jmespath' to query and '--format UNIX' to format
+output:
+
+----
+$ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
+$  globus ls $ep_id:/share/godata/ \
+    --jmespath 'DATA[*].[type, permissions, name, last_modified]' \
+    --format UNIX
+----
+
+=== Filtering
 
 List files and dirs on a specific path on an endpoint, filtering in various
 ways.
@@ -92,7 +111,7 @@ $ globus ls $ep_id:/share/godata/ --filter 'file2.txt'  # same as '=file2.txt'
 $ globus ls $ep_id:/share/godata/ --filter '!=file2.txt'  # anything but "file2.txt"
 ----
 
-Compare a grep with a `globus ls --filter`. These two are the same, but the
+Compare a grep with a *globus ls --filter*. These two are the same, but the
 filter will be faster because it doesn't require that filenames which are
 filtered out are returned to the CLI:
 

--- a/adoc/task_list.1.adoc
+++ b/adoc/task_list.1.adoc
@@ -99,4 +99,14 @@ $ globus task list --limit 100 \
     --filter-not-label 'autolabel' --exact
 ----
 
+List active transfers in a tabular format suitable for consumption by unix
+tools:
+
+----
+$ globus task list --format unix \
+    --jmespath 'DATA[?status==`ACTIVE`].[task_id, source_endpoint_id, destination_endpoint_id, label]'
+----
+
+NOTE: 'destination_endpoint_id' will be 'None' in the case of Delete tasks.
+
 include::include/exit_status.adoc[]

--- a/adoc/task_list.1.adoc
+++ b/adoc/task_list.1.adoc
@@ -109,4 +109,24 @@ $ globus task list --format unix \
 
 NOTE: 'destination_endpoint_id' will be 'None' in the case of Delete tasks.
 
+Cancel all tasks with expired credentials:
+
+----
+# careful: do not quote this output, but instead rely on the shell's
+# word-splitting for this for-loop
+for id in $(globus task list --filter-status=INACTIVE \
+                             --format=UNIX \
+                             --jmespath='DATA[*].task_id'); do
+    globus task cancel $id
+done
+----
+
+Print out task statuses with links to their pages in the web UI:
+
+----
+globus task list --format=unix --jmespath='DATA[*].[task_id, status]' | \
+    awk '{printf "Task %s is currently %s\n", $1, $2;
+          printf "View at https://www.globus.org/app/activity/%s\n\n", $1}'
+----
+
 include::include/exit_status.adoc[]

--- a/adoc/transfer.1.adoc
+++ b/adoc/transfer.1.adoc
@@ -178,4 +178,33 @@ godata mygodatadir -r
 ----
 
 
+Consume a batch of files to transfer from a data file, submit the transfer
+task, get back its task ID for use in `globus task wait`, wait for up to 30
+seconds for the task to complete, and then print a success or failure message.
+
+----
+$ cat my_file_batch.txt
+/share/godata/file1.txt ~/myfile1.txt
+/share/godata/file2.txt ~/myfile2.txt
+/share/godata/file3.txt ~/myfile3.txt
+----
+
+----
+source_ep=ddb59aef-6d04-11e5-ba46-22000b92c6ec
+dest_ep=ddb59af0-6d04-11e5-ba46-22000b92c6ec
+
+task_id="$(globus transfer $source_ep $dest_ep \
+    --jmespath 'task_id' --format=UNIX \
+    --batch < my_file_batch.txt)"
+
+echo "Waiting on 'globus transfer' task '$task_id'"
+globus task wait "$task_id" --timeout 30
+if [ $? -eq 0 ]; then
+    echo "$task_id completed successfully";
+else
+    echo "$task_id failed!";
+fi
+----
+
+
 include::include/exit_status.adoc[]


### PR DESCRIPTION
Docs for several commands feature exciting uses of `--format=UNIX` output amongst their various examples. Although it would be nice to get these examples in place for *all* commands, this is a decent start.