### PR TITLE
fix endpoint role list's handling of group principals

### DIFF
--- a/globus_cli/commands/endpoint/role/list.py
+++ b/globus_cli/commands/endpoint/role/list.py
@@ -12,7 +12,11 @@ def principal_str(role):
     principal = role['principal']
     if role['principal_type'] == 'identity':
         username = lookup_identity_name(principal)
-    return username or principal
+        return username or principal
+    elif role['principal_type'] == 'group':
+        return (u'https://www.globus.org/app/groups/{}').format(principal)
+    else:
+        return principal
 
 
 @click.command('list', help='List of assigned roles on an endpoint')


### PR DESCRIPTION
Ran into an error in `globus endpoint role list` when a role's principal was a group so the `username` variable wasn't being initialized.