### PR TITLE
Add verbose output to `globus version`

### DIFF
--- a/globus_cli/helpers/version.py
+++ b/globus_cli/helpers/version.py
@@ -1,5 +1,46 @@
+import platform
+import site
+import sys
+
+from globus_cli.helpers.options import is_verbose, verbosity
 from globus_cli.safeio import safeprint
 from globus_cli.version import get_versions
+
+
+def _get_package_data():
+    """
+    Import a set of important packages and return relevant data about them in a
+    dict.
+    Imports are done in here to avoid potential for circular imports and other
+    problems, and to make iteration simpler.
+    """
+    moddata = []
+    modlist = ('click', 'configobj', 'cryptography', 'globus_cli',
+               'globus_sdk', 'jmespath', 'requests', 'six')
+    if verbosity() < 2:
+        modlist = ('globus_cli', 'globus_sdk', 'requests')
+
+    for mod in modlist:
+        cur = [mod]
+        try:
+            loaded_mod = __import__(mod)
+        except ImportError:
+            loaded_mod = None
+
+        for attr in ('__version__', '__file__', '__path__'):
+            # if loading failed, be sure to pad with error messages
+            if loaded_mod is None:
+                cur.append('[import failed]')
+                continue
+
+            try:
+                attrval = getattr(loaded_mod, attr)
+            except AttributeError:
+                attrval = ''
+            cur.append(attrval)
+        moddata.append(cur)
+
+    return moddata
 
 
 def print_version():
@@ -29,3 +70,25 @@ def print_version():
                  'You are running a preview version of the Globus CLI'
             )
         )
+
+    # verbose shows more platform and python info
+    # it also includes versions of some CLI dependencies
+    if is_verbose():
+        moddata = _get_package_data()
+
+        safeprint('\nVerbose Data\n---')
+
+        safeprint('platform:')
+        safeprint('  platform: {}'.format(platform.platform()))
+        safeprint('  py_implementation: {}'
+                  .format(platform.python_implementation()))
+        safeprint('  py_version: {}'.format(platform.python_version()))
+        safeprint('  sys.executable: {}'.format(sys.executable))
+        safeprint('  site.USER_BASE: {}'.format(site.USER_BASE))
+
+        safeprint('modules:')
+        for mod, modversion, modfile, modpath in moddata:
+            safeprint('  {}:'.format(mod))
+            safeprint('    __version__: {}'.format(modversion))
+            safeprint('    __file__: {}'.format(modfile))
+            safeprint('    __path__: {}'.format(modpath))


### PR DESCRIPTION
Prints py interpreter info, and some package/module info.

We discussed this a while ago and it's been sitting in my fork waiting for me to look at it again.
No rush; review at your leisure.

Sample output:
```
$ globus -vvv --version                                                                                                                   
Installed Version: 1.6.2                                                                                                                                              
Latest Version:    1.6.2                                                                                                                                              
                                                                                                                                                                      
You are running the latest version of the Globus CLI                                                                                                                  
                                                                                                                                                                      
Verbose Data                                                                                                                                                          
---                                                                                                                                                                   
platform:                                                                                                                                                             
  platform: Linux-4.15.0-1010-aws-x86_64-with-Ubuntu-18.04-bionic                                                                                                     
  py_implementation: CPython                                                                                                                                          
  py_version: 2.7.15rc1                                                                                                                                               
  sys.executable: /mnt/efs/home/sirosen/dev/globus-cli/.venv/bin/python                                                                                               
  site.USER_BASE: /mnt/efs/home/sirosen/.local                                                                                                                        
modules:                                                                                                                                                              
  click:                                                                                                                                                              
    __version__: 6.7                                                                                                                                                  
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/click-6.7-py2.7.egg/click/__init__.pyc                                     
    __path__: ['/mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/click-6.7-py2.7.egg/click']                                              
  configobj:                                                                                                                                                          
    __version__: 5.0.6                                                                                                                                                
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/configobj-5.0.6-py2.7.egg/configobj.pyc                                    
    __path__:                                                                                                                                                         
  cryptography:                                                                                                                                                       
    __version__: 2.2.2                                                                                                                                                
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/cryptography-2.2.2-py2.7-linux-x86_64.egg/cryptography/__init__.pyc        
    __path__: ['/mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/cryptography-2.2.2-py2.7-linux-x86_64.egg/cryptography']                 
  globus_cli:                                                                                                                                                         
    __version__: 1.6.2                                                                                                                                                
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/globus_cli/__init__.pyc                                                                                            
    __path__: ['/mnt/efs/home/sirosen/dev/globus-cli/globus_cli']                                                                                                     
  globus_sdk:                                                                                                                                                         
    __version__: 1.5.0                                                                                                                                                
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/globus_sdk-1.5.0-py2.7.egg/globus_sdk/__init__.pyc                         
    __path__: ['/mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/globus_sdk-1.5.0-py2.7.egg/globus_sdk']                                  
  jmespath:                                                                                                                                                           
    __version__: 0.9.2                                                                                                                                                
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/jmespath-0.9.2-py2.7.egg/jmespath/__init__.pyc                             
    __path__: ['/mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/jmespath-0.9.2-py2.7.egg/jmespath']                                      
  requests:                                                                                                                                                           
    __version__: 2.19.1                                                                                                                                               
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/requests-2.19.1-py2.7.egg/requests/__init__.pyc                            
    __path__: ['/mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/requests-2.19.1-py2.7.egg/requests']                                     
  six:                                                                                                                                                                
    __version__: 1.11.0                                                                                                                                               
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/six-1.11.0-py2.7.egg/six.pyc                                               
    __path__: [] 
```

```
$ globus -v --version
Installed Version: 1.6.2
Latest Version:    1.6.2

You are running the latest version of the Globus CLI

Verbose Data
---
platform:
  platform: Linux-4.15.0-1010-aws-x86_64-with-Ubuntu-18.04-bionic
  py_implementation: CPython
  py_version: 2.7.15rc1
  sys.executable: /mnt/efs/home/sirosen/dev/globus-cli/.venv/bin/python
  site.USER_BASE: /mnt/efs/home/sirosen/.local
modules:
  globus_cli:
    __version__: 1.6.2
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/globus_cli/__init__.pyc
    __path__: ['/mnt/efs/home/sirosen/dev/globus-cli/globus_cli']
  globus_sdk:
    __version__: 1.5.0
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/globus_sdk-1.5.0-py2.7.egg/globus_sdk/__init__.pyc
    __path__: ['/mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/globus_sdk-1.5.0-py2.7.egg/globus_sdk']
  requests:
    __version__: 2.19.1
    __file__: /mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/requests-2.19.1-py2.7.egg/requests/__init__.pyc
    __path__: ['/mnt/efs/home/sirosen/dev/globus-cli/.venv/local/lib/python2.7/site-packages/requests-2.19.1-py2.7.egg/requests']
```

NOTE: `globus --version -v` doesn't work because both options are eager and `--version` gets evaluated first. I think that is reason enough that in CLI v2, `--version` shouldn't be an option, and we should consolidate to `globus version` as the only way of getting version info. A debate for another time.