### PR TITLE
Batch resolve IDs to usernames in permissions list

### DIFF
--- a/globus_cli/commands/endpoint/permission/list.py
+++ b/globus_cli/commands/endpoint/permission/list.py
@@ -2,8 +2,35 @@ import click
 
 from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.safeio import formatted_print
-from globus_cli.services.auth import lookup_identity_name
+from globus_cli.helpers import outformat_is_text
+from globus_cli.services.auth import get_auth_client
 from globus_cli.services.transfer import get_client
+
+_id_batch_size = 100
+
+
+def _resolve_identities(rules):
+    """
+    Batch resolve identities to usernames.
+    Used only for text-output to get a nice listing.
+
+    Returns a dict mapping IDs to usernames.
+    """
+    to_resolve = set()
+    for rule in rules:
+        if rule['principal_type'] == 'identity':
+            to_resolve.add(rule['principal'])
+    to_resolve = list(to_resolve)
+
+    ac = get_auth_client()
+    resolved_map = {}
+    for i in range(0, len(to_resolve), _id_batch_size):
+        chunk = to_resolve[i:i+_id_batch_size]
+        resolved_result = ac.get_identities(ids=chunk)
+        for x in resolved_result['identities']:
+            resolved_map[x['id']] = x['username']
+
+    return resolved_map
 
 
 @click.command('list', help='List of permissions on an endpoint')
@@ -17,10 +44,14 @@ def list_command(endpoint_id):
 
     rules = client.endpoint_acl_list(endpoint_id)
 
+    resolved_map = {}
+    if outformat_is_text():
+        resolved_map = _resolve_identities(rules)
+
     def principal_str(rule):
         principal = rule['principal']
         if rule['principal_type'] == 'identity':
-            username = lookup_identity_name(principal)
+            username = resolved_map.get(rule['principal'])
 
             return username or principal
         elif rule['principal_type'] == 'group':


### PR DESCRIPTION
When doing an ACL listing, we resolve identities one-by-one (*and* we don't keep the results). The result is that the permissions list takes many times longer than it should.

For now, apply a fix directly in this command. As a future refinement, we should make mapping identities to usernames in bulk a generic operation which many commands can share. There are presumably other cases for this type of lookup? If not, leave it as something specific to this command, but maybe come back and clean it up a little.

I'd like to do something in which we can be a bit less ham-fisted about checking for text output, but maybe this way is best.

Closes #422