### PR TITLE
Simplify lazy bulk identity lookups, apply to `role list`

### DIFF
--- a/globus_cli/commands/endpoint/permission/list.py
+++ b/globus_cli/commands/endpoint/permission/list.py
@@ -2,35 +2,10 @@ import click
 
 from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.safeio import formatted_print
-from globus_cli.helpers import outformat_is_text
-from globus_cli.services.auth import get_auth_client
+
+from globus_cli.services.auth import LazyIdentityMap
+
 from globus_cli.services.transfer import get_client
-
-_id_batch_size = 100
-
-
-def _resolve_identities(rules):
-    """
-    Batch resolve identities to usernames.
-    Used only for text-output to get a nice listing.
-
-    Returns a dict mapping IDs to usernames.
-    """
-    to_resolve = set()
-    for rule in rules:
-        if rule['principal_type'] == 'identity':
-            to_resolve.add(rule['principal'])
-    to_resolve = list(to_resolve)
-
-    ac = get_auth_client()
-    resolved_map = {}
-    for i in range(0, len(to_resolve), _id_batch_size):
-        chunk = to_resolve[i:i+_id_batch_size]
-        resolved_result = ac.get_identities(ids=chunk)
-        for x in resolved_result['identities']:
-            resolved_map[x['id']] = x['username']
-
-    return resolved_map
 
 
 @click.command('list', help='List of permissions on an endpoint')
@@ -44,15 +19,13 @@ def list_command(endpoint_id):
 
     rules = client.endpoint_acl_list(endpoint_id)
 
-    resolved_map = {}
-    if outformat_is_text():
-        resolved_map = _resolve_identities(rules)
+    resolved_ids = LazyIdentityMap(
+        x['principal'] for x in rules if x['principal_type'] == 'identity')
 
     def principal_str(rule):
         principal = rule['principal']
         if rule['principal_type'] == 'identity':
-            username = resolved_map.get(rule['principal'])
-
+            username = resolved_ids.get(principal)
             return username or principal
         elif rule['principal_type'] == 'group':
             return (u'https://www.globus.org/app/groups/{}'

--- a/globus_cli/commands/endpoint/role/list.py
+++ b/globus_cli/commands/endpoint/role/list.py
@@ -3,20 +3,9 @@ import click
 from globus_cli.parsing import common_options, endpoint_id_arg
 from globus_cli.safeio import formatted_print
 
-from globus_cli.services.auth import lookup_identity_name
+from globus_cli.services.auth import LazyIdentityMap
 
 from globus_cli.services.transfer import get_client
-
-
-def principal_str(role):
-    principal = role['principal']
-    if role['principal_type'] == 'identity':
-        username = lookup_identity_name(principal)
-        return username or principal
-    elif role['principal_type'] == 'group':
-        return (u'https://www.globus.org/app/groups/{}').format(principal)
-    else:
-        return principal
 
 
 @click.command('list', help='List of assigned roles on an endpoint')
@@ -28,6 +17,19 @@ def role_list(endpoint_id):
     """
     client = get_client()
     roles = client.endpoint_role_list(endpoint_id)
+
+    resolved_ids = LazyIdentityMap(
+        x['principal'] for x in roles if x['principal_type'] == 'identity')
+
+    def principal_str(role):
+        principal = role['principal']
+        if role['principal_type'] == 'identity':
+            username = resolved_ids.get(principal)
+            return username or principal
+        elif role['principal_type'] == 'group':
+            return (u'https://www.globus.org/app/groups/{}').format(principal)
+        else:
+            return principal
 
     formatted_print(roles, fields=[
         ('Principal Type', 'principal_type'), ('Role ID', 'id'),

--- a/globus_cli/services/auth.py
+++ b/globus_cli/services/auth.py
@@ -71,3 +71,40 @@ def maybe_lookup_identity_id(identity_name, provision=False):
 
 def lookup_identity_name(identity_id):
     return _lookup_identity_field(id_id=identity_id, field='username')
+
+
+class LazyIdentityMap(object):
+    """
+    There's a common pattern of not needing identity IDs resolved to
+    usernames until text output is being rendered.
+
+    Rather than having all of the usage sites explicitly check the output
+    format which is going to be used, define a lazy dict-like type which does a
+    bulk identity lookup whenever it is first accessed.
+    """
+    def __init__(self, identity_ids):
+        # uniquify and copy
+        self.identity_ids = list(set(identity_ids))
+
+        self._resolved_map = None
+
+    def _lookup_identity_names(self):
+        """
+        Batch resolve identities to usernames.
+        Returns a dict mapping IDs to Usernames
+        """
+        id_batch_size = 100
+
+        # fetch in batches of 100, store in a dict
+        ac = get_auth_client()
+        self._resolved_map = {}
+        for i in range(0, len(self.identity_ids), id_batch_size):
+            chunk = self.identity_ids[i:i+id_batch_size]
+            resolved_result = ac.get_identities(ids=chunk)
+            for x in resolved_result['identities']:
+                self._resolved_map[x['id']] = x['username']
+
+    def get(self, *args, **kwargs):
+        if self._resolved_map is None:
+            self._lookup_identity_names()
+        return self._resolved_map.get(*args, **kwargs)


### PR DESCRIPTION
Define a new helper object: LazyIdentityMap which is dict-like (but not actually a dict -- why bother?) which handles mapping identity ids to names.
Use it for `role list` and replace the prior method which I used in `permissions list`. This also fulfills any need for a `lookup_identity_usernames` helper.

It accepts a list of IDs to lookup when it's instantiated, and does the lookup whenever it is first accessed. This isn't the "laziest" behavior possible, certainly -- but it's simple and effective.

The big advantage is that we can declare that we want the LazyIdentityMap ready, and then not worry about which output format is going to be used. It will only (in practice) be checked when text
formatting is done.

As a result, `-Fjson` and `-Funix` output still run just as fast, and `-Ftext` output triggers the right action, but without a sloppy `outformat_is_text()` check in the command to decide whether or not to populate an identity map.

I think this comes out cleaner at the usage sites by enough to warrant the extra complexity, but I'm also open to the opinion that we should just explicitly check if `outformat_is_text()` the way I had it before.