### PR TITLE
Minor tweak to adoc/index to match doc site

### DIFF
--- a/adoc/index.adoc
+++ b/adoc/index.adoc
@@ -1,6 +1,12 @@
 = Command Line Interface (CLI) Reference
 
-NOTE: This page refers to the current Globus CLI which is locally installed program. We also have a link:../hosted[reference for the hosted CLI], which is accessed via SSH but will eventually be deprecated.
+[NOTE]
+====
+This page refers to the current Globus CLI which is locally installed program.
+We also have a link:../legacy[reference for the hosted CLI], which is accessed
+via SSH but is deprecated.
+Support for the Hosted CLI will end August 1st, 2018.
+====
 
 link:list_commands[globus list-commands]::
 List all CLI commands


### PR DESCRIPTION
We updated to this header note on the doc site, but not here in the repo. As a result, if you sync docs from this repo, you end up unintentionally changing the header there.