### PR TITLE
Add section to contrib doc about releasing

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -141,13 +141,14 @@ If you are a CLI maintainer, you need to be able to do a release.
 Setup:
 
   - Make sure you have a pypi account
-  - Setup your credentials for twine (the pypi upload tool) https://github.com/pypa/twine[twine docs for detail]
-  - Make sure you have a gpg key setup for use with git
+  - Setup your credentials for twine (the pypi upload tool)
+      https://github.com/pypa/twine[twine docs for detail]
+  - Make sure you have a gpg key setup for use with git.
+      https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work[git-scm.com guide for detail]
 
 Do it:
 
-  - `rm -r dist/` to make sure there are no old or weird source dists lying around
-  - `make upload` to build new source dists in `dist/` and upload via twine
-  - `git tag -s $VERSION` and write `v${VERSION}` in the tag. e.g. `v1.7.0`
+  - `make release` to build source dists, upload via twine, and tag the release
+  - push the newly created version tag to GitHub
   - Ensure that `docs.globus.org` gets updated with new docs/changelog
       Procedure is set in that repo.

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -131,3 +131,23 @@ Some rules and tips for the python and documentation in this project.
   - Use named parameters, not positional arguments
   - Use the verbs `create`, `show`, `update`, and `remove` for underlying API
       CRUD operations
+
+
+Releasing a Version
+-------------------
+
+If you are a CLI maintainer, you need to be able to do a release.
+
+Setup:
+
+  - Make sure you have a pypi account
+  - Setup your credentials for twine (the pypi upload tool) https://github.com/pypa/twine[twine docs for detail]
+  - Make sure you have a gpg key setup for use with git
+
+Do it:
+
+  - `rm -r dist/` to make sure there are no old or weird source dists lying around
+  - `make upload` to build new source dists in `dist/` and upload via twine
+  - `git tag -s $VERSION` and write `v${VERSION}` in the tag. e.g. `v1.7.0`
+  - Ensure that `docs.globus.org` gets updated with new docs/changelog
+      Procedure is set in that repo.

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,23 @@
 VIRTUALENV=.venv
+CLI_VERSION=$(shell grep '^__version__' globus_cli/version.py | cut -d '"' -f2)
 
-.PHONY: build upload localdev test clean help travis
+.PHONY: build release localdev test clean showvars help travis
 
 help:
 	@echo "These are our make targets and what they do."
 	@echo "All unlisted targets are internal."
 	@echo ""
 	@echo "  help:      Show this helptext"
+	@echo "  showvars:  Show makefile variables"
 	@echo "  localdev:  Setup local development env with a 'setup.py develop'"
-	@echo "  build:     Create the distributions which we like to upload to pypi"
+	@echo "  build:     Create the source distributions for release"
 	@echo "  test:      Run the full suite of tests"
-	@echo "  upload:    [build], but also upload to pypi using twine"
+	@echo "  release:   [build], but also upload to pypi using twine and create a signed git tag"
 	@echo "  clean:     Remove typically unwanted files, mostly from [build]"
+
+
+showvars:
+	@echo "CLI_VERSION=$(CLI_VERSION)"
 
 
 $(VIRTUALENV):
@@ -25,15 +31,16 @@ localdev: $(VIRTUALENV)
 
 
 build: $(VIRTUALENV)
+	rm -rf dist/
 	$(VIRTUALENV)/bin/python setup.py sdist bdist_egg
 
 
 $(VIRTUALENV)/bin/twine: $(VIRTUALENV) upload-requirements.txt
 	$(VIRTUALENV)/bin/pip install -U -r upload-requirements.txt
 
-upload: $(VIRTUALENV)/bin/twine build
+release: $(VIRTUALENV)/bin/twine build
 	$(VIRTUALENV)/bin/twine upload dist/*
-
+	git tag -s "$(CLI_VERSION)" -m "v$(CLI_VERSION)"
 
 $(VIRTUALENV)/bin/flake8 $(VIRTUALENV)/bin/nose2: test-requirements.txt $(VIRTUALENV)
 	$(VIRTUALENV)/bin/pip install -r test-requirements.txt


### PR DESCRIPTION
So that our release procedure is documented.

I noticed we didn't have this when getting Aaron set to do a release (because we realized he hadn't done one before).
Unlike the other parts of the contrib doc, I'm not interested in this being super-friendly -- it just need to be what someone new to the project but sufficiently knowledgeable needs to know.