### PR TITLE
Update WebApp links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,4 @@ clean:
 	-rm -r dist
 	-rm -r build
 	-rm -r *.egg-info
+	find . -name '*.pyc' -delete

--- a/adoc/task_list.1.adoc
+++ b/adoc/task_list.1.adoc
@@ -126,7 +126,7 @@ Print out task statuses with links to their pages in the web UI:
 ----
 globus task list --format=unix --jmespath='DATA[*].[task_id, status]' | \
     awk '{printf "Task %s is currently %s\n", $1, $2;
-          printf "View at https://www.globus.org/app/activity/%s\n\n", $1}'
+          printf "View at https://app.globus.org/activity/%s\n\n", $1}'
 ----
 
 include::include/exit_status.adoc[]

--- a/globus_cli/commands/endpoint/activate.py
+++ b/globus_cli/commands/endpoint/activate.py
@@ -189,7 +189,7 @@ def endpoint_activate(endpoint_id,
 
     # web activation
     elif web:
-        url = ("https://www.globus.org/app/"
+        url = ("https://app.globus.org/"
                "endpoints/{}/activate".format(endpoint_id))
         if no_browser or is_remote_session():
             res = {"message": "Web activation url: {}".format(url),

--- a/globus_cli/commands/endpoint/activate.py
+++ b/globus_cli/commands/endpoint/activate.py
@@ -189,8 +189,8 @@ def endpoint_activate(endpoint_id,
 
     # web activation
     elif web:
-        url = ("https://app.globus.org/"
-               "endpoints/{}/activate".format(endpoint_id))
+        url = ("https://app.globus.org/file-manager"
+               "?origin_id={}".format(endpoint_id))
         if no_browser or is_remote_session():
             res = {"message": "Web activation url: {}".format(url),
                    "url": url}

--- a/globus_cli/commands/endpoint/permission/list.py
+++ b/globus_cli/commands/endpoint/permission/list.py
@@ -28,7 +28,7 @@ def list_command(endpoint_id):
             username = resolved_ids.get(principal)
             return username or principal
         elif rule['principal_type'] == 'group':
-            return (u'https://www.globus.org/app/groups/{}'
+            return (u'https://app.globus.org/groups/{}'
                     ).format(principal)
         else:
             principal = rule['principal_type']

--- a/globus_cli/commands/endpoint/permission/show.py
+++ b/globus_cli/commands/endpoint/permission/show.py
@@ -10,7 +10,7 @@ def _shared_with_keyfunc(rule):
     if rule['principal_type'] == 'identity':
         return lookup_identity_name(rule['principal'])
     elif rule['principal_type'] == 'group':
-        return (u'https://www.globus.org/app/groups/{}'
+        return (u'https://app.globus.org/groups/{}'
                 .format(rule['principal']))
     else:
         return rule['principal_type']

--- a/globus_cli/commands/endpoint/role/list.py
+++ b/globus_cli/commands/endpoint/role/list.py
@@ -27,7 +27,7 @@ def role_list(endpoint_id):
             username = resolved_ids.get(principal)
             return username or principal
         elif role['principal_type'] == 'group':
-            return (u'https://www.globus.org/app/groups/{}').format(principal)
+            return (u'https://app.globus.org/groups/{}').format(principal)
         else:
             return principal
 


### PR DESCRIPTION
- all links to www.globus.org/app are rewritten as app.globus.org
- no other changes to the request URIs are made

Primarily impacts the display of Group links, but also some activation links and an example on one of the docs pages of a task overview link.

There's also a one-line addition to `make clean` because I did a `make clean; fgrep -R 'www.globus.org'` and was annoyed to see pyc files in my results.