### PR TITLE
GCP connection/paused status via the endpoint resource

### DIFF
--- a/globus_cli/commands/endpoint/server/show.py
+++ b/globus_cli/commands/endpoint/server/show.py
@@ -1,4 +1,5 @@
 import click
+from textwrap import dedent
 
 from globus_cli.parsing import common_options, endpoint_id_arg, server_id_arg
 from globus_cli.safeio import formatted_print, FORMAT_TEXT_RECORD
@@ -18,8 +19,13 @@ def server_show(endpoint_id, server_id):
 
     server_doc = client.get_endpoint_server(endpoint_id, server_id)
     if not server_doc['uri']:  # GCP endpoint server
-        fields = (('ID', 'id'), ('Is Connected', 'is_connected'),
-                  ('Is Paused (macOS only)', 'is_paused'))
+        fields = (('ID', 'id'),)
+        text_epilog = dedent("""
+            This server is for a Globus Connect Personal installation.
+
+            For its connection status, try:
+            globus endpoint show {}
+        """.format(endpoint_id))
     else:
         def advertised_port_summary(server):
             def get_range_summary(start, end):
@@ -36,6 +42,7 @@ def server_show(endpoint_id, server_id):
 
         fields = (('ID', 'id'), ('URI', 'uri'), ('Subject', 'subject'),
                   ('Data Ports', advertised_port_summary))
+        text_epilog = None
 
     formatted_print(server_doc, text_format=FORMAT_TEXT_RECORD,
-                    fields=fields)
+                    fields=fields, text_epilog=text_epilog)

--- a/globus_cli/commands/endpoint/show.py
+++ b/globus_cli/commands/endpoint/show.py
@@ -17,23 +17,36 @@ def endpoint_show(endpoint_id):
 
     res = client.get_endpoint(endpoint_id)
 
-    def _managed_endpoint(x):
-        """ Helper for converting subscription_id into managed_endpoint """
-        return bool(x["subscription_id"])
     formatted_print(
-        res, text_format=FORMAT_TEXT_RECORD,
-        fields=(("Display Name", "display_name"), ("ID", "id"),
-                ("Owner", "owner_string"), ("Activated", "activated"),
-                ("Shareable", "shareable"), ("Department", "department"),
-                ("Keywords", "keywords"), ("Endpoint Info Link", "info_link"),
-                ("Contact E-mail", "contact_email"),
-                ("Organization", "organization"), ("Department", "department"),
-                ("Other Contact Info", "contact_info"),
-                ("Visibility", "public"),
-                ("Default Directory", "default_directory"),
-                ("Force Encryption", "force_encryption"),
-                ("Managed Endpoint", _managed_endpoint),
-                ("Subscription ID", "subscription_id"),
-                ("Legacy Name", "canonical_name"),
-                ("Local User Info Available", "local_user_info_available"))
-        )
+        res,
+        text_format=FORMAT_TEXT_RECORD,
+        fields=GCP_FIELDS if res['is_globus_connect'] else STANDARD_FIELDS,
+    )
+
+
+STANDARD_FIELDS = (
+    ("Display Name", "display_name"),
+    ("ID", "id"),
+    ("Owner", "owner_string"),
+    ("Activated", "activated"),
+    ("Shareable", "shareable"),
+    ("Department", "department"),
+    ("Keywords", "keywords"),
+    ("Endpoint Info Link", "info_link"),
+    ("Contact E-mail", "contact_email"),
+    ("Organization", "organization"),
+    ("Department", "department"),
+    ("Other Contact Info", "contact_info"),
+    ("Visibility", "public"),
+    ("Default Directory", "default_directory"),
+    ("Force Encryption", "force_encryption"),
+    ("Managed Endpoint", lambda res: bool(res["subscription_id"])),
+    ("Subscription ID", "subscription_id"),
+    ("Legacy Name", "canonical_name"),
+    ("Local User Info Available", "local_user_info_available"),
+)
+
+GCP_FIELDS = STANDARD_FIELDS + (
+    ("GCP Connected", "gcp_connected"),
+    ("GCP Paused (macOS only)", "gcp_paused"),
+)


### PR DESCRIPTION
Expose `gcp_connected` and `gcp_paused` as fields in the text-mode `globus endpoint show` for a GCP endpoint.

In `globus endpoint server show`, stop showing `is_connected` and `is_paused` for GCP endpoints but rather refer people to `globus endpoint show` instead.

Fixes #437.