### PR TITLE
Release 1.9.0

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -1,5 +1,15 @@
 = CLI Changelog
 
+== 1.9.0
+
+Enhancements:
+
+* GCP connection/paused status via the endpoint resource
+(https://github.com/globus/globus-cli/pull/440[440])
+* Update WebApp links
+(https://github.com/globus/globus-cli/pull/438[438])
+* Minor internal improvements
+
 == 1.8.0
 
 Enhancements:

--- a/generate_release_notes.sh
+++ b/generate_release_notes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# handy script for autogenerating release notes from GitHub merged PRs
+# not perfect, but easy to update if we want to change it up in the future
+
+last_tag=$(git tag --list | egrep '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$' | sort -V | tail -n 1)
+
+github-issue-title () {
+    local reponame="globus/globus-cli"
+	local num="$1"
+	api_out="$(curl --silent \
+        "https://api.github.com/repos/$reponame/issues/$num")"
+	echo "$api_out" | grep '"title"' | cut -d':' -f2- | sed -e 's/^ "//' -e 's/",$//'
+}
+
+git log "${last_tag}..master" --oneline | grep 'Merge pull' | egrep -o '#[[:digit:]]+' | tr -d '#' | \
+    while read line; do
+        echo "* $(github-issue-title "$line")"
+        echo "(https://github.com/globus/globus-cli/pull/${line}[${line}])"
+    done

--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -2,7 +2,7 @@ from distutils.version import LooseVersion
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 # app name to send as part of SDK requests
 app_name = "Globus CLI v{}".format(__version__)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     version=version,
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=[
-        'globus-sdk==1.5.0',
+        'globus-sdk==1.6.1',
         'click>=6.6,<7.0',
         'jmespath==0.9.2',
         'configobj>=5.0.6,<6.0.0',


### PR DESCRIPTION
Has the webapp link updates.

I was bad and folded in the SDK upgrade to v1.6.1 into this changeset.
I assume that's fine though.

I also got tired of writing asciidoc changelog stuff by hand, so I added a small script for it.