### PR TITLE
Add missing changelog for 1.9.1

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -1,5 +1,9 @@
 = CLI Changelog
 
+== 1.9.1
+
+* Minor internal improvements
+
 == 1.9.0
 
 Enhancements:


### PR DESCRIPTION
It's kind of vacuous, but I want to show anyone reading the changelog that "nothing happened".