### PR TITLE
Add --timeout-exit-code opt to wait commands

### DIFF
--- a/globus_cli/commands/rm.py
+++ b/globus_cli/commands/rm.py
@@ -28,7 +28,7 @@ from globus_cli.services.transfer import (
 def rm_command(ignore_missing, star_silent, recursive, enable_globs,
                endpoint_plus_path, label, submission_id, dry_run, deadline,
                skip_activation_check, notify,
-               meow, heartbeat, polling_interval, timeout):
+               meow, heartbeat, polling_interval, timeout, timeout_exit_code):
     """
     Executor for `globus rm`
     """
@@ -78,4 +78,4 @@ def rm_command(ignore_missing, star_silent, recursive, enable_globs,
 
     # do a `task wait` equivalent, including printing and correct exit status
     task_wait_with_io(meow, heartbeat, polling_interval, timeout, task_id,
-                      client=client)
+                      timeout_exit_code, client=client)

--- a/globus_cli/commands/task/wait.py
+++ b/globus_cli/commands/task/wait.py
@@ -10,8 +10,10 @@ from globus_cli.services.transfer import task_wait_with_io
 @common_options
 @task_id_arg
 @synchronous_task_wait_options
-def task_wait(meow, heartbeat, polling_interval, timeout, task_id):
+def task_wait(meow, heartbeat, polling_interval, timeout, task_id,
+              timeout_exit_code):
     """
     Executor for `globus task wait`
     """
-    task_wait_with_io(meow, heartbeat, polling_interval, timeout, task_id)
+    task_wait_with_io(meow, heartbeat, polling_interval, timeout, task_id,
+                      timeout_exit_code)

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -468,6 +468,17 @@ def synchronous_task_wait_options(f):
 
         return value
 
+    def exit_code_callback(ctx, param, value):
+        if not value:
+            return None
+
+        exit_stat_set = [0, 1] + list(range(50, 100))
+        if value not in exit_stat_set:
+            raise click.UsageError(
+                "--timeout-exit-code must have a value in 0,1,50-99")
+
+        return value
+
     f = click.option('--timeout', type=int, metavar='N',
                      help=('Wait N seconds. If the Task does not terminate by '
                            'then, or terminates with an unsuccessful status, '
@@ -480,6 +491,11 @@ def synchronous_task_wait_options(f):
         '--heartbeat', '-H', is_flag=True,
         help=('Every polling interval, print "." to stdout to '
               'indicate that task wait is till active'))(f)
+    f = click.option(
+        "--timeout-exit-code", type=int, default=1, show_default=True,
+        callback=exit_code_callback,
+        help=("If the task times out, exit with this status code. Must have "
+              "a value in 0,1,50-99"))(f)
     f = click.option('--meow', is_flag=True, cls=HiddenOption)(f)
     return f
 

--- a/globus_cli/services/transfer.py
+++ b/globus_cli/services/transfer.py
@@ -268,7 +268,7 @@ def get_endpoint_w_server_list(endpoint_id):
 
 
 def task_wait_with_io(meow, heartbeat, polling_interval, timeout, task_id,
-                      client=None):
+                      timeout_exit_code,  client=None):
     """
     Options are the core "task wait" options, including the `--meow` easter
     egg.
@@ -335,15 +335,17 @@ def task_wait_with_io(meow, heartbeat, polling_interval, timeout, task_id,
     if heartbeat:
         safeprint('', write_to_stderr=True)
 
+    exit_code = 1
     if timed_out(waited_time):
         safeprint('Task has yet to complete after {} seconds'.format(timeout),
                   write_to_stderr=True)
+        exit_code = timeout_exit_code
 
     # output json if requested, but nothing for text mode
     res = client.get_task(task_id)
     formatted_print(res, text_format=FORMAT_SILENT)
 
-    click.get_current_context().exit(1)
+    click.get_current_context().exit(exit_code)
 
 
 ENDPOINT_LIST_FIELDS = (('ID', 'id'), ('Owner', 'owner_string'),

--- a/tests/unit/test_rm.py
+++ b/tests/unit/test_rm.py
@@ -132,3 +132,19 @@ class RMTests(CliTestCase):
             assert_exit_code=1)
         self.assertIn(("Task has yet to complete "
                        "after {} seconds".format(timeout)), output)
+
+    def test_timeout_explicit_status(self):
+        """
+        Attempts to remove a path we are not allowed to remove,
+        confirms rm times out and exits STATUS after given timeout, where
+        STATUS is set via the --timeout-exit-code opt
+        """
+        timeout = 1
+        status = 50
+        path = "/share/godata/file1.txt"
+        output = self.run_line(
+            "globus rm -r --timeout {} --timeout-exit-code {} {}:{}"
+            .format(timeout, status, GO_EP1_ID, path),
+            assert_exit_code=status)
+        self.assertIn(("Task has yet to complete "
+                       "after {} seconds".format(timeout)), output)


### PR DESCRIPTION
resolves #450

`globus task wait` and `globus rm` are getting a new waiting/timeout related option. `--timeout-exit-code` sets the exit code when a timeout occurs, which lets users map it back to 0 or map to another status to differentiate timeout from task failure.

Like `--map-http-status`, the option supports 0,1,50-99

Testing can be done by trying to `globus rm` go#ep1:/share/godata/file1.txt
or by starting a transfer to a non-writable destination dir (e.g. to go#ep2/share/godata/ ) and `globus task wait`ing on the resulting task ID.

My tests with the exit status not set (default=1), set to 0, 1, 50, 51, etc. all behave as expected and desired.
While I'd love for us to rewrite the CLI test suite to have more comprehensive non-IO-blocking tests, for now I've just added one test to the `globus rm` tests to cover this minimally.