### PR TITLE
Add `--cancel-jobs` to manual cleanup script

### DIFF
--- a/tests/manual_cleanup.py
+++ b/tests/manual_cleanup.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+import click
+
 from globus_cli.services.transfer import get_client as get_tc
 from tests.framework.cli_testcase import default_test_config
 
@@ -12,10 +15,21 @@ def cleanup_bookmarks(tc):
         tc.delete_bookmark(bm['id'])
 
 
-@patch("globus_cli.config.get_config_obj", new=default_test_config)
-def main():
-    tc = get_tc()
-    cleanup_bookmarks(tc)
+def cleanup_tasks(tc):
+    tasks = tc.task_list(num_results=None, filter="status:ACTIVE,INACTIVE")
+    for t in tasks:
+        tc.cancel_task(t['task_id'])
+
+
+@click.command("cleanup")
+@click.option("--cancel-jobs", is_flag=True)
+def main(cancel_jobs):
+    with patch("globus_cli.config.get_config_obj", new=default_test_config):
+        tc = get_tc()
+        cleanup_bookmarks(tc)
+
+        if cancel_jobs:
+            cleanup_tasks(tc)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add an option to this script to cancel all ACTIVE,INACTIVE tasks (i.e. not SUCCEDED,FAILED).
While this can disrupt a run of the tests pretty badly if you run it while the tets are running, it's pretty much the only way to "fix it" if the tests go off the rails because of a partial or failed job, etc.