### PR TITLE
Rename 'session boost' to 'session update'

### DIFF
--- a/adoc/session_update.1.adoc
+++ b/adoc/session_update.1.adoc
@@ -1,18 +1,18 @@
-= GLOBUS SESSION BOOST(1)
+= GLOBUS SESSION UPDATE(1)
 
 == NAME
 
-globus session boost - Boost the user's CLI auth session
+globus session update - Update the user's CLI auth session
 
 
 == SYNOPSIS
 
-*globus session boost* ['OPTIONS'] ['UUID_OR_USERNAME(s)']
+*globus session update* ['OPTIONS'] ['UUID_OR_USERNAME(s)']
 
 
 == DESCRIPTION
 
-The *globus session boost* command starts an authentication
+The *globus session update* command starts an authentication
 flow with Globus Auth similarly to *globus login* but specifies which
 identities to authenticate with.
 

--- a/globus_cli/commands/session/commands.py
+++ b/globus_cli/commands/session/commands.py
@@ -1,5 +1,5 @@
-from globus_cli.commands.session.update import session_update
 from globus_cli.commands.session.show import session_show
+from globus_cli.commands.session.update import session_update
 from globus_cli.parsing import globus_group
 
 

--- a/globus_cli/commands/session/commands.py
+++ b/globus_cli/commands/session/commands.py
@@ -1,4 +1,4 @@
-from globus_cli.commands.session.boost import session_boost
+from globus_cli.commands.session.update import session_update
 from globus_cli.commands.session.show import session_show
 from globus_cli.parsing import globus_group
 
@@ -9,5 +9,5 @@ def session_command():
 
 
 # commands
-session_command.add_command(session_boost)
+session_command.add_command(session_update)
 session_command.add_command(session_show)

--- a/globus_cli/commands/session/update.py
+++ b/globus_cli/commands/session/update.py
@@ -13,10 +13,10 @@ from globus_cli.services.auth import get_auth_client
 
 
 @click.command(
-    "boost",
-    short_help=("Boost your CLI auth session"),
+    "update",
+    short_help=("Update your CLI auth session"),
     help=(
-        "Boost your current CLI auth session by authenticating "
+        "Update your current CLI auth session by authenticating "
         "with specific identities."
     ),
 )
@@ -26,7 +26,7 @@ from globus_cli.services.auth import get_auth_client
 @click.option(
     "--all", is_flag=True, help="authenticate with every identity in your identity set"
 )
-def session_boost(identities, no_local_server, all):
+def session_update(identities, no_local_server, all):
 
     if (not (identities or all)) or (identities and all):
         raise click.UsageError("Either give one or more IDENTITIES or use --all")
@@ -73,7 +73,7 @@ def session_boost(identities, no_local_server, all):
     # create session params once we have all identity ids
     session_params = {
         "session_required_identities": ",".join(identity_ids),
-        "session_message": "Authenticate to boost your CLI session.",
+        "session_message": "Authenticate to update your CLI session.",
     }
 
     # use a link login if remote session or user requested
@@ -83,16 +83,16 @@ def session_boost(identities, no_local_server, all):
     # otherwise default to a local server login flow
     else:
         safeprint(
-            "You are running 'globus session boost', "
+            "You are running 'globus session update', "
             "which should automatically open a browser window for you to "
             "authenticate with specific identities.\n"
             "If this fails or you experience difficulty, try "
-            "'globus session boost --no-local-server'"
+            "'globus session update --no-local-server'"
             "\n---"
         )
         do_local_server_auth_flow(session_params=session_params)
 
     safeprint(
-        "\nYou have successfully boosted your CLI session.\n"
+        "\nYou have successfully updated your CLI session.\n"
         "Use 'globus session show' to see the updated session."
     )

--- a/globus_cli/parsing/excepthook.py
+++ b/globus_cli/parsing/excepthook.py
@@ -51,12 +51,12 @@ def session_hook(exception):
         id_str = " ".join(identities)
         safeprint(
             "Please run\n\n"
-            "    globus session boost {}\n\n"
+            "    globus session update {}\n\n"
             "to re-authenticate with the required identities".format(id_str)
         )
     else:
         safeprint(
-            'Please use "globus session boost" to re-authenticate '
+            'Please use "globus session update" to re-authenticate '
             "with specific identities".format(id_str)
         )
 
@@ -176,7 +176,7 @@ def custom_except_hook(exc_info):
             reraise(exception_type, exception, traceback)
 
         # catch any session errors to give helpful instructions
-        # on how to use globus session boost
+        # on how to use globus session update
         elif (
             isinstance(exception, exc.GlobusAPIError)
             and exception.raw_json


### PR DESCRIPTION
We've been asked to change these command names and we should do so now.

To clarify for anyone reading our repo changes: much of the discussion about how/why to change these was internal, but I don't intend to restate it here.