### PR TITLE
Add `--limit` as a param on EP search

### DIFF
--- a/globus_cli/commands/endpoint/search.py
+++ b/globus_cli/commands/endpoint/search.py
@@ -39,8 +39,15 @@ from globus_cli.services.transfer import (
         'Username, as in "go@globusid.org"'
     ),
 )
+@click.option(
+    "--limit",
+    default=25,
+    show_default=True,
+    type=click.IntRange(1, 1000),
+    help="The maximum number of results to return.",
+)
 @click.argument("filter_fulltext", required=False)
-def endpoint_search(filter_fulltext, filter_owner_id, filter_scope):
+def endpoint_search(filter_fulltext, limit, filter_owner_id, filter_scope):
     """
     Executor for `globus endpoint search`
     """
@@ -62,6 +69,7 @@ def endpoint_search(filter_fulltext, filter_owner_id, filter_scope):
         filter_fulltext=filter_fulltext,
         filter_scope=filter_scope,
         filter_owner_id=owner_id,
+        num_results=limit,
     )
 
     formatted_print(
@@ -69,3 +77,15 @@ def endpoint_search(filter_fulltext, filter_owner_id, filter_scope):
         fields=ENDPOINT_LIST_FIELDS,
         json_converter=iterable_response_to_dict,
     )
+
+    if search_iterator.limit_less_than_available_results:
+        click.echo(
+            click.style(
+                """
+WARNING: More results were available from the Endpoint Search API, but you
+         specified a limit lower than the number of available results
+""",
+                fg="yellow",
+            ),
+            err=True,
+        )


### PR DESCRIPTION
- limit defaults to 25
- is the limit on number of results returned
- when the limit applies (as detected by the paginator), print a warning to stderr -- use `click.style` to get yellow ANSI color on non-Win platforms when stderr is a tty

Will require an SDK release (to expose `limit_less_than_available_results`) before this can merge.

Here's an example of what the output looks like:
![image](https://user-images.githubusercontent.com/1300022/56927776-fb9b0e80-6aa2-11e9-8c1e-5f4e5ec4b301.png)

Which is, I think, what we were going for.
This inspires me to take a look at `click.style` on some of our other output, to get colors without headache on the non-Win terminals.