### PR TITLE
Fix blackened strings, minor fix to task list help

### DIFF
--- a/globus_cli/commands/delete.py
+++ b/globus_cli/commands/delete.py
@@ -21,7 +21,7 @@ from globus_cli.services.transfer import autoactivate, get_client
 @click.command(
     "delete",
     short_help="Submit a delete task (asynchronous)",
-    help=("Delete a file or directory from one endpoint as an " "asynchronous task."),
+    help="Delete a file or directory from one endpoint as an asynchronous task.",
 )
 @common_options
 @task_submission_options

--- a/globus_cli/commands/endpoint/activate.py
+++ b/globus_cli/commands/endpoint/activate.py
@@ -65,9 +65,7 @@ from globus_cli.services.transfer import activation_requirements_help_text, get_
     "--web",
     is_flag=True,
     default=False,
-    help=(
-        "Use web activation. Mutually exclusive with --myproxy " "and --delegate-proxy."
-    ),
+    help="Use web activation. Mutually exclusive with --myproxy  and --delegate-proxy.",
 )
 @click.option(
     "--no-browser",
@@ -83,9 +81,7 @@ from globus_cli.services.transfer import activation_requirements_help_text, get_
     "--myproxy",
     is_flag=True,
     default=False,
-    help=(
-        "Use myproxy activation. Mutually exclusive with --web " "and --delegate-proxy."
-    ),
+    help="Use myproxy activation. Mutually exclusive with --web and --delegate-proxy.",
 )
 @click.option(
     "--myproxy-username",
@@ -259,7 +255,7 @@ def endpoint_activate(
 
     # web activation
     elif web:
-        url = "https://app.globus.org/file-manager" "?origin_id={}".format(endpoint_id)
+        url = "https://app.globus.org/file-manager?origin_id={}".format(endpoint_id)
         if no_browser or is_remote_session():
             res = {"message": "Web activation url: {}".format(url), "url": url}
         else:

--- a/globus_cli/commands/endpoint/permission/commands.py
+++ b/globus_cli/commands/endpoint/permission/commands.py
@@ -7,7 +7,7 @@ from globus_cli.parsing import globus_group
 
 
 @globus_group(
-    name="permission", help=("Manage endpoint permissions " "(Access Control Lists)")
+    name="permission", help="Manage endpoint permissions (Access Control Lists)"
 )
 def permission_command():
     pass

--- a/globus_cli/commands/endpoint/permission/create.py
+++ b/globus_cli/commands/endpoint/permission/create.py
@@ -10,9 +10,7 @@ from globus_cli.services.auth import maybe_lookup_identity_id
 from globus_cli.services.transfer import assemble_generic_doc, get_client
 
 
-@click.command(
-    "create", help=("Create an access control rule, allowing new " "permissions")
-)
+@click.command("create", help="Create an access control rule, allowing new permissions")
 @common_options
 @security_principal_opts(
     allow_anonymous=True, allow_all_authenticated=True, allow_provision=True
@@ -26,7 +24,7 @@ from globus_cli.services.transfer import assemble_generic_doc, get_client
 @click.option(
     "--notify-email",
     metavar="EMAIL_ADDRESS",
-    help=("An email address to notify that " "the permission has been added"),
+    help="An email address to notify that the permission has been added",
 )
 @click.option(
     "--notify-message",

--- a/globus_cli/commands/endpoint/permission/delete.py
+++ b/globus_cli/commands/endpoint/permission/delete.py
@@ -5,9 +5,7 @@ from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
 from globus_cli.services.transfer import get_client
 
 
-@click.command(
-    "delete", help=("Delete an access control rule, removing " "permissions")
-)
+@click.command("delete", help="Delete an access control rule, removing permissions")
 @common_options
 @endpoint_id_arg
 @click.argument("rule_id")

--- a/globus_cli/commands/endpoint/permission/update.py
+++ b/globus_cli/commands/endpoint/permission/update.py
@@ -6,8 +6,7 @@ from globus_cli.services.transfer import assemble_generic_doc, get_client
 
 
 @click.command(
-    "update",
-    help=("Update an access control rule, changing " "permissions on an endpoint"),
+    "update", help="Update an access control rule, changing permissions on an endpoint"
 )
 @endpoint_id_arg
 @common_options

--- a/globus_cli/commands/login.py
+++ b/globus_cli/commands/login.py
@@ -51,7 +51,7 @@ You may force a new login with
 
 @click.command(
     "login",
-    short_help=("Log into Globus to get credentials for " "the Globus CLI"),
+    short_help="Log into Globus to get credentials for the Globus CLI",
     help=(
         "Get credentials for the Globus CLI. "
         "Necessary before any Globus CLI commands which require "

--- a/globus_cli/commands/ls.py
+++ b/globus_cli/commands/ls.py
@@ -50,7 +50,7 @@ If none of these are given, "=" will be used
     "-l",
     "long_output",
     is_flag=True,
-    help=("For text output only. Do long form output, kind " "of like `ls -l`"),
+    help="For text output only. Do long form output, kind of like `ls -l`",
 )
 @click.option(
     "--filter",
@@ -63,7 +63,7 @@ If none of these are given, "=" will be used
     "-r",
     is_flag=True,
     show_default=True,
-    help=("Do a recursive listing, up to the depth limit. " "Similar to `ls -R`"),
+    help="Do a recursive listing, up to the depth limit. Similar to `ls -R`",
 )
 @click.option(
     "--recursive-depth-limit",

--- a/globus_cli/commands/task/list.py
+++ b/globus_cli/commands/task/list.py
@@ -55,7 +55,7 @@ def _format_date_callback(ctx, param, value):
     default=True,
     help=(
         "Allows / disallows --filter-label and --filter-not-label to use"
-        "* as a wild-card character and ignore case"
+        " '*' as a wild-card character and ignore case"
     ),
 )
 @click.option(

--- a/globus_cli/commands/task/list.py
+++ b/globus_cli/commands/task/list.py
@@ -30,9 +30,7 @@ def _format_date_callback(ctx, param, value):
     "--filter-status",
     multiple=True,
     type=click.Choice(["ACTIVE", "INACTIVE", "FAILED", "SUCCEEDED"]),
-    help=(
-        "Task status to filter results by. " "This option can be used multiple times."
-    ),
+    help="Task status to filter results by. This option can be used multiple times.",
 )
 @click.option(
     "--filter-label",
@@ -54,8 +52,8 @@ def _format_date_callback(ctx, param, value):
     "--inexact / --exact",
     default=True,
     help=(
-        "Allows / disallows --filter-label and --filter-not-label to use"
-        " '*' as a wild-card character and ignore case"
+        "Allows / disallows --filter-label and --filter-not-label to use "
+        "'*' as a wild-card character and ignore case"
     ),
 )
 @click.option(

--- a/globus_cli/commands/transfer.py
+++ b/globus_cli/commands/transfer.py
@@ -76,7 +76,7 @@ from globus_cli.services.transfer import autoactivate, get_client
     "-r",
     is_flag=True,
     help=(
-        "SOURCE_PATH and DEST_PATH are both directories, do a " "recursive dir transfer"
+        "SOURCE_PATH and DEST_PATH are both directories, do a recursive dir transfer"
     ),
 )
 @click.option(
@@ -176,7 +176,7 @@ def transfer_command(
 
     if (cmd_source_path is None or cmd_dest_path is None) and (not batch):
         raise click.UsageError(
-            ("transfer requires either SOURCE_PATH and DEST_PATH or " "--batch")
+            "transfer requires either SOURCE_PATH and DEST_PATH or --batch"
         )
 
     # because python can't handle multiple **kwargs expansions in a single

--- a/globus_cli/commands/update.py
+++ b/globus_cli/commands/update.py
@@ -78,7 +78,7 @@ def update_command(yes, development, development_version):
     #   pip, anyone doing this is forced to get two copies of pip, which seems
     #   kind of nasty (even if "they're asking for it")
     if not _check_pip_installed():
-        click.echo("`globus update` requires pip. " "Please install pip and try again")
+        click.echo("`globus update` requires pip. Please install pip and try again")
         click.get_current_context().exit(1)
 
     # --development-version implies --development
@@ -90,7 +90,7 @@ def update_command(yes, development, development_version):
         # default to master
         development_version = development_version or "master"
         target_version = (
-            "https://github.com/globus/globus-cli/archive/{}" ".tar.gz#egg=globus-cli"
+            "https://github.com/globus/globus-cli/archive/{}.tar.gz#egg=globus-cli"
         ).format(development_version)
     else:
         # lookup version from PyPi, abort if we can't get it

--- a/globus_cli/commands/whoami.py
+++ b/globus_cli/commands/whoami.py
@@ -16,9 +16,7 @@ from globus_cli.services.auth import get_auth_client
 @click.option(
     "--linked-identities",
     is_flag=True,
-    help=(
-        "Also show identities linked to the currently logged-in " "primary identity."
-    ),
+    help="Also show identities linked to the currently logged-in primary identity.",
 )
 def whoami_command(linked_identities):
     """

--- a/globus_cli/helpers/delegate_proxy.py
+++ b/globus_cli/helpers/delegate_proxy.py
@@ -213,7 +213,7 @@ def confirm_not_old_proxy(loaded_cert):
     # if the last CN is 'proxy' or 'limited proxy' we are in an old proxy
     if last_cn.value in ("proxy", "limited proxy"):
         raise ValueError(
-            "Proxy certificate is in an outdated format " "that is no longer supported"
+            "Proxy certificate is in an outdated format that is no longer supported"
         )
 
 

--- a/globus_cli/helpers/version.py
+++ b/globus_cli/helpers/version.py
@@ -63,13 +63,11 @@ def print_version():
     latest, current = get_versions()
     if latest is None:
         click.echo(
-            ("Installed Version: {0}\n" "Failed to lookup latest version.").format(
-                current
-            )
+            ("Installed Version: {0}\nFailed to lookup latest version.").format(current)
         )
     else:
         click.echo(
-            ("Installed Version: {0}\n" "Latest Version:    {1}\n" "\n{2}").format(
+            ("Installed Version: {0}\nLatest Version:    {1}\n\n{2}").format(
                 current,
                 latest,
                 "You are running the latest version of the Globus CLI"

--- a/globus_cli/parsing/one_use_option.py
+++ b/globus_cli/parsing/one_use_option.py
@@ -48,7 +48,7 @@ def one_use_option(*args, **kwargs):
     # cannot force a multiple or count option to be single use
     if "multiple" in kwargs or "count" in kwargs:
         raise ValueError(
-            "Internal error, one_use_option cannot be  used " "with multiple or count."
+            "Internal error, one_use_option cannot be used with multiple or count."
         )
 
     # cannot force a non Option Paramater (argument) to be a OneUseOption

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -183,7 +183,7 @@ def endpoint_create_and_update_params(*args, **kwargs):
         )(f)
         f = click.option(
             "--myproxy-server",
-            help=("Set the MyProxy Server URI " "(Globus Connect Server only)"),
+            help="Set the MyProxy Server URI (Globus Connect Server only)",
         )(f)
         f = click.option(
             "--oauth-server",
@@ -300,7 +300,7 @@ def validate_endpoint_create_and_update_params(endpoint_type, managed, params):
         # catch params with two option flags
         if params["public"] is False:
             raise click.UsageError(
-                "Option --private only allowed " "for Globus Connect Server endpoints"
+                "Option --private only allowed for Globus Connect Server endpoints"
             )
         # catch any params only usable with GCS
         for option in [
@@ -497,7 +497,7 @@ def task_submission_options(f):
     f = click.option(
         "--dry-run",
         is_flag=True,
-        help=("Don't actually submit the task, print submission " "data instead"),
+        help="Don't actually submit the task, print submission data instead",
     )(f)
     f = click.option(
         "--notify",
@@ -528,7 +528,7 @@ def task_submission_options(f):
     f = click.option(
         "--skip-activation-check",
         is_flag=True,
-        help=("Submit the task even if the endpoint(s) " "aren't currently activated."),
+        help="Submit the task even if the endpoint(s) aren't currently activated.",
     )(f)
 
     return f
@@ -767,7 +767,7 @@ def security_principal_opts(*args, **kwargs):
 
             if identity and provision_identity:
                 raise click.UsageError(
-                    "Only one of --identity or --provision-identity " "allowed"
+                    "Only one of --identity or --provision-identity allowed"
                 )
             if kwargs.get("principal") is not None:
                 if has_identity or group:


### PR DESCRIPTION
Any cases of multiple string literals concatenated on a single line are now merged together.

I noticed a bit of helptext with a missing space, so I added space and `'` chars to make it easier to read.