### PR TITLE
Revert jmespath ParseError behavior

### DIFF
--- a/globus_cli/parsing/command_state.py
+++ b/globus_cli/parsing/command_state.py
@@ -56,10 +56,7 @@ def format_option(f):
             return
 
         state = ctx.ensure_object(CommandState)
-        try:
-            state.jmespath_expr = jmespath.compile(value)
-        except jmespath.exceptions.ParseError as e:
-            raise click.UsageError("jmespath ParseError: {}".format(e))
+        state.jmespath_expr = jmespath.compile(value)
 
         if state.output_format == TEXT_FORMAT:
             state.output_format = JSON_FORMAT

--- a/tests/integration/test_jmespath_output.py
+++ b/tests/integration/test_jmespath_output.py
@@ -83,6 +83,6 @@ class JMESPathTests(CliTestCase):
         that it gives a JMESPath ParseError.
         """
         output = self.run_line(
-            ("globus endpoint search 'Tutorial' --jmespath '{}'"), assert_exit_code=2
+            ("globus endpoint search 'Tutorial' --jmespath '{}'"), assert_exit_code=1
         )
-        self.assertIn("jmespath ParseError:", output)
+        self.assertIn("ParseError:", output)


### PR DESCRIPTION
In one of the intermediate commits of #465, JMESPath ParseError handling had to be reworked a bit to handle the top-level exception handling being changed. But this change actually results in more verbose, worse errors for the most part. It's better to handle these the way we were doing before, so this reverts the change.

Compare how it looks right now on `master`:
```
$ globus ls ddb59aef-6d04-11e5-ba46-22000b92c6ec --jq '?foo.bar]'
Usage: globus ls [OPTIONS] ENDPOINT_ID[:PATH]

Error: jmespath ParseError: Bad jmespath expression: Unknown token ?:
?foo.bar]
^
```

vs how it used to look, and this is moving back to:
```
$ globus ls ddb59aef-6d04-11e5-ba46-22000b92c6ec --jq '?foo.bar]'
LexerError: Bad jmespath expression: Unknown token ?:
?foo.bar]
^
```

I think there's no question that making this a kind of usage error (which therefore prints the usage string) is all downside with no upside, now that the top-level exception handling has been reverted.