### PR TITLE
Colorize errors and "command hints"

### DIFF
--- a/globus_cli/parsing/excepthook.py
+++ b/globus_cli/parsing/excepthook.py
@@ -206,5 +206,9 @@ def custom_except_hook(exc_info):
     # or NotImplementedError bubbled all the way up here: just print it
     # out, basically
     else:
-        click.echo(u"{}: {}".format(exception_type.__name__, exception))
+        click.echo(
+            u"{}: {}".format(
+                click.style(exception_type.__name__, bold=True, fg="red"), exception
+            )
+        )
         sys.exit(1)

--- a/globus_cli/safeio/errors.py
+++ b/globus_cli/safeio/errors.py
@@ -43,19 +43,23 @@ def write_error_info(error_name, fields, message=None):
 
     if outformat_is_json():
         # dictify joined tuple lists and dump to json string
-        message = json.dumps(
-            dict(
-                [("error_name", error_name)] + [(f.name, f.raw_value) for f in fields]
+        message = click.style(
+            json.dumps(
+                dict(
+                    [("error_name", error_name)]
+                    + [(f.name, f.raw_value) for f in fields]
+                ),
+                indent=2,
+                separators=(",", ": "),
+                sort_keys=True,
             ),
-            indent=2,
-            separators=(",", ": "),
-            sort_keys=True,
+            fg="yellow",
         )
     if not message:
         message = u"A{0} {1} Occurred.\n{2}".format(
             "n" if error_name[0] in "aeiouAEIOU" else "",
-            error_name,
-            "\n".join(f.value for f in fields),
+            click.style(error_name, bold=True, fg="red"),
+            click.style("\n".join(f.value for f in fields), fg="yellow"),
         )
         message = u"{0} {1}".format(PrintableErrorField.TEXT_PREFIX, message)
 

--- a/globus_cli/safeio/write.py
+++ b/globus_cli/safeio/write.py
@@ -13,4 +13,4 @@ def print_command_hint(message):
     before printing a given command hint message
     """
     if term_is_interactive() and err_is_terminal() and out_is_terminal():
-        click.echo(message, err=True)
+        click.echo(click.style(message, fg="yellow"), err=True)


### PR DESCRIPTION
This is low priority, but it's my initial thought on where ANSI colors might be nice to have.

- yellow for print_command_hint
- red, bold for the error name in text output
- yellow for error details in text output
- yellow for full error body in JSON output

closes #464