### PR TITLE
Fix path normalization on Windows

### DIFF
--- a/globus_cli/parsing/task_path.py
+++ b/globus_cli/parsing/task_path.py
@@ -15,20 +15,29 @@ def _normpath(path):
     Note that this does not preserve leading slashes in the same way as python's
     posixpath module -- it's not clear how Transfer would treat such paths and
     non-obvious that we need to allow such usage
+
+    Also, unlike normpath, we want to preserve trailing slashes because they may be
+    required
     """
     initial_slash = 1 if path.startswith("/") else 0
+    trailing_slash = 1 if path.endswith("/") and path != "/" else 0
     parts = path.split("/")
     new_parts = []
     for part in parts:
         if part in ("", "."):
             continue
         # either not adding a ".." OR chaining together multiple ".."s
-        if part != ".." or (new_parts and new_parts[-1] == ".."):
+        # OR working with a non-absolute path that starts with ".."
+        if (
+            part != ".."
+            or (new_parts and new_parts[-1] == "..")
+            or (not initial_slash and not new_parts)
+        ):
             new_parts.append(part)
         elif new_parts:  # adding a ".." to a path which isn't already ending in one
             new_parts.pop()
 
-    return ("/" * initial_slash) + "/".join(new_parts)
+    return ("/" * initial_slash) + "/".join(new_parts) + ("/" * trailing_slash)
 
 
 def _pathjoin(a, b):

--- a/globus_cli/parsing/task_path.py
+++ b/globus_cli/parsing/task_path.py
@@ -1,6 +1,51 @@
-import os
-
 import click
+
+
+def _normpath(path):
+    """
+    Globus Transfer-specific normalization, based on a careful reading of the stdlib
+    posixpath implementation:
+      https://github.com/python/cpython/blob/ea0f7aa47c5d2e58dc99314508172f0523e144c6/Lib/posixpath.py#L338
+
+    this must be done without using os.path.normpath to be compatible with CLI calls
+    from Windows systems
+
+    Transfer requires forward slashes, even when communicating with Windows systems, so
+    we must handle these strings appropriately.
+    Note that this does not preserve leading slashes in the same way as python's
+    posixpath module -- it's not clear how Transfer would treat such paths and
+    non-obvious that we need to allow such usage
+    """
+    initial_slash = 1 if path.startswith("/") else 0
+    parts = path.split("/")
+    new_parts = []
+    for part in parts:
+        if part in ("", "."):
+            continue
+        # either not adding a ".." OR chaining together multiple ".."s
+        if part != ".." or (new_parts and new_parts[-1] == ".."):
+            new_parts.append(part)
+        elif new_parts:  # adding a ".." to a path which isn't already ending in one
+            new_parts.pop()
+
+    return ("/" * initial_slash) + "/".join(new_parts)
+
+
+def _pathjoin(a, b):
+    """
+    POSIX-like path join for Globus Transfer paths
+
+    As with _normpath above, this is meant to behave correctly even on Windows systems
+    """
+    if not b:  # given "" as a file path
+        return a
+    elif b.startswith("/"):  # a path starting with / is absolute
+        return b
+
+    if a.endswith("/"):
+        return a + b
+    else:
+        return a + "/" + b
 
 
 class TaskPath(click.ParamType):
@@ -36,11 +81,11 @@ class TaskPath(click.ParamType):
         self.orig_path = self.path = value
 
         if self.base_dir:
-            self.path = os.path.join(self.base_dir, self.path)
+            self.path = _pathjoin(self.base_dir, self.path)
         if self.coerce_to_dir and not self.path.endswith("/"):
             self.path += "/"
         if self.normalize:
-            self.path = os.path.normpath(self.path)
+            self.path = _normpath(self.path)
 
         if self.require_absolute and not (
             self.path.startswith("/") or self.path.startswith("~")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def run_command(runner):
+    def _run(cmd, args, exit_code=0):
+        result = runner.invoke(cmd, args, catch_exceptions=bool(exit_code))
+        assert result.exit_code == exit_code
+        return result
+
+    return _run

--- a/tests/unit/test_task_path.py
+++ b/tests/unit/test_task_path.py
@@ -1,0 +1,142 @@
+import click
+
+from globus_cli.parsing.task_path import TaskPath
+
+
+def test_task_path_normpath_updir(run_command):
+    @click.command()
+    @click.option("--bar", type=TaskPath(base_dir="/foo"))
+    def foo(bar):
+        click.echo(repr(bar))
+
+    result = run_command(foo, ["--bar", "../baz.txt"])
+    assert (
+        "TaskPath(base_dir=/foo,coerce_to_dir=False,normalize=True,"
+        "path=/baz.txt,orig_path=../baz.txt)\n"
+    ) == result.output
+
+    # going up "too many dirs" does nothing
+    result = run_command(foo, ["--bar", "../../../baz.txt"])
+    assert (
+        "TaskPath(base_dir=/foo,coerce_to_dir=False,normalize=True,"
+        "path=/baz.txt,orig_path=../../../baz.txt)\n"
+    ) == result.output
+
+
+def test_task_path_normpath_updir_no_base(run_command):
+    @click.command()
+    @click.option("--bar", type=TaskPath())
+    def foo(bar):
+        click.echo(repr(bar))
+
+    # a ".." based path should be preserved
+    result = run_command(foo, ["--bar", "../../../baz.txt"])
+    assert (
+        "TaskPath(base_dir=None,coerce_to_dir=False,normalize=True,"
+        "path=../../../baz.txt,orig_path=../../../baz.txt)\n"
+    ) == result.output
+    # a ".." based path should be preserved
+    result = run_command(foo, ["--bar", "../../../baz/"])
+    assert (
+        "TaskPath(base_dir=None,coerce_to_dir=False,normalize=True,"
+        "path=../../../baz/,orig_path=../../../baz/)\n"
+    ) == result.output
+
+
+def test_task_path_normpath_only_slash(run_command):
+    @click.command()
+    @click.option("--bar", type=TaskPath())
+    def foo(bar):
+        click.echo(repr(bar))
+
+    # a path of "/" should be preserved
+    result = run_command(foo, ["--bar", "/"])
+    assert (
+        "TaskPath(base_dir=None,coerce_to_dir=False,normalize=True,"
+        "path=/,orig_path=/)\n"
+    ) == result.output
+
+
+def test_task_path_join_slashes(run_command):
+    # NOTE: normalize=False so that we get more direct results
+    @click.command()
+    @click.option("--bar", type=TaskPath(base_dir="/foo/", normalize=False))
+    def foo(bar):
+        click.echo(repr(bar))
+
+    # absolute paths don't join
+    result = run_command(foo, ["--bar", "/baz.txt"])
+    assert (
+        "TaskPath(base_dir=/foo/,coerce_to_dir=False,normalize=False,"
+        "path=/baz.txt,orig_path=/baz.txt)\n"
+    ) == result.output
+    result = run_command(foo, ["--bar", "/baz/"])
+    assert (
+        "TaskPath(base_dir=/foo/,coerce_to_dir=False,normalize=False,"
+        "path=/baz/,orig_path=/baz/)\n"
+    ) == result.output
+
+    # empty paths give you the base path
+    result = run_command(foo, ["--bar", ""])
+    assert (
+        "TaskPath(base_dir=/foo/,coerce_to_dir=False,normalize=False,"
+        "path=/foo/,orig_path=)\n"
+    ) == result.output
+
+    # slash join any ordinary path
+    result = run_command(foo, ["--bar", "baz.txt"])
+    assert (
+        "TaskPath(base_dir=/foo/,coerce_to_dir=False,normalize=False,"
+        "path=/foo/baz.txt,orig_path=baz.txt)\n"
+    ) == result.output
+    result = run_command(foo, ["--bar", "baz/"])
+    assert (
+        "TaskPath(base_dir=/foo/,coerce_to_dir=False,normalize=False,"
+        "path=/foo/baz/,orig_path=baz/)\n"
+    ) == result.output
+
+
+def test_task_path_require_absolute(run_command):
+    @click.command()
+    @click.option("--bar", type=TaskPath(require_absolute=True))
+    def foo(bar):
+        click.echo(repr(bar))
+
+    # absolute paths are fine
+    result = run_command(foo, ["--bar", "/baz.txt"])
+    assert (
+        "TaskPath(base_dir=None,coerce_to_dir=False,normalize=True,"
+        "path=/baz.txt,orig_path=/baz.txt)\n"
+    ) == result.output
+    result = run_command(foo, ["--bar", "/baz/"])
+    assert (
+        "TaskPath(base_dir=None,coerce_to_dir=False,normalize=True,"
+        "path=/baz/,orig_path=/baz/)\n"
+    ) == result.output
+
+    # non-absolute paths error
+    result = run_command(foo, ["--bar", "baz.txt"], exit_code=2)
+    assert "baz.txt is not absolute" in result.output
+    result = run_command(foo, ["--bar", "baz/"], exit_code=2)
+    assert "baz/ is not absolute" in result.output
+
+
+def test_task_path_coerce_to_dir(run_command):
+    @click.command()
+    @click.option("--bar", type=TaskPath(coerce_to_dir=True))
+    def foo(bar):
+        click.echo(repr(bar))
+
+    # filename -> append slash
+    result = run_command(foo, ["--bar", "/baz.txt"])
+    assert (
+        "TaskPath(base_dir=None,coerce_to_dir=True,normalize=True,"
+        "path=/baz.txt/,orig_path=/baz.txt)\n"
+    ) == result.output
+
+    # dirname -> no change
+    result = run_command(foo, ["--bar", "baz/"])
+    assert (
+        "TaskPath(base_dir=None,coerce_to_dir=True,normalize=True,"
+        "path=baz/,orig_path=baz/)\n"
+    ) == result.output


### PR DESCRIPTION
Marking this as a work-in-progress because I don't have time to spec out the tests for this yet. I need to look at the testsuite's coverage of batch mode and see if we can consider the Travis testing to be sufficient.

batchmode transfers and deletes from a Windows system should still produce POSX-style paths. Otherwise, these will join incorrectly on Windows and then be passed to Transfer where they will be treated as POSIX paths. In order to handle this nicely without much headache, simply define our own normpath and pathjoin functions based on the posixpath implementation in the python stdlib.

This should *NOT* be thought of as "POSIX normalization", but rather "Globus Transfer normalization". While in practice those two may be the same, there are in theory subtle differences.

For example, this implementation takes the liberty of not caring about the number of leading slashes on a path, on the assumption that this can hardly even (if ever) matter to Globus Transfer.

closes #455