### PR TITLE
Clarify that submission ID != task ID

### DIFF
--- a/globus_cli/commands/task/generate_submission_id.py
+++ b/globus_cli/commands/task/generate_submission_id.py
@@ -9,13 +9,16 @@ from globus_cli.services.transfer import get_client
     "generate-submission-id",
     short_help="Get a submission ID",
     help=(
-        "Generate a new task submission ID for use in "
-        "`globus transfer` and `gloubs delete`. Submission IDs "
-        "allow you to safely retry submission of a task in the "
-        "presence of network errors. No matter how many times "
-        "you submit a task with a given ID, it will only be "
-        "accepted and executed once. The response status may "
-        "change between submissions."
+        """\
+    Generate a new task submission ID for use in  `globus transfer` and `gloubs delete`.
+    Submission IDs allow you to safely retry submission of a task in the presence of
+    network errors. No matter how many times you submit a task with a given ID, it will
+    only be accepted and executed once. The response status may change between
+    submissions.
+
+    \b
+    Important Note: Submission IDs are not the same as Task IDs.
+    """
     ),
 )
 @common_options


### PR DESCRIPTION
Calling this out in the helptext will hopefully help avoid people conflating these two quite as easily. (An imperfect solution for an imperfect world.)