### PR TITLE
Update Travis build config for py38 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
----
 sudo: false
 dist: xenial
 language: python
@@ -7,40 +6,45 @@ matrix:
     - python: "2.7"
       env: TOXENV=py
     # py2 linting build (flake8 on py2 can flag different stuff)
-    - python: "2.7"
+    - name: "Python: 2.7 (linting)"
+      python: "2.7"
       env: TOXENV=lint
-    # test on 3.4, 3.5, 3.6
-    - python: "3.4"
-      env: TOXENV=py
     - python: "3.5"
       env: TOXENV=py
     - python: "3.6"
       env: TOXENV=py
     # separate py3.6 linting build, which runs 'black --check' (no py2 support)
-    - python: "3.6"
+    - name: "Python: 3.6 (linting)"
+      python: "3.6"
       env: TOXENV=py36-lint
-    # hack py37, py38 to use a different Travis worker type
-    # sudo:required gets us the VM builds where these pythons work
     - python: "3.7"
       env: TOXENV=py
-      sudo: required
-    # windows testing
-    - os: windows
-      language: sh
-      python: "2.7"
-      env: TOXENV=py,lint
+    - python: "3.8"
+      env: TOXENV=py
+    # non-Linux testing
+    #   https://docs.travis-ci.com/user/languages/python/#running-python-tests-on-multiple-operating-systems
+    #
+    # Windows
+    - name: "py2 + windows"
+      os: windows
+      language: shell
+      env: TOXENV=py,lint PATH=/c/Python27:/c/Python27/Scripts:$PATH
       before_install:
         - choco install python2
-        - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
-        - python -m pip install --upgrade pip setuptools
-    - os: windows
-      language: sh
-      python: "3.7"
-      env: TOXENV=py,py37-lint
+        - python -m pip install --upgrade pip wheel
+    - name: "py3.8 + windows"
+      os: windows
+      language: shell
+      env: TOXENV=py,py38-lint PATH=/c/Python38:/c/Python38/Scripts:$PATH
       before_install:
         - choco install python3
-        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-        - python -m pip install --upgrade pip setuptools
+        - python -m pip install --upgrade pip wheel
+    # macOS
+    - name: "py3 + macOS"
+      os: osx
+      osx_image: xcode10.2  # py3.7 on macOS 10.14
+      language: shell
+      env: TOXENV=py3,py37-lint
 cache: pip
 install:
   - pip install -U pip setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
-    py{37,36,35,27}
+    py{38,37,36,35,27}
 # for CLI builds, don't do "lowestdeps" builds until we can refactor the testsuite
 # we don't want to hammer the APIs and get higher flaky error rates with these additional
 # builds
 #    py{37,36,35,27}-lowestdeps
-    py{37,36,27}-lint
+    py{38,37,36,27}-lint
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Similar to https://github.com/globus/globus-sdk-python/pull/362

Windows builds now install py38 via chocolatey, so the path in use needs to be changed.

Also, drop py3.4 builds (it has reached EOL) and add macOS py3 builds. Add py38 to the build matrix for linux.