### PR TITLE
session_required_single_domain support

### DIFF
--- a/globus_cli/commands/session/update.py
+++ b/globus_cli/commands/session/update.py
@@ -18,9 +18,15 @@ from globus_cli.services.auth import get_auth_client
 )
 @no_local_server_option
 @click.argument("identities", nargs=-1, required=False)
-@click.option("--domain", multiple=True, help="authenticate with a specific domain")
 @click.option(
-    "--all", is_flag=True, help="authenticate with every identity in your identity set"
+    "--domain", multiple=True,
+    help="authenticate with a specific domain requirement. Can be passed "
+         "multiple times if multiple domains are required. "
+         "Mutually exclusive with IDENTITIES and --all")
+@click.option(
+    "--all", is_flag=True,
+    help="authenticate with every identity in your identity set. Mutually "
+         "exclusive with IDENTITIES and --domain"
 )
 def session_update(identities, no_local_server, all, domain):
     """

--- a/globus_cli/parsing/excepthook.py
+++ b/globus_cli/parsing/excepthook.py
@@ -48,6 +48,8 @@ def session_hook(exception):
         click.echo("message: {}".format(message))
 
     identities = params.get("session_required_identities")
+    domains = params.get("session_required_single_domain")
+
     if identities:
         id_str = " ".join(identities)
         click.echo(
@@ -55,11 +57,15 @@ def session_hook(exception):
             "    globus session update {}\n\n"
             "to re-authenticate with the required identities".format(id_str)
         )
-    else:
+    elif domains:
+        domain_str = " ".join(["--domain " + domain for domain in domains])
         click.echo(
-            'Please use "globus session update" to re-authenticate '
-            "with specific identities".format(id_str)
+            "Please run\n\n"
+            "    globus session update {}\n\n"
+            "to re-authenticate with a required domain".format(domain_str)
         )
+    else:
+        click.echo('Please use "globus session update" to re-authenticate ')
 
     exit_with_mapped_status(exception.http_status)
 


### PR DESCRIPTION
This is the work I've been using to test end to end mapped collection flows on sandbox

I'm not super attached to the `--domain` option, but since the arguments to `session update` are already overloaded between identity names and identity ids I'm not sure there is a nice way to have them also potentially be domains?