### PR TITLE
Classifiers for python3 versions are out of date

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,9 @@ setup(
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )


### PR DESCRIPTION
Remove 3.4 and add 3.8, to be in sync with the versions we test.