### PR TITLE
Add endpoint set-subscription-id command

### DIFF
--- a/globus_cli/commands/endpoint/commands.py
+++ b/globus_cli/commands/endpoint/commands.py
@@ -9,6 +9,9 @@ from globus_cli.commands.endpoint.permission import permission_command
 from globus_cli.commands.endpoint.role import role_command
 from globus_cli.commands.endpoint.search import endpoint_search
 from globus_cli.commands.endpoint.server import server_command
+from globus_cli.commands.endpoint.set_subscription_id import (
+    set_endpoint_subscription_id,
+)
 from globus_cli.commands.endpoint.show import endpoint_show
 from globus_cli.commands.endpoint.update import endpoint_update
 from globus_cli.parsing import group
@@ -30,6 +33,7 @@ endpoint_command.add_command(endpoint_show)
 endpoint_command.add_command(endpoint_create)
 endpoint_command.add_command(endpoint_update)
 endpoint_command.add_command(endpoint_delete)
+endpoint_command.add_command(set_endpoint_subscription_id)
 
 endpoint_command.add_command(endpoint_activate)
 endpoint_command.add_command(endpoint_is_activated)

--- a/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/globus_cli/commands/endpoint/set_subscription_id.py
@@ -1,0 +1,47 @@
+import uuid
+
+import click
+
+from globus_cli.parsing import EXPLICIT_NULL, command, endpoint_id_arg
+from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
+from globus_cli.services.transfer import get_client
+
+
+class SubscriptionIdType(click.ParamType):
+    def convert(self, value, param, ctx):
+        if value is None or (ctx and ctx.resilient_parsing):
+            return None
+        if value.lower() == "null":
+            return EXPLICIT_NULL
+        try:
+            uuid.UUID(value)
+            return value
+        except ValueError:
+            self.fail("{} is not a valid Subscription ID".format(value), param, ctx)
+
+
+@command("set-subscription-id")
+@endpoint_id_arg
+@click.argument("SUBSCRIPTION_ID", type=SubscriptionIdType())
+def set_endpoint_subscription_id(**kwargs):
+    """Set an endpoint's subscription
+
+    Unlike the '--managed' flag for 'globus endpoint update', this operation does not
+    require you to be an admin of the endpoint. It is useful in cases where you are a
+    subscription manager applying a subscription to an endpoint with a different admin.
+
+    SUBSCRIPTION_ID should either be a valid subscription ID or 'null'.
+    """
+    # validate params. Requires a get call to check the endpoint type
+    client = get_client()
+    endpoint_id = kwargs.pop("endpoint_id")
+    subscription_id = kwargs.pop("subscription_id")
+    if subscription_id is EXPLICIT_NULL:
+        subscription_id = None
+
+    # make the update
+    res = client.put(
+        "/endpoint/{}/subscription".format(endpoint_id),
+        {"subscription_id": subscription_id},
+    )
+    formatted_print(res, text_format=FORMAT_TEXT_RAW, response_key="message")


### PR DESCRIPTION
Adds a new command which calls the PUT subscription ID API directly.
This is useful when working with High Assurance endpoints and with GCSv5.x endpoints where the constraints around managing subscription IDs have become more complex. There are scenarios like a GCSv5 endpoint where the endpoint client is the owner/admin, and a user needs to set the endpoint to be managed under a subscription before being granted admin rights on the endpoint.

Until now, support for this method of setting the subscription ID was largely academic -- this is the new way to do it, but there was no pressing need to enable this method. However, especially with the new HA GCP setup flow and potential new versions of GCS, it's becoming more important to have this available in the CLI.

While I don't expect much usage, this is an important escape-valve, especially in case the webapp doesn't correctly decide on whether to use endpoint update or this PUT subscription API.