### PR TITLE
Add tox to development requirements?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
             # not just py2: py3 versions of mock don't all have the same
             # interface!
             'mock==2.0.0;python_version<"3.6"',
+            "tox<4",
         ],
     },
     entry_points={"console_scripts": ["globus = globus_cli:main"]},


### PR DESCRIPTION
It was dropped in aa5368121868a8eeb7d08815c08ab6103234062d but I'm not sure why--can we bring it back or was there an issue?