### PR TITLE
Make security_principal_opts decorator use `wraps`

### DIFF
--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -1,3 +1,5 @@
+import functools
+
 import click
 
 from globus_cli.parsing.command_state import (
@@ -762,6 +764,7 @@ def server_add_and_update_opts(*args, **kwargs):
 
 def security_principal_opts(*args, **kwargs):
     def preprocess_security_principals(f):
+        @functools.wraps(f)
         def decorator(*args, **kwargs):
             identity = kwargs.pop("identity", None)
             group = kwargs.pop("group", None)

--- a/tests/functional/test_helptext.py
+++ b/tests/functional/test_helptext.py
@@ -1,0 +1,17 @@
+"""
+tests which ensure that helptext rendering is correct
+"""
+
+
+# This is a regression test for
+#   https://github.com/globus/globus-cli/issues/496
+def test_helptext_for_commands_with_security_principal_opts(run_line):
+    """
+    Test commands which use the security principal options and ensure that their
+    helptext renders correctly.
+    """
+    result = run_line("globus endpoint role create --help")
+    assert "Create a role on an endpoint" in result.output
+
+    result = run_line("globus endpoint permission create --help")
+    assert "Create an access control rule, allowing new permissions" in result.output


### PR DESCRIPTION
Failing to apply functools.wraps results in this decorator not passing through attributes of the decorated function. As a result, `__doc__` (which becomes helptext) is not passed through and the help text is not properly displayed.

Includes a regression test which ensures the fix sticks.

fixes #496

---

Either of your reviews would be sufficient, FYI. We've been a bit unclear about that in the past. For the purposes of a PR review, I'm just tagging both of you in to notify.