### PR TITLE
Add handling for the data_access scope

### DIFF
--- a/globus_cli/commands/session/commands.py
+++ b/globus_cli/commands/session/commands.py
@@ -1,3 +1,4 @@
+from globus_cli.commands.session.consent import session_consent
 from globus_cli.commands.session.show import session_show
 from globus_cli.commands.session.update import session_update
 from globus_cli.parsing import group
@@ -11,3 +12,4 @@ def session_command():
 # commands
 session_command.add_command(session_update)
 session_command.add_command(session_show)
+session_command.add_command(session_consent)

--- a/globus_cli/commands/session/consent.py
+++ b/globus_cli/commands/session/consent.py
@@ -1,0 +1,44 @@
+import click
+
+from globus_cli.helpers import (
+    do_link_auth_flow,
+    do_local_server_auth_flow,
+    is_remote_session,
+)
+from globus_cli.parsing import command, no_local_server_option
+
+
+@command(
+    "consent",
+    short_help="Update your session with specific consents",
+    disable_options=["format", "map_http_status"],
+)
+@no_local_server_option
+@click.argument("SCOPES", nargs=-1, required=True)
+def session_consent(scopes, no_local_server):
+    """
+    Update your current CLI auth session by authenticating with a specific scope or set
+    of scopes.
+
+    This command is necessary when the CLI needs access to resources which require the
+    user to explicitly consent to access.
+    """
+    session_params = {"scope": " ".join(scopes)}
+
+    # use a link login if remote session or user requested
+    if no_local_server or is_remote_session():
+        do_link_auth_flow(session_params=session_params)
+
+    # otherwise default to a local server login flow
+    else:
+        click.echo(
+            "You are running 'globus session consent', "
+            "which should automatically open a browser window for you to "
+            "authenticate with specific identities.\n"
+            "If this fails or you experience difficulty, try "
+            "'globus session consent --no-local-server'"
+            "\n---"
+        )
+        do_local_server_auth_flow(session_params=session_params)
+
+    click.echo("\nYou have successfully updated your CLI session.\n")

--- a/globus_cli/parsing/excepthook.py
+++ b/globus_cli/parsing/excepthook.py
@@ -68,10 +68,20 @@ def consent_required_hook(exception):
     """
     Expects an exception with a required_scopes field in its raw_json
     """
-    click.echo(
-        "The resource you are trying to access requires you to "
-        "consent to additional access for the Globus CLI."
-    )
+    message = exception.raw_json.get("message")
+
+    # specialized message for data_access errors
+    # otherwise, use more generic phrasing
+    if message == "Missing required data_access consent":
+        click.echo(
+            "The collection you are trying to access data on requires you to "
+            "grant consent for the Globus CLI to access it."
+        )
+    else:
+        click.echo(
+            "The resource you are trying to access requires you to "
+            "consent to additional access for the Globus CLI."
+        )
 
     required_scopes = exception.raw_json.get("required_scopes")
     if not required_scopes:
@@ -79,7 +89,6 @@ def consent_required_hook(exception):
             "Fatal Error: ConsentRequired but no required_scopes!", bold=True, fg="red"
         )
         sys.exit(255)
-    message = exception.raw_json.get("message")
     if message:
         click.echo("message: {}".format(message))
 


### PR DESCRIPTION
This is the "minimum viable" version of this feature. Unfortunately, since I have limited time for this right now, I've chosen to eschew any automated tests. (I'd like to add something, but it's something of a matter of "when".)

Add a new command, `globus session consent`. Similar to `globus session update`, this is a specialized login flow which will allows users to modify their state in Auth. Specifically, in this case it will allow users to consent to additional scopes. Various names for this action are possible, e.g. "globus consent add". However, we already have the `globus session` command group for commands which manage your authentications, so this logically belongs there (whether or not the underlying implementation is treated as such notwithstanding -- it is not clear whether or not this feature is billed as part of "sessions" because it is not yet documented).

Add a new handler, like the session hook, which handles ConsentRequired errors. The hook will exit(255) if the error format is
not valid, but otherwise it looks almost identical to the session hook. The hard failure is appropriate in this case as there is no
graceful degradation we can perform if there is no required_scopes list. Other than that, it's almost a copy-paste-replace of the session hook, in this case directing users to invoke `globus session consent` with the specified scopes.

The ConsentRequired hook will single-quote the scopes for presentation to the user. Otherwise, it is easily possible to output a command which cannot run correctly as stated due to glob-expansion and other substitutions by the shell which we would expect to see on scope names.

One area that needed repair in order to handle these changes is the redirection handler for authentications. Because, in this case, we may only receive back a partial set of tokens, the handler cannot error out if the `auth.globus.org` tokens are not present. Instead, the handler must handle this possibility gracefully. In order to do so, the refactor "queues up" data to store, conditionally, and then processes that data. This flow of control should easily adapt to future storage methods or additional resource servers.

Here's a sample of this in action (against a Sandbox v5.4 Endpoint):
![image](https://user-images.githubusercontent.com/1300022/93269166-7c33db00-f77c-11ea-81bf-85a3449278cf.png)