### PR TITLE
Limit upgrades to <2.0 when on py2

### DIFF
--- a/globus_cli/commands/update.py
+++ b/globus_cli/commands/update.py
@@ -118,33 +118,36 @@ def update_command(yes, development, development_version):
         # latest version supported by the current platform/runtime . So exit 0 with a
         # warning
         if current == upgrade_target:
-            click.echo(
-                click.style(
-                    (
-                        "You are running the latest version ({}) supported by your "
-                        "runtime environment.\n"
-                        "However, a newer version ({}) is available.\n"
-                        "You need to uninstall and reinstall the CLI in order to "
-                        "update."
-                    ).format(upgrade_target, latest),
-                    fg="yellow",
+            if upgrade_target != latest:
+                click.echo(
+                    click.style(
+                        (
+                            "You are running the latest version ({}) supported by "
+                            "python2.\n"
+                            "However, a newer version ({}) is available.\n"
+                            "If you would like to update to the latest version, you "
+                            "need to reinstall globus-cli using python3."
+                        ).format(upgrade_target, latest),
+                        fg="yellow",
+                    )
                 )
-            )
             return
 
-        # if we're up to date (or ahead, meaning a dev version was installed)
-        # then prompt before continuing, respecting `--yes`
-        else:
-            click.echo(
-                (
-                    "You are already running version {}\n"
-                    "The latest version for you is   {}"
-                ).format(current, upgrade_target)
+        # show the version(s) and prompt to continue
+        explain_upgrade = "The latest version is {}".format(latest)
+        if upgrade_target != latest:
+            explain_upgrade = """\
+The latest version for python2 is {0}
+The latest version for python3 is {1}.
+If you would like to install version {1}, you must reinstall globus-cli using python3.
+""".format(
+                upgrade_target, latest
             )
-            if not yes and (
-                not click.confirm("Continue with the upgrade?", default=True)
-            ):
-                click.get_current_context().exit(1)
+        click.echo(
+            "You are already running version {}\n" "{}".format(current, explain_upgrade)
+        )
+        if not yes and (not click.confirm("Continue with the upgrade?", default=True)):
+            click.get_current_context().exit(1)
 
         # if we make it through to here, it means we didn't hit any safe (or
         # unsafe) abort conditions, so set the target version for upgrade to

--- a/globus_cli/helpers/version.py
+++ b/globus_cli/helpers/version.py
@@ -53,15 +53,22 @@ def _get_package_data():
 
 
 def _get_versionblock_message(current, latest, upgrade_target):
-    base = """\
-Installed Version: {}
-Latest Version:    {}""".format(
-        current, latest
-    )
     if latest == upgrade_target:
-        return base
+        return """\
+Installed version:  {}
+Latest version:     {}""".format(
+            current, latest
+        )
+    # latest != upgrade_target means it's a py2 environment where we're capped at <2.0
     else:
-        return base + "\nUpgrade Target:    {}".format(upgrade_target)
+        return """\
+You are running the Globus CLI on python2
+
+Installed version:           {}
+Latest version for python2:  {}
+Latest version for python3:  {}""".format(
+            current, upgrade_target, latest
+        )
 
 
 def _get_post_message(current, latest, upgrade_target):
@@ -73,18 +80,19 @@ def _get_post_message(current, latest, upgrade_target):
         return "You should update your version of the Globus CLI with\n  globus update"
     if current == upgrade_target:
         return """\
-You are running the latest version of the Globus CLI supported by
-your runtime.
+You are running the latest version of the Globus CLI supported by python2.
 
-To upgrade to the latest version of the CLI, you will need to
-uninstall and reinstall the CLI."""
+To upgrade to the latest version of the CLI ({}), you will need to
+uninstall and reinstall the CLI using python3.""".format(
+            latest
+        )
     if current < upgrade_target:
         return """\
 You should update your version of the Globus CLI.
-However, your runtime does not support the latest version.
+However, your python2 runtime does not support the latest version.
 
 You may update with the 'globus update' command, but we recommend that
-you uninstall and reinstall the CLI."""
+you uninstall and reinstall the CLI using python3."""
     # should be unreachable
     return "Unrecognized status. You may be on a development version."
 

--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -16,18 +16,33 @@ def get_versions():
 
     Also protects import of `requests` from issues when grabbed by setuptools.
     More on that inline
+
+    Returns a 3-tuple:
+      (upgrade_target, latest_version, current_version)
+
+    For CLI v1.x, upgrade_target is the latest v1 version IF you are on a python2
+    interpreter.
+    latest_version is the unbounded most recent version (could be 2.x, 3.x, etc)
+    regardless of runtime.
     """
     # import in the func (rather than top-level scope) so that at setup time,
-    # `requests` isn't required -- otherwise, setuptools will fail to run
-    # because requests isn't installed yet.
+    # `requests` and `six` aren't required -- otherwise, setuptools will fail to run
+    # because they aren't installed yet.
     import requests
+    import six
 
     try:
         version_data = requests.get(
             "https://pypi.python.org/pypi/globus-cli/json"
         ).json()
-        latest = max(LooseVersion(v) for v in version_data["releases"])
-        return latest, LooseVersion(__version__)
+        parsed_versions = [LooseVersion(v) for v in version_data["releases"]]
+        upgrade_target = latest = max(parsed_versions)
+        # python2 only; limit the upgrade to only the latest v1
+        if six.PY2:
+            upgrade_target = max(
+                v for v in parsed_versions if v < LooseVersion("2.0.0")
+            )
+        return upgrade_target, latest, LooseVersion(__version__)
     # if the fetch from pypi fails
     except requests.RequestException:
-        return None, LooseVersion(__version__)
+        return None, None, LooseVersion(__version__)


### PR DESCRIPTION
First, change the `get_versions()` helper to return a 3-tuple: `upgrade_target, latest, current`

This allows for the upgrade target to differ from the actual latest version. Specifically, when running under python2, filter the versions we get back such that upgrade_target is the maximal version satisfying `< 2.0`.

Then modify the `globus version` and `globus update` commands to handle this new output.

In the case of the version printing, the logic is somewhat refactored so that we can more easily distinguish the various conditions that determine what we say. If the latest and upgrade_target versions match, the behavior is completely unchanged. But if they differ, we print a generic message about how the latest CLI version isn't supported by your runtime and you should reinstall.

In the update command, we just add a check for `current == upgrade_target` after we've checked for `current == latest`.
If it matches, we print a warning message and exit(0).

Once we release this change, we can recommend that users update to the latest version of the CLI so that `globus update` will not unintentionally update them to a version incompatible with a py2 runtime. We can work out exactly what we want to say later, after this releases.