### PR TITLE
Use status badge from GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: build
 on:
   push:
     branches: ["master"]

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-.. image:: https://travis-ci.org/globus/globus-cli.svg?branch=master
+.. image:: https://github.com/globus/globus-cli/workflows/build/badge.svg?event=push
     :alt: build status
-    :target: https://travis-ci.org/globus/globus-cli
+    :target: https://github.com/globus/globus-cli/actions?query=workflow%3Abuild
 .. image:: https://badge.fury.io/py/globus-cli.svg
     :alt: PyPi Version
     :target: https://badge.fury.io/py/globus-cli


### PR DESCRIPTION
This switches the README status badge from Travis to GitHub Actions and changes the name of the workflow from "Test" to "build."