### PR TITLE
Update pre-commit; lint github workflow config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,14 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v2.5.0
+  rev: v3.4.0
   hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace
     - id: end-of-file-fixer
+- repo: https://github.com/sirosen/check-jsonschema
+  rev: 0.3.0
+  hooks:
+    - id: check-github-workflows
 - repo: https://github.com/python/black
   rev: 20.8b1
   hooks:
@@ -21,7 +25,7 @@ repos:
       language_version: python3
       additional_dependencies: ['flake8-bugbear==20.11.1']
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.6.4
+  rev: 5.7.0
   hooks:
     - id: isort
       name: "Sort python imports"


### PR DESCRIPTION
Adds the check-jsonschema hook and invokes the check-github-workflows checker. Also update the version of isort used.

Since we're doing some maintenance here, this is the first of several projects I'll do this on. I'd like to introduce this hook  to ensure that a bad workflow config can't get pushed.