### PR TITLE
default disable-verify should be None

### DIFF
--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -169,6 +169,7 @@ def endpoint_create_and_update_params(*args, **kwargs):
         )(f)
         f = click.option(
             "--disable-verify/--no-disable-verify",
+            default=None,
             is_flag=True,
             help="(Un)Set the endpoint to ignore checksum verification",
         )(f)


### PR DESCRIPTION
While debugging some transfer behavior using the CLI I noticed that the disable_verify flag was being passed as False even when I didn't use that CLI flag.