### PR TITLE
Update GitHub Actions and default branch name

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,15 +1,16 @@
 name: build
 on:
   push:
-    branches: ["master"]
   pull_request:
-    branches: ["master"]
+  # build weekly at 4:00 AM UTC
+  schedule:
+    - cron: '0 4 * * 1'
 jobs:
   test:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8"]
+        python-version: ["2.7", "3.6", "3.7", "3.8"]
         # we do not want a large number of windows and macos builds, so
         # enumerate them explicitly
         include:
@@ -38,19 +39,8 @@ jobs:
       - name: Install Requirements
         run: python -m pip install -U pip setuptools tox
       - name: Run Linting
-        # only lint on 3.8 for two reasons
-        #  1. faster overall runs
-        #  2. Linting fails on py3.5 because tools require 3.6+
+        # only lint on 3.8 for faster overall runs
         if: ${{ matrix.python-version == '3.8' }}
         run: python -m tox -e lint
-      # really clumsy retry with backoff... is there a better way?
       - name: Run Tests
-        id: testrun1
-        continue-on-error: true
         run: python -m tox -e py
-      - name: Wait and retest if first test failed
-        if: steps.testrun1.outcome == 'failure'
-        id: testrun2
-        run: |
-          sleep 60
-          python -m tox -e py

--- a/generate_release_notes.sh
+++ b/generate_release_notes.sh
@@ -13,7 +13,7 @@ github-issue-title () {
 	echo "$api_out" | grep '"title"' | cut -d':' -f2- | sed -e 's/^ "//' -e 's/",$//'
 }
 
-git log "${last_tag}..master" --oneline | grep 'Merge pull' | egrep -o '#[[:digit:]]+' | tr -d '#' | \
+git log "${last_tag}..main" --oneline | grep 'Merge pull' | egrep -o '#[[:digit:]]+' | tr -d '#' | \
     while read line; do
         echo "* $(github-issue-title "$line")"
         echo "(https://github.com/globus/globus-cli/pull/${line}[${line}])"

--- a/globus_cli/commands/update.py
+++ b/globus_cli/commands/update.py
@@ -50,7 +50,7 @@ def _check_pip_installed():
 )
 @click.option("--yes", is_flag=True, help='Automatically say "yes" to all prompts')
 # hidden options to fetch branches or tags from GitHub. One turns this mode
-# on or off, and the other is used to set a non-master target
+# on or off, and the other is used to set a non-main target
 # --development-version implies --development
 @click.option("--development", is_flag=True, hidden=True)
 @click.option("--development-version", hidden=True, default=None)
@@ -97,8 +97,8 @@ def update_command(yes, development, development_version):
     # if we're running with `--development`, then the target version is a
     # tarball from GitHub, and we can skip out on the safety checks
     if development:
-        # default to master
-        development_version = development_version or "master"
+        # default to main
+        development_version = development_version or "main"
         target_version = (
             "https://github.com/globus/globus-cli/archive/{}.tar.gz#egg=globus-cli"
         ).format(development_version)


### PR DESCRIPTION
The branch name change is master -> main . GitHub says they'll redirect downloads of tarballs after a branch rename, so the change in `update` (and the impact there) is basically nil.

This got me looking at the workflow file, and I realized that I didn't clean it up when I did the testsuite refactor. The games with retrying a flakey testsuite are no longer necessary.