### PR TITLE
skip and quota support

### DIFF
--- a/globus_cli/commands/task/show.py
+++ b/globus_cli/commands/task/show.py
@@ -46,9 +46,24 @@ SUCCESSFULL_TRANSFER_FIELDS = [
     ("Destination Path", "destination_path"),
 ]
 
+SKIPPED_PATHS_FIELDS = [
+    ("Source Path", "source_path"),
+    ("Destination Path", "destination_path"),
+    ("Error Code", "error_code"),
+]
+
 
 def print_successful_transfers(client, task_id):
     res = client.task_successful_transfers(task_id, num_results=None)
+    formatted_print(
+        res,
+        fields=SUCCESSFULL_TRANSFER_FIELDS,
+        json_converter=iterable_response_to_dict,
+    )
+
+
+def print_skipped_errors(client, task_id):
+    res = client.task_skipped_errors(task_id, num_results=None)
     formatted_print(
         res,
         fields=SUCCESSFULL_TRANSFER_FIELDS,
@@ -125,17 +140,32 @@ $ globus task show TASK_ID
     "-t",
     is_flag=True,
     default=False,
-    help="Show files that were transferred as result of this task.",
+    help=("Show files that were transferred as result of this task. "
+          "Mutually exclusive with --skipped-errors"),
 )
-def show_task(successful_transfers, task_id):
+@click.option(
+    "--skipped-errors",
+    is_flag=True,
+    default=False,
+    help=("Show paths that were skipped due to errors during this task. "
+          "Mutually exclusive with --successful-transfers"),
+)
+
+def show_task(successful_transfers, skipped_errors, task_id):
     """
     Print information detailing the status and other info about a task.
 
     The task may be pending, completed, or in progress.
     """
+    if successful_transfers and skipped_errors:
+        raise click.UsageError(
+            "--successful-transfers and --skipped-errors are mutually exclusive"
+        )
     client = get_client()
 
     if successful_transfers:
         print_successful_transfers(client, task_id)
+    elif skipped_errors:
+        print_skipped_errors(client, task_id)
     else:
         print_task_detail(client, task_id)

--- a/globus_cli/commands/task/show.py
+++ b/globus_cli/commands/task/show.py
@@ -21,6 +21,7 @@ COMMON_FIELDS = [
     ("Subtasks Failed", "subtasks_failed"),
     ("Subtasks Canceled", "subtasks_canceled"),
     ("Subtasks Expired", "subtasks_expired"),
+    ("Subtasks with Skipped Errors", "subtasks_skipped_errors"),
 ]
 
 ACTIVE_FIELDS = [("Deadline", "deadline"), ("Details", "nice_status")]
@@ -66,7 +67,7 @@ def print_skipped_errors(client, task_id):
     res = client.task_skipped_errors(task_id, num_results=None)
     formatted_print(
         res,
-        fields=SUCCESSFULL_TRANSFER_FIELDS,
+        fields=SKIPPED_PATHS_FIELDS,
         json_converter=iterable_response_to_dict,
     )
 
@@ -140,17 +141,20 @@ $ globus task show TASK_ID
     "-t",
     is_flag=True,
     default=False,
-    help=("Show files that were transferred as result of this task. "
-          "Mutually exclusive with --skipped-errors"),
+    help=(
+        "Show files that were transferred as result of this task. "
+        "Mutually exclusive with --skipped-errors"
+    ),
 )
 @click.option(
     "--skipped-errors",
     is_flag=True,
     default=False,
-    help=("Show paths that were skipped due to errors during this task. "
-          "Mutually exclusive with --successful-transfers"),
+    help=(
+        "Show paths that were skipped due to errors during this task. "
+        "Mutually exclusive with --successful-transfers"
+    ),
 )
-
 def show_task(successful_transfers, skipped_errors, task_id):
     """
     Print information detailing the status and other info about a task.

--- a/globus_cli/commands/transfer.py
+++ b/globus_cli/commands/transfer.py
@@ -173,6 +173,26 @@ fi
     show_default=True,
     help=("Specify an algorithm for --external-checksum or --verify-checksum"),
 )
+@click.option(
+    "--skip-source-errors",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help=(
+        "Skip over source paths that hit permission denied or file not "
+        "found errors during the transfer."
+    ),
+)
+@click.option(
+    "--fail-on-quota-errors",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help=(
+        "Cause the task to fail if any quota exceeded errors are hit "
+        "during the transfer."
+    ),
+)
 @click.argument(
     "source", metavar="SOURCE_ENDPOINT_ID[:SOURCE_PATH]", type=ENDPOINT_PLUS_OPTPATH
 )
@@ -191,6 +211,8 @@ def transfer_command(
     source,
     checksum_algorithm,
     external_checksum,
+    skip_source_errors,
+    fail_on_quota_errors,
     label,
     preserve_mtime,
     verify_checksum,
@@ -335,6 +357,8 @@ def transfer_command(
         delete_destination_extra=delete,
         deadline=deadline,
         skip_activation_check=skip_activation_check,
+        skip_source_errors=skip_source_errors,
+        fail_on_quota_errors=fail_on_quota_errors,
         **kwargs
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,11 @@ def go_ep2_id():
     return "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
 
 
+@pytest.fixture(scope="session")
+def task_id():
+    return "549ef13c-600f-11eb-9608-0afa7b051b85"
+
+
 @pytest.fixture
 def default_test_config():
     """
@@ -213,7 +218,7 @@ def _iter_fixture_routes(routes):
 
 
 @pytest.fixture
-def load_api_fixtures(register_api_route, test_file_dir, go_ep1_id, go_ep2_id):
+def load_api_fixtures(register_api_route, test_file_dir, go_ep1_id, go_ep2_id, task_id):
     def func(filename):
         filename = os.path.join(test_file_dir, "api_fixtures", filename)
         with open(filename) as fp:
@@ -226,7 +231,9 @@ def load_api_fixtures(register_api_route, test_file_dir, go_ep1_id, go_ep2_id):
 
             for path, method, params in _iter_fixture_routes(routes):
                 # allow /endpoint/{GO_EP1_ID} as a path
-                use_path = path.format(GO_EP1_ID=go_ep1_id, GO_EP2_ID=go_ep2_id)
+                use_path = path.format(
+                    GO_EP1_ID=go_ep1_id, GO_EP2_ID=go_ep2_id, TASK_ID=task_id
+                )
                 if "query_params" in params:
                     # copy and set match_querystring=True
                     params = dict(match_querystring=True, **params)

--- a/tests/files/api_fixtures/skipped_error_list.yaml
+++ b/tests/files/api_fixtures/skipped_error_list.yaml
@@ -1,0 +1,35 @@
+transfer:
+  - path: /task/{TASK_ID}/skipped_errors
+    method: get
+    status: 200
+    json:
+      {
+  "DATA": [
+    {
+      "DATA_TYPE": "skipped_error",
+      "checksum_algorithm": null,
+      "destination_path": "/~/no-such-file",
+      "error_code": "FILE_NOT_FOUND",
+      "error_details": "550-GlobusError: v=1 c=PATH_NOT_FOUND%0D%0A550-GridFTP-Errno: 2%0D%0A550-GridFTP-Reason: System error in stat%0D%0A550-GridFTP-Error-String: No such file or directory%0D%0A550 End.%0D%0A",
+      "error_time": "2021-01-29T18:50:37+00:00",
+      "external_checksum": null,
+      "is_delete_destination_extra": false,
+      "is_directory": false,
+      "is_symlink": false,
+      "source_path": "/~/no-such-file"
+    },
+    {
+      "DATA_TYPE": "skipped_error",
+      "checksum_algorithm": null,
+      "destination_path": "/~/restricted-file",
+      "error_code": "PERMISSION_DENIED",
+      "error_details": "Error (transfer)\nEndpoint: Dev GCP (15f47c5e-648e-11ea-aa9b-0afa7b051b85)\nServer: 172.31.20.254:40964\nFile: /~/restricted-file\nCommand: RETR ~/restricted-file\nMessage: Fatal FTP response\nTest-Unicode: \u24ca\u24c3\u24be\u24b8\u24c4\u24b9\u24ba \u2764 \u2605 \u262f\n---\nDetails: 500-GlobusError: v=1 c=INTERNAL_ERROR\\r\\n500-GridFTP-Error: globus_xio_register_open\\r\\n500-globus_xio: Unable to open file /home/aaron/restricted-file\\r\\n500-globus_xio: System error in open: Permission denied\\r\\n500-globus_xio: A system call failed: Permission denied\\r\\n500 End.\\r\\n\n",
+      "error_time": "2021-01-29T18:50:44+00:00",
+      "external_checksum": null,
+      "is_delete_destination_extra": false,
+      "is_directory": false,
+      "is_symlink": false,
+      "source_path": "/~/restricted-file"
+    }
+  ]
+}

--- a/tests/functional/test_task_show.py
+++ b/tests/functional/test_task_show.py
@@ -1,0 +1,12 @@
+def test_skipped_errors(run_line, load_api_fixtures, task_id):
+    """
+    Confirms --skipped-errors option for task show parses the output of
+    GET /task/<task_id>/skipped_errors
+    """
+    load_api_fixtures("skipped_error_list.yaml")
+
+    result = run_line("globus task show --skipped-errors {}".format(task_id))
+    assert "/~/no-such-file" in result.output
+    assert "FILE_NOT_FOUND" in result.output
+    assert "/~/restricted-file" in result.output
+    assert "PERMISSION_DENIED" in result.output


### PR DESCRIPTION
Adds --skip-source-errors and --fail-on-quota errors options to `globus transfer`
Adds --skipped-errors and a default ouput field for subtasks_skipped_errors to `globus task show`

I wrote this to depend on the SDK changes in https://github.com/globus/globus-sdk-python/pull/393
I'll see if I can write a few tests using the new framework by the time that gets merged.
