### PR TITLE
Release v1.16.0

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -1,5 +1,15 @@
 = CLI Changelog
 
+== 1.16.0
+
+Enhancements:
+
+* `globus transfer` now supports two new flags, `--skip-source-errors` and
+  `--fail-on-quota-errors`, which allow you to better control error behaviors
+
+* `globus task show --skipped-errors` is a new flag which will show skipped
+  transfer errors (for transfers which support them)
+
 == 1.15.0
 
 Bugfixes:

--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -2,7 +2,7 @@ from distutils.version import LooseVersion
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.15.0"
+__version__ = "1.16.0"
 
 # app name to send as part of SDK requests
 app_name = "Globus CLI v{}".format(__version__)


### PR DESCRIPTION
As we discussed, the other outstanding work is on hold until we can handle our major version updates.

I also did due-diligence and checked the result of `reference/_generate.py` after the recent changes.