### PR TITLE
Drop python 2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,37 +10,26 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["2.7", "3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         # we do not want a large number of windows and macos builds, so
         # enumerate them explicitly
         include:
           - os: windows-latest
-            python-version: 2.7
-          - os: windows-latest
-            python-version: 3.8
+            python-version: 3.9
           - os: macos-latest
-            python-version: 3.8
+            python-version: 3.9
     name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      # without VC on windows, we can't install ruamel.yaml
-      #
-      # if you're reading this comment, I just want you to know that there is
-      # no swearing here because I did all of my swearing out loud when we ran
-      # into this issue
-      - name: "Install Visual C++ for Python 2.7"
-        if: ${{ matrix.os == 'windows-latest' && matrix.python-version == '2.7' }}
-        run: choco install vcpython27 -f -y
       - name: Install Requirements
         run: python -m pip install -U pip setuptools tox
       - name: Run Linting
-        # only lint on 3.8 for faster overall runs
-        if: ${{ matrix.python-version == '3.8' }}
+        # only lint on 3.9 for faster overall runs
+        if: ${{ matrix.python-version == '3.9' }}
         run: python -m tox -e lint
       - name: Run Tests
         run: python -m tox -e py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
       name: "Sort python imports"
       types: [python]
       language_version: python3
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.7.4
+  hooks:
+    - id: pyupgrade
+      args: ["--py36-plus"]

--- a/globus_cli/commands/bookmark/helpers.py
+++ b/globus_cli/commands/bookmark/helpers.py
@@ -32,9 +32,7 @@ def resolve_id_or_name(client, bookmark_id_or_name):
             )
 
         except StopIteration:
-            click.echo(
-                u'No bookmark found for "{}"'.format(bookmark_id_or_name), err=True
-            )
+            click.echo(f'No bookmark found for "{bookmark_id_or_name}"', err=True)
             click.get_current_context().exit(1)
 
     return res

--- a/globus_cli/commands/config/filename.py
+++ b/globus_cli/commands/config/filename.py
@@ -9,7 +9,7 @@ def filename_command():
     """Output the path of the config file"""
     try:
         config = get_config_obj(file_error=True)
-    except IOError as e:
+    except OSError as e:
         click.echo(e, err=True)
         click.get_current_context().exit(1)
     else:

--- a/globus_cli/commands/config/init.py
+++ b/globus_cli/commands/config/init.py
@@ -74,7 +74,7 @@ def init_command(default_output_format, default_myproxy_username):
 
     # write to disk
     click.echo(
-        "\n\nWriting updated config to {0}".format(os.path.expanduser("~/.globus.cfg"))
+        "\n\nWriting updated config to {}".format(os.path.expanduser("~/.globus.cfg"))
     )
     write_option(OUTPUT_FORMAT_OPTNAME, default_output_format)
     write_option(MYPROXY_USERNAME_OPTNAME, default_myproxy_username)

--- a/globus_cli/commands/config/remove.py
+++ b/globus_cli/commands/config/remove.py
@@ -21,5 +21,5 @@ def remove_command(parameter):
     del conf[section][parameter]
 
     # write to disk
-    click.echo("Writing updated config to {}".format(conf.filename))
+    click.echo(f"Writing updated config to {conf.filename}")
     conf.write()

--- a/globus_cli/commands/config/set.py
+++ b/globus_cli/commands/config/set.py
@@ -22,5 +22,5 @@ def set_command(value, parameter):
     conf[section][parameter] = value
 
     # write to disk
-    click.echo("Writing updated config to {}".format(conf.filename))
+    click.echo(f"Writing updated config to {conf.filename}")
     conf.write()

--- a/globus_cli/commands/config/show.py
+++ b/globus_cli/commands/config/show.py
@@ -15,6 +15,6 @@ def show_command(parameter):
     value = lookup_option(parameter, section=section)
 
     if value is None:
-        click.echo("{} not set".format(parameter))
+        click.echo(f"{parameter} not set")
     else:
-        click.echo("{} = {}".format(parameter, value))
+        click.echo(f"{parameter} = {value}")

--- a/globus_cli/commands/endpoint/activate.py
+++ b/globus_cli/commands/endpoint/activate.py
@@ -276,9 +276,9 @@ def endpoint_activate(
 
     # web activation
     elif web:
-        url = "https://app.globus.org/file-manager?origin_id={}".format(endpoint_id)
+        url = f"https://app.globus.org/file-manager?origin_id={endpoint_id}"
         if no_browser or is_remote_session():
-            res = {"message": "Web activation url: {}".format(url), "url": url}
+            res = {"message": f"Web activation url: {url}", "url": url}
         else:
             webbrowser.open(url, new=1)
             res = {"message": "Browser opened to web activation page", "url": url}

--- a/globus_cli/commands/endpoint/is_activated.py
+++ b/globus_cli/commands/endpoint/is_activated.py
@@ -92,7 +92,7 @@ def endpoint_is_activated(endpoint_id, until, absolute_time):
     def fail(deadline=None):
         exp_string = ""
         if deadline is not None:
-            exp_string = " or will expire within {} seconds".format(deadline)
+            exp_string = f" or will expire within {deadline} seconds"
 
         message = "The endpoint is not activated{}.\n\n".format(
             exp_string

--- a/globus_cli/commands/endpoint/local_id.py
+++ b/globus_cli/commands/endpoint/local_id.py
@@ -55,7 +55,7 @@ def local_id(personal):
     if personal:
         try:
             ep_id = LocalGlobusConnectPersonal().endpoint_id
-        except IOError as e:
+        except OSError as e:
             click.echo(e, err=True)
             click.get_current_context().exit(1)
 

--- a/globus_cli/commands/endpoint/permission/list.py
+++ b/globus_cli/commands/endpoint/permission/list.py
@@ -36,7 +36,7 @@ def list_command(endpoint_id):
             except KeyError:
                 return principal
         if rule["principal_type"] == "group":
-            return (u"https://app.globus.org/groups/{}").format(principal)
+            return ("https://app.globus.org/groups/{}").format(principal)
         return rule["principal_type"]
 
     formatted_print(

--- a/globus_cli/commands/endpoint/permission/show.py
+++ b/globus_cli/commands/endpoint/permission/show.py
@@ -10,7 +10,7 @@ def _shared_with_keyfunc(rule):
     if rule["principal_type"] == "identity":
         return lookup_identity_name(rule["principal"])
     elif rule["principal_type"] == "group":
-        return u"https://app.globus.org/groups/{}".format(rule["principal"])
+        return "https://app.globus.org/groups/{}".format(rule["principal"])
     else:
         return rule["principal_type"]
 

--- a/globus_cli/commands/endpoint/role/list.py
+++ b/globus_cli/commands/endpoint/role/list.py
@@ -51,7 +51,7 @@ def role_list(endpoint_id):
             except KeyError:
                 return principal
         if role["principal_type"] == "group":
-            return (u"https://app.globus.org/groups/{}").format(principal)
+            return f"https://app.globus.org/groups/{principal}"
         return principal
 
     formatted_print(

--- a/globus_cli/commands/endpoint/server/delete.py
+++ b/globus_cli/commands/endpoint/server/delete.py
@@ -93,7 +93,7 @@ def server_delete(endpoint_id, server):
     if mode != "id":
         matches = _spec_to_matches(server_list, server, mode)
         if not matches:
-            raise click.UsageError('No server was found matching "{}"'.format(server))
+            raise click.UsageError(f'No server was found matching "{server}"')
         elif len(matches) > 1:
             raise click.UsageError(
                 dedent(

--- a/globus_cli/commands/endpoint/server/show.py
+++ b/globus_cli/commands/endpoint/server/show.py
@@ -46,7 +46,7 @@ def server_show(endpoint_id, server_id):
                     if not start and not end
                     else "unrestricted"
                     if start == 1024 and end == 65535
-                    else "{}-{}".format(start, end)
+                    else f"{start}-{end}"
                 )
 
             return "incoming {}, outgoing {}".format(

--- a/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/globus_cli/commands/endpoint/set_subscription_id.py
@@ -17,7 +17,7 @@ class SubscriptionIdType(click.ParamType):
             uuid.UUID(value)
             return value
         except ValueError:
-            self.fail("{} is not a valid Subscription ID".format(value), param, ctx)
+            self.fail(f"{value} is not a valid Subscription ID", param, ctx)
 
 
 @command("set-subscription-id", short_help="Set an endpoint's subscription")
@@ -42,7 +42,7 @@ def set_endpoint_subscription_id(**kwargs):
 
     # make the update
     res = client.put(
-        "/endpoint/{}/subscription".format(endpoint_id),
+        f"/endpoint/{endpoint_id}/subscription",
         {"subscription_id": subscription_id},
     )
     formatted_print(res, text_format=FORMAT_TEXT_RAW, response_key="message")

--- a/globus_cli/commands/list_commands.py
+++ b/globus_cli/commands/list_commands.py
@@ -51,7 +51,7 @@ def list_commands():
         parents = " ".join(parent_names)
         if parents:
             parents = parents + " "
-        click.echo("\n=== {}{} ===\n".format(parents, command.name))
+        click.echo(f"\n=== {parents}{command.name} ===\n")
 
     def _recursive_list_commands(command, parent_names=None):
         if parent_names is None:

--- a/globus_cli/commands/login.py
+++ b/globus_cli/commands/login.py
@@ -28,7 +28,7 @@ Logout of the Globus CLI with
 
 _LOGIN_EPILOG = (
     (
-        u"""\
+        """\
 
 You have successfully logged in to the Globus CLI!
 """

--- a/globus_cli/commands/logout.py
+++ b/globus_cli/commands/logout.py
@@ -69,14 +69,12 @@ def logout_command():
         username = get_auth_client().oauth2_userinfo()["preferred_username"]
     except AuthAPIError:
         click.echo(
-            (
-                "Unable to lookup username. You may not be logged in. "
-                "Attempting logout anyway...\n"
-            )
+            "Unable to lookup username. You may not be logged in. "
+            "Attempting logout anyway...\n"
         )
         username = None
     click.echo(
-        u"Logging out of Globus{}\n".format(u" as " + username if username else "")
+        "Logging out of Globus{}\n".format(" as " + username if username else "")
     )
 
     # we use a Native Client to prevent an invalid instance client
@@ -110,11 +108,8 @@ def logout_command():
         # that we can revoke later when the network is working
         except globus_sdk.NetworkError:
             click.echo(
-                (
-                    "Failed to reach Globus to revoke tokens. "
-                    "Because we cannot revoke these tokens, cancelling "
-                    "logout"
-                )
+                "Failed to reach Globus to revoke tokens. "
+                "Because we cannot revoke these tokens, cancelling logout"
             )
             click.get_current_context().exit(1)
         # finally, we revoked, so it's safe to remove the token
@@ -126,7 +121,7 @@ def logout_command():
     if client_id:
         instance_client = internal_auth_client()
         try:
-            instance_client.delete("/v2/api/clients/{}".format(client_id))
+            instance_client.delete(f"/v2/api/clients/{client_id}")
 
         # if the client secret has been invalidated or the client has
         # already been removed, we continue on

--- a/globus_cli/commands/ls.py
+++ b/globus_cli/commands/ls.py
@@ -169,7 +169,7 @@ def ls_command(
         if "/" in filter_val:
             raise click.UsageError('--filter cannot contain "/"')
         # format into a simple filter clause which operates on filenames
-        ls_params["filter"] = "name:{}".format(filter_val)
+        ls_params["filter"] = f"name:{filter_val}"
 
     # get the `ls` result
     if recursive:

--- a/globus_cli/commands/rm.py
+++ b/globus_cli/commands/rm.py
@@ -83,7 +83,7 @@ def rm_command(
         deadline=deadline,
         skip_activation_check=skip_activation_check,
         interpret_globs=enable_globs,
-        **notify
+        **notify,
     )
 
     if not star_silent and enable_globs and path.endswith("*"):
@@ -94,7 +94,7 @@ def rm_command(
             err_is_terminal()
             and term_is_interactive()
             and not click.confirm(
-                'Are you sure you want to delete all files matching "{}"?'.format(path),
+                f'Are you sure you want to delete all files matching "{path}"?',
                 err=True,
             )
         ):
@@ -111,7 +111,7 @@ def rm_command(
     # respected, as it will be by `task wait`
     res = client.submit_delete(delete_data)
     task_id = res["task_id"]
-    click.echo('Delete task submitted under ID "{}"'.format(task_id), err=True)
+    click.echo(f'Delete task submitted under ID "{task_id}"', err=True)
 
     # do a `task wait` equivalent, including printing and correct exit status
     task_wait_with_io(

--- a/globus_cli/commands/session/update.py
+++ b/globus_cli/commands/session/update.py
@@ -74,7 +74,7 @@ def session_update(identities, no_local_server, all):
                         identity_ids.append(identity["id"])
                         break
                 else:
-                    click.echo("No such identity {}".format(val), err=True)
+                    click.echo(f"No such identity {val}", err=True)
                     click.get_current_context().exit(1)
 
     # create session params once we have all identity ids

--- a/globus_cli/commands/task/cancel.py
+++ b/globus_cli/commands/task/cancel.py
@@ -92,9 +92,7 @@ def cancel_task(all, task_id):
 
         def _custom_text(res):
             for (i, (task_id, data)) in enumerate(cancellation_iterator(), start=1):
-                click.echo(
-                    u"{} ({} of {}): {}".format(task_id, i, task_count, data["message"])
-                )
+                click.echo(f"{task_id} ({i} of {task_count}): {data['message']}")
 
         # FIXME: this is kind of an abuse of formatted_print because the
         # text format and json converter are doing their own thing, not really

--- a/globus_cli/commands/task/list.py
+++ b/globus_cli/commands/task/list.py
@@ -1,5 +1,4 @@
 import click
-import six
 
 from globus_cli.parsing import command
 from globus_cli.safeio import formatted_print
@@ -164,8 +163,8 @@ def task_list(
 
     def _process_filterval(prefix, value, default=None):
         if value:
-            if isinstance(value, six.string_types):
-                return "{}:{}/".format(prefix, value)
+            if isinstance(value, str):
+                return f"{prefix}:{value}/"
             return "{}:{}/".format(prefix, ",".join(str(x) for x in value))
         else:
             return default or ""

--- a/globus_cli/commands/task/pause_info.py
+++ b/globus_cli/commands/task/pause_info.py
@@ -86,7 +86,7 @@ def task_pause_info(task_id):
         effective_pause_rules = res["pause_rules"]
 
         if not explicit_pauses and not effective_pause_rules:
-            click.echo("Task {} is not paused.".format(task_id))
+            click.echo(f"Task {task_id} is not paused.")
             click.get_current_context().exit(0)
 
         if explicit_pauses:

--- a/globus_cli/commands/transfer.py
+++ b/globus_cli/commands/transfer.py
@@ -299,20 +299,16 @@ def transfer_command(
 
     if recursive and batch:
         raise click.UsageError(
-            (
-                "You cannot use --recursive in addition to --batch. "
-                "Instead, use --recursive on lines of --batch input "
-                "which need it"
-            )
+            "You cannot use --recursive in addition to --batch. "
+            "Instead, use --recursive on lines of --batch input "
+            "which need it"
         )
 
     if external_checksum and batch:
         raise click.UsageError(
-            (
-                "You cannot use --external-checksum in addition to --batch. "
-                "Instead, use --external-checksum on lines of --batch input "
-                "which need it"
-            )
+            "You cannot use --external-checksum in addition to --batch. "
+            "Instead, use --external-checksum on lines of --batch input "
+            "which need it"
         )
 
     if recursive and external_checksum:
@@ -333,13 +329,13 @@ def transfer_command(
     # notify comes to us clean, perf opts need more care
     # put them together into a dict before passing to TransferData
     kwargs = {}
-    perf_opts = dict(
-        (k, v)
+    perf_opts = {
+        k: v
         for (k, v) in dict(
             perf_cc=perf_cc, perf_p=perf_p, perf_pp=perf_pp, perf_udt=perf_udt
         ).items()
         if v is not None
-    )
+    }
     kwargs.update(perf_opts)
     kwargs.update(notify)
 

--- a/globus_cli/commands/update.py
+++ b/globus_cli/commands/update.py
@@ -111,7 +111,7 @@ def update_command(yes, development, development_version):
 
         # in the case where we're already up to date, do nothing and exit
         if current == latest:
-            click.echo("You are already running the latest version: {}".format(current))
+            click.echo(f"You are already running the latest version: {current}")
             return
 
         # we are not all the way up to date (did not match `latest`) but we match the
@@ -134,7 +134,7 @@ def update_command(yes, development, development_version):
             return
 
         # show the version(s) and prompt to continue
-        explain_upgrade = "The latest version is {}".format(latest)
+        explain_upgrade = f"The latest version is {latest}"
         if upgrade_target != latest:
             explain_upgrade = """\
 The latest version for python2 is {0}
@@ -152,7 +152,7 @@ If you would like to install version {1}, you must reinstall globus-cli using py
         # if we make it through to here, it means we didn't hit any safe (or
         # unsafe) abort conditions, so set the target version for upgrade to
         # the latest
-        target_version = "globus-cli=={}".format(upgrade_target)
+        target_version = f"globus-cli=={upgrade_target}"
 
     # print verbose warning/help message, to guide less fortunate souls who hit
     # Ctrl+C at a foolish time, lose connectivity, or don't invoke with `sudo`

--- a/globus_cli/commands/update.py
+++ b/globus_cli/commands/update.py
@@ -104,7 +104,7 @@ def update_command(yes, development, development_version):
         ).format(development_version)
     else:
         # lookup version from PyPi, abort if we can't get it
-        upgrade_target, latest, current = get_versions()
+        latest, current = get_versions()
         if latest is None:
             click.echo("Failed to lookup latest version. Aborting.")
             click.get_current_context().exit(1)
@@ -114,45 +114,15 @@ def update_command(yes, development, development_version):
             click.echo(f"You are already running the latest version: {current}")
             return
 
-        # we are not all the way up to date (did not match `latest`) but we match the
-        # latest version supported by the current platform/runtime . So exit 0 with a
-        # warning
-        if current == upgrade_target:
-            if upgrade_target != latest:
-                click.echo(
-                    click.style(
-                        (
-                            "You are running the latest version ({}) supported by "
-                            "python2.\n"
-                            "However, a newer version ({}) is available.\n"
-                            "If you would like to update to the latest version, you "
-                            "need to reinstall globus-cli using python3."
-                        ).format(upgrade_target, latest),
-                        fg="yellow",
-                    )
-                )
-            return
-
         # show the version(s) and prompt to continue
-        explain_upgrade = f"The latest version is {latest}"
-        if upgrade_target != latest:
-            explain_upgrade = """\
-The latest version for python2 is {0}
-The latest version for python3 is {1}.
-If you would like to install version {1}, you must reinstall globus-cli using python3.
-""".format(
-                upgrade_target, latest
-            )
-        click.echo(
-            "You are already running version {}\n" "{}".format(current, explain_upgrade)
-        )
+        click.echo(f"You are running version {current}\nThe latest version is {latest}")
         if not yes and (not click.confirm("Continue with the upgrade?", default=True)):
             click.get_current_context().exit(1)
 
         # if we make it through to here, it means we didn't hit any safe (or
         # unsafe) abort conditions, so set the target version for upgrade to
         # the latest
-        target_version = f"globus-cli=={upgrade_target}"
+        target_version = f"globus-cli=={latest}"
 
     # print verbose warning/help message, to guide less fortunate souls who hit
     # Ctrl+C at a foolish time, lose connectivity, or don't invoke with `sudo`

--- a/globus_cli/config.py
+++ b/globus_cli/config.py
@@ -52,16 +52,16 @@ GLOBUS_ENV = os.environ.get("GLOBUS_SDK_ENVIRONMENT")
 
 # if the env is set, rewrite the option names to have it as a prefix
 if GLOBUS_ENV:
-    AUTH_RT_OPTNAME = "{0}_auth_refresh_token".format(GLOBUS_ENV)
-    AUTH_AT_OPTNAME = "{0}_auth_access_token".format(GLOBUS_ENV)
-    AUTH_AT_EXPIRES_OPTNAME = "{0}_auth_access_token_expires".format(GLOBUS_ENV)
-    TRANSFER_RT_OPTNAME = "{0}_transfer_refresh_token".format(GLOBUS_ENV)
-    TRANSFER_AT_OPTNAME = "{0}_transfer_access_token".format(GLOBUS_ENV)
-    TRANSFER_AT_EXPIRES_OPTNAME = "{0}_transfer_access_token_expires".format(GLOBUS_ENV)
+    AUTH_RT_OPTNAME = f"{GLOBUS_ENV}_auth_refresh_token"
+    AUTH_AT_OPTNAME = f"{GLOBUS_ENV}_auth_access_token"
+    AUTH_AT_EXPIRES_OPTNAME = f"{GLOBUS_ENV}_auth_access_token_expires"
+    TRANSFER_RT_OPTNAME = f"{GLOBUS_ENV}_transfer_refresh_token"
+    TRANSFER_AT_OPTNAME = f"{GLOBUS_ENV}_transfer_access_token"
+    TRANSFER_AT_EXPIRES_OPTNAME = f"{GLOBUS_ENV}_transfer_access_token_expires"
 
-    CLIENT_ID_OPTNAME = "{0}_client_id".format(GLOBUS_ENV)
-    CLIENT_SECRET_OPTNAME = "{0}_client_secret".format(GLOBUS_ENV)
-    TEMPLATE_ID_OPTNAME = "{0}_template_id".format(GLOBUS_ENV)
+    CLIENT_ID_OPTNAME = f"{GLOBUS_ENV}_client_id"
+    CLIENT_SECRET_OPTNAME = f"{GLOBUS_ENV}_client_secret"
+    TEMPLATE_ID_OPTNAME = f"{GLOBUS_ENV}_template_id"
     DEFAULT_TEMPLATE_ID = {
         "sandbox": "33b6a241-bce4-4359-9c6d-09f88b3c9eef",
         "integration": "e0c31fd1-663b-44e1-840f-f4304bb9ee7a",
@@ -208,7 +208,7 @@ def internal_auth_client(requires_instance=False, force_new_client=False):
     if force_new_client and existing:
         existing_client = globus_sdk.ConfidentialAppAuthClient(client_id, client_secret)
         try:
-            existing_client.delete("/v2/api/clients/{}".format(client_id))
+            existing_client.delete(f"/v2/api/clients/{client_id}")
 
         # if the client secret has been invalidated or the client has
         # already been removed, we continue on

--- a/globus_cli/helpers/auth_flows.py
+++ b/globus_cli/helpers/auth_flows.py
@@ -71,7 +71,7 @@ def do_local_server_auth_flow(session_params=None, force_new_client=False):
     # start local server and create matching redirect_uri
     with start_local_server(listen=("127.0.0.1", 0)) as server:
         _, port = server.socket.getsockname()
-        redirect_uri = "http://localhost:{}".format(port)
+        redirect_uri = f"http://localhost:{port}"
 
         # get the ConfidentialApp client object and start a flow
         auth_client = internal_auth_client(
@@ -89,11 +89,11 @@ def do_local_server_auth_flow(session_params=None, force_new_client=False):
         auth_code = server.wait_for_code()
 
     if isinstance(auth_code, LocalServerError):
-        click.echo("Authorization failed: {}".format(auth_code), err=True)
+        click.echo(f"Authorization failed: {auth_code}", err=True)
         click.get_current_context().exit(1)
     elif isinstance(auth_code, Exception):
         click.echo(
-            "Authorization failed with unexpected error:\n{}".format(auth_code),
+            f"Authorization failed with unexpected error:\n{auth_code}",
             err=True,
         )
         click.get_current_context().exit(1)

--- a/globus_cli/helpers/delegate_proxy.py
+++ b/globus_cli/helpers/delegate_proxy.py
@@ -3,7 +3,6 @@ import os
 import re
 import struct
 
-import six
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
@@ -114,13 +113,15 @@ def parse_issuer_cred(issuer_cred):
     # then validate that each section of data can be decoded as expected
     try:
         loaded_cert = x509.load_pem_x509_certificate(
-            six.b(issuer_cert), default_backend()
+            issuer_cert.encode("utf-8"), default_backend()
         )
         loaded_private_key = serialization.load_pem_private_key(
-            six.b(issuer_private_key), password=None, backend=default_backend()
+            issuer_private_key.encode("utf-8"), password=None, backend=default_backend()
         )
         for chain_cert in issuer_chain_certs:
-            x509.load_pem_x509_certificate(six.b(chain_cert), default_backend())
+            x509.load_pem_x509_certificate(
+                chain_cert.encode("utf-8"), default_backend()
+            )
         issuer_chain = "".join(issuer_chain_certs)
     except ValueError:
         raise ValueError(

--- a/globus_cli/helpers/delegate_proxy.py
+++ b/globus_cli/helpers/delegate_proxy.py
@@ -25,10 +25,8 @@ def fill_delegate_proxy_activation_requirements(
             break
     else:
         raise ValueError(
-            (
-                "No public_key found in activation requirements, this endpoint "
-                "does not support Delegate Proxy activation."
-            )
+            "No public_key found in activation requirements, this endpoint "
+            "does not support Delegate Proxy activation."
         )
 
     # get user credentials from user credential file"
@@ -45,10 +43,8 @@ def fill_delegate_proxy_activation_requirements(
             return requirements_data
     else:
         raise ValueError(
-            (
-                "No proxy_chain found in activation requirements, this endpoint "
-                "does not support Delegate Proxy activation."
-            )
+            "No proxy_chain found in activation requirements, this endpoint "
+            "does not support Delegate Proxy activation."
         )
 
 
@@ -78,9 +74,10 @@ def create_proxy_credentials(issuer_cred, public_key, lifetime_hours):
     )
 
     # extend the proxy chain as a unicode string
-    extended_chain = loaded_cert.public_bytes(serialization.Encoding.PEM).decode(
-        "ascii"
-    ) + six.u(issuer_chain)
+    extended_chain = (
+        loaded_cert.public_bytes(serialization.Encoding.PEM).decode("ascii")
+        + issuer_chain
+    )
 
     # return in PEM format as a unicode string
     return (
@@ -170,7 +167,7 @@ def create_proxy_cert(
     # set the new proxy's subject
     # append a CommonName to the new proxy's subject
     # with the serial as the value of the CN
-    new_atribute = x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, six.u(str(serial)))
+    new_atribute = x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, str(serial))
     subject_attributes = list(loaded_cert.subject)
     subject_attributes.append(new_atribute)
     builder = builder.subject_name(x509.Name(subject_attributes))

--- a/globus_cli/helpers/local_server.py
+++ b/globus_cli/helpers/local_server.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from string import Template
 
 import click
-import six
 
 try:
     import http.client as http_client
@@ -105,22 +104,18 @@ class RedirectHandler(BaseHTTPRequestHandler):
         code = query_params.get("code")
         if code:
             self.wfile.write(
-                six.b(
-                    HTML_TEMPLATE.substitute(
-                        post_login_message=DOC_URL, login_result="Login successful"
-                    )
-                )
+                HTML_TEMPLATE.substitute(
+                    post_login_message=DOC_URL, login_result="Login successful"
+                ).encode("utf-8")
             )
             self.server.return_code(code)
         else:
             msg = query_params.get("error_description", query_params.get("error"))
 
             self.wfile.write(
-                six.b(
-                    HTML_TEMPLATE.substitute(
-                        post_login_message=msg, login_result="Login failed"
-                    )
-                )
+                HTML_TEMPLATE.substitute(
+                    post_login_message=msg, login_result="Login failed"
+                ).encode("utf-8")
             )
 
             self.server.return_code(LocalServerError(msg))

--- a/globus_cli/helpers/local_server.py
+++ b/globus_cli/helpers/local_server.py
@@ -129,9 +129,9 @@ class RedirectHandler(BaseHTTPRequestHandler):
         return
 
 
-class RedirectHTTPServer(HTTPServer, object):
+class RedirectHTTPServer(HTTPServer):
     def __init__(self, listen, handler_class):
-        super(RedirectHTTPServer, self).__init__(listen, handler_class)
+        super().__init__(listen, handler_class)
 
         self._auth_code_queue = Queue.Queue()
 

--- a/globus_cli/helpers/version.py
+++ b/globus_cli/helpers/version.py
@@ -51,43 +51,18 @@ def _get_package_data():
     return moddata
 
 
-def _get_versionblock_message(current, latest, upgrade_target):
-    if latest == upgrade_target:
-        return f"""\
+def _get_versionblock_message(current, latest):
+    return f"""\
 Installed version:  {current}
 Latest version:     {latest}"""
-    # latest != upgrade_target means it's a py2 environment where we're capped at <2.0
-    else:
-        return f"""\
-You are running the Globus CLI on python2
-
-Installed version:           {current}
-Latest version for python2:  {upgrade_target}
-Latest version for python3:  {latest}"""
 
 
-def _get_post_message(current, latest, upgrade_target):
+def _get_post_message(current, latest):
     if current == latest:
         return "You are running the latest version of the Globus CLI"
     if current > latest:
         return "You are running a preview version of the Globus CLI"
-    if upgrade_target == latest:
-        return "You should update your version of the Globus CLI with\n  globus update"
-    if current == upgrade_target:
-        return f"""\
-You are running the latest version of the Globus CLI supported by python2.
-
-To upgrade to the latest version of the CLI ({latest}), you will need to
-uninstall and reinstall the CLI using python3."""
-    if current < upgrade_target:
-        return """\
-You should update your version of the Globus CLI.
-However, your python2 runtime does not support the latest version.
-
-You may update with the 'globus update' command, but we recommend that
-you uninstall and reinstall the CLI using python3."""
-    # should be unreachable
-    return "Unrecognized status. You may be on a development version."
+    return "You should update your version of the Globus CLI with\n  globus update"
 
 
 def print_version():
@@ -98,14 +73,14 @@ def print_version():
     It may seem odd that this isn't in globus_cli.version , but it's done this
     way to separate concerns over printing the version from looking it up.
     """
-    upgrade_target, latest, current = get_versions()
+    latest, current = get_versions()
     if latest is None:
         click.echo(f"Installed Version: {current}\nFailed to lookup latest version.")
     else:
         click.echo(
-            _get_versionblock_message(current, latest, upgrade_target)
+            _get_versionblock_message(current, latest)
             + "\n\n"
-            + _get_post_message(current, latest, upgrade_target)
+            + _get_post_message(current, latest)
         )
 
     # verbose shows more platform and python info

--- a/globus_cli/helpers/version.py
+++ b/globus_cli/helpers/version.py
@@ -54,21 +54,17 @@ def _get_package_data():
 
 def _get_versionblock_message(current, latest, upgrade_target):
     if latest == upgrade_target:
-        return """\
-Installed version:  {}
-Latest version:     {}""".format(
-            current, latest
-        )
+        return f"""\
+Installed version:  {current}
+Latest version:     {latest}"""
     # latest != upgrade_target means it's a py2 environment where we're capped at <2.0
     else:
-        return """\
+        return f"""\
 You are running the Globus CLI on python2
 
-Installed version:           {}
-Latest version for python2:  {}
-Latest version for python3:  {}""".format(
-            current, upgrade_target, latest
-        )
+Installed version:           {current}
+Latest version for python2:  {upgrade_target}
+Latest version for python3:  {latest}"""
 
 
 def _get_post_message(current, latest, upgrade_target):
@@ -79,13 +75,11 @@ def _get_post_message(current, latest, upgrade_target):
     if upgrade_target == latest:
         return "You should update your version of the Globus CLI with\n  globus update"
     if current == upgrade_target:
-        return """\
+        return f"""\
 You are running the latest version of the Globus CLI supported by python2.
 
-To upgrade to the latest version of the CLI ({}), you will need to
-uninstall and reinstall the CLI using python3.""".format(
-            latest
-        )
+To upgrade to the latest version of the CLI ({latest}), you will need to
+uninstall and reinstall the CLI using python3."""
     if current < upgrade_target:
         return """\
 You should update your version of the Globus CLI.
@@ -107,9 +101,7 @@ def print_version():
     """
     upgrade_target, latest, current = get_versions()
     if latest is None:
-        click.echo(
-            ("Installed Version: {0}\nFailed to lookup latest version.").format(current)
-        )
+        click.echo(f"Installed Version: {current}\nFailed to lookup latest version.")
     else:
         click.echo(
             _get_versionblock_message(current, latest, upgrade_target)
@@ -125,15 +117,15 @@ def print_version():
         click.echo("\nVerbose Data\n---")
 
         click.echo("platform:")
-        click.echo("  platform: {}".format(platform.platform()))
-        click.echo("  py_implementation: {}".format(platform.python_implementation()))
-        click.echo("  py_version: {}".format(platform.python_version()))
-        click.echo("  sys.executable: {}".format(sys.executable))
-        click.echo("  site.USER_BASE: {}".format(site.USER_BASE))
+        click.echo(f"  platform: {platform.platform()}")
+        click.echo(f"  py_implementation: {platform.python_implementation()}")
+        click.echo(f"  py_version: {platform.python_version()}")
+        click.echo(f"  sys.executable: {sys.executable}")
+        click.echo(f"  site.USER_BASE: {site.USER_BASE}")
 
         click.echo("modules:")
         for mod, modversion, modfile, modpath in moddata:
-            click.echo("  {}:".format(mod))
-            click.echo("    __version__: {}".format(modversion))
-            click.echo("    __file__: {}".format(modfile))
-            click.echo("    __path__: {}".format(modpath))
+            click.echo(f"  {mod}:")
+            click.echo(f"    __version__: {modversion}")
+            click.echo(f"    __file__: {modfile}")
+            click.echo(f"    __path__: {modpath}")

--- a/globus_cli/helpers/version.py
+++ b/globus_cli/helpers/version.py
@@ -24,7 +24,6 @@ def _get_package_data():
         "globus_sdk",
         "jmespath",
         "requests",
-        "six",
     )
     if verbosity() < 2:
         modlist = ("globus_cli", "globus_sdk", "requests")

--- a/globus_cli/parsing/command_state.py
+++ b/globus_cli/parsing/command_state.py
@@ -12,7 +12,7 @@ TEXT_FORMAT = "text"
 UNIX_FORMAT = "unix"
 
 
-class CommandState(object):
+class CommandState:
     def __init__(self):
         # default is config value, or TEXT if it's not set
         self.output_format = config.get_output_format() or TEXT_FORMAT

--- a/globus_cli/parsing/custom_classes.py
+++ b/globus_cli/parsing/custom_classes.py
@@ -35,7 +35,7 @@ for more details."""
             kwargs["help"] = helptext.format(
                 AUTOMATIC_ACTIVATION=self.AUTOMATIC_ACTIVATION_HELPTEXT
             )
-        super(GlobusCommand, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class GlobusCommandGroup(click.Group):
@@ -60,7 +60,7 @@ class GlobusCommandGroup(click.Group):
         if self.no_args_is_help and not ctx.protected_args:
             click.echo(ctx.get_help())
             ctx.exit()
-        return super(GlobusCommandGroup, self).invoke(ctx)
+        return super().invoke(ctx)
 
 
 class TopLevelGroup(GlobusCommandGroup):
@@ -73,6 +73,6 @@ class TopLevelGroup(GlobusCommandGroup):
 
     def invoke(self, ctx):
         try:
-            return super(TopLevelGroup, self).invoke(ctx)
+            return super().invoke(ctx)
         except Exception:
             custom_except_hook(sys.exc_info())

--- a/globus_cli/parsing/endpoint_plus_path.py
+++ b/globus_cli/parsing/endpoint_plus_path.py
@@ -15,7 +15,7 @@ class EndpointPlusPath(click.ParamType):
         # path requirement defaults to True, but can be tweaked by a kwarg
         self.path_required = kwargs.pop("path_required", True)
 
-        super(EndpointPlusPath, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_metavar(self, param):
         """

--- a/globus_cli/parsing/excepthook.py
+++ b/globus_cli/parsing/excepthook.py
@@ -12,7 +12,6 @@ import sys
 import click
 import click.exceptions
 from globus_sdk import exc
-from six import reraise
 
 from globus_cli.parsing.command_state import CommandState
 from globus_cli.safeio import PrintableErrorField, write_error_info
@@ -45,7 +44,7 @@ def session_hook(exception):
     params = exception.raw_json["authorization_parameters"]
     message = params.get("session_message")
     if message:
-        click.echo("message: {}".format(message))
+        click.echo(f"message: {message}")
 
     identities = params.get("session_required_identities")
     if identities:
@@ -90,12 +89,12 @@ def consent_required_hook(exception):
         )
         sys.exit(255)
     if message:
-        click.echo("message: {}".format(message))
+        click.echo(f"message: {message}")
 
     click.echo(
         "\nPlease run\n\n"
         "  globus session consent {}\n\n".format(
-            " ".join("'{}'".format(x) for x in required_scopes)
+            " ".join(f"'{x}'" for x in required_scopes)
         )
         + "to login with the required scopes"
     )
@@ -247,14 +246,14 @@ def custom_except_hook(exc_info):
     elif isinstance(
         exception, (click.ClickException, click.exceptions.Abort, click.exceptions.Exit)
     ):
-        reraise(exception_type, exception, traceback)
+        raise exception.with_traceback(traceback)
 
     # not a GlobusError, not a ClickException -- something like ValueError
     # or NotImplementedError bubbled all the way up here: just print it
     # out, basically
     else:
         click.echo(
-            u"{}: {}".format(
+            "{}: {}".format(
                 click.style(exception_type.__name__, bold=True, fg="red"), exception
             )
         )

--- a/globus_cli/parsing/location.py
+++ b/globus_cli/parsing/location.py
@@ -18,8 +18,6 @@ class LocationType(click.ParamType):
             return value
         except (ValueError, AttributeError):
             self.fail(
-                (
-                    "location {} is not two comma separated floats "
-                    "for lattitude and longitude".format(value)
-                )
+                f"location {value} is not two comma separated floats "
+                "for lattitude and longitude"
             )

--- a/globus_cli/parsing/one_use_option.py
+++ b/globus_cli/parsing/one_use_option.py
@@ -11,7 +11,7 @@ class OneUseOption(click.Option):
     def type_cast_value(self, ctx, value):
 
         # get the result of a normal type_cast
-        converted_val = super(OneUseOption, self).type_cast_value(ctx, value)
+        converted_val = super().type_cast_value(ctx, value)
 
         # if the option takes arguments (multiple was set to true)
         # assert no more than one argument was gotten, and if an argument
@@ -33,10 +33,8 @@ class OneUseOption(click.Option):
 
         else:
             raise ValueError(
-                (
-                    "Internal error, OneUseOption expected either "
-                    "multiple or count, but got neither."
-                )
+                "Internal error, OneUseOption expected either "
+                "multiple or count, but got neither."
             )
 
 

--- a/globus_cli/parsing/process_stdin.py
+++ b/globus_cli/parsing/process_stdin.py
@@ -16,11 +16,12 @@ def shlex_process_stdin(process_command, helptext):
     # if input is interactive, print help to stderr
     if sys.stdin.isatty():
         click.echo(
-            (
-                "{}\n".format(helptext) + "Lines are split with shlex in POSIX mode: "
-                "https://docs.python.org/library/shlex.html#parsing-rules\n"
-                "Terminate input with Ctrl+D or <EOF>\n"
-            ),
+            f"""\
+{helptext}
+Lines are split with shlex in POSIX mode:
+  https://docs.python.org/library/shlex.html#parsing-rules
+Terminate input with Ctrl+D or <EOF>
+""",
             err=True,
         )
 

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -324,10 +324,8 @@ def validate_endpoint_create_and_update_params(endpoint_type, managed, params):
         ]:
             if params[option] is not None:
                 raise click.UsageError(
-                    (
-                        "Option --{} can only be used with Globus Connect Server "
-                        "endpoints".format(option.replace("_", "-"))
-                    )
+                    f"Option --{option.replace('_', '-')} can only be used with "
+                    "Globus Connect Server endpoints"
                 )
 
     # if the endpoint was not previously managed, and is not being passed
@@ -342,10 +340,8 @@ def validate_endpoint_create_and_update_params(endpoint_type, managed, params):
         ]:
             if params[option] is not None:
                 raise click.UsageError(
-                    (
-                        "Option --{} can only be used with managed "
-                        "endpoints".format(option.replace("_", "-"))
-                    )
+                    f"Option --{option.replace('_', '-')} can only be used with "
+                    "managed endpoints"
                 )
 
     # because the Transfer service doesn't do network use level updates in a
@@ -464,12 +460,12 @@ def task_submission_options(f):
         off = "off" in value
         on = "on" in value
         # set-ize it -- duplicates are fine
-        vals = set([x for x in value if x not in ("off", "on")])
+        vals = {x for x in value if x not in ("off", "on")}
 
         if (vals or on) and off:
             raise click.UsageError('--notify cannot accept "off" and another value')
 
-        allowed_vals = set(("on", "succeeded", "failed", "inactive"))
+        allowed_vals = {"on", "succeeded", "failed", "inactive"}
         if not vals <= allowed_vals:
             raise click.UsageError(
                 "--notify received at least one invalid value among {}".format(
@@ -600,7 +596,7 @@ def synchronous_task_wait_options(f):
 
         if value < 1:
             raise click.UsageError(
-                "--polling-interval={0} was less than minimum of {1}".format(value, 1)
+                f"--polling-interval={value} was less than minimum of 1"
             )
 
         return value
@@ -747,7 +743,7 @@ def server_add_and_update_opts(*args, **kwargs):
             ("outgoing", "from", "to"),
         ]:
             f = click.option(
-                "--{}-data-ports".format(adjective),
+                f"--{adjective}-data-ports",
                 callback=port_range_callback,
                 help="Indicate to firewall administrators at other sites how to "
                 "allow {} traffic {} this server {} their own. Specify as "
@@ -783,17 +779,13 @@ def security_principal_opts(*args, **kwargs):
             else:
                 if has_identity and group:
                     raise click.UsageError(
-                        (
-                            "You have passed both an identity and a group. "
-                            "Please only pass one principal type"
-                        )
+                        "You have passed both an identity and a group. "
+                        "Please only pass one principal type"
                     )
                 elif not has_identity and not group:
                     raise click.UsageError(
-                        (
-                            "You must provide at least one principal "
-                            "(identity, group, etc.)"
-                        )
+                        "You must provide at least one principal "
+                        "(identity, group, etc.)"
                     )
 
                 if identity:

--- a/globus_cli/parsing/task_path.py
+++ b/globus_cli/parsing/task_path.py
@@ -100,7 +100,7 @@ class TaskPath(click.ParamType):
             self.path.startswith("/") or self.path.startswith("~")
         ):
             self.fail(
-                "{} is not absolute (abspath required)".format(self.path),
+                f"{self.path} is not absolute (abspath required)",
                 param=param,
                 ctx=ctx,
             )

--- a/globus_cli/safeio/awscli_text.py
+++ b/globus_cli/safeio/awscli_text.py
@@ -1,27 +1,24 @@
 # pulled from the AWSCLI and modified by Globus
+# note that this file has also been modified by auotfixers (e.g. black, pyupgrade)
 
 # Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
-
+#
 #     http://aws.amazon.com/apache2.0/
-
+#
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
 # START Globus changes
+
 import errno
 import json
 import sys
-
-# AWSCLI defines a vendored version of 'six'
-# we're going to use the stock/standard one and it should have all of the
-# same/correct behaviors
-import six
 
 # END Globus changes
 
@@ -38,7 +35,7 @@ def _format_text(item, stream, identifier=None, scalar_keys=None):
     else:
         # If it's not a list or a dict, we just write the scalar
         # value out directly.
-        stream.write(six.text_type(item))
+        stream.write(str(item))
         stream.write("\n")
 
 
@@ -75,10 +72,10 @@ def _partition_list(item):
 def _format_scalar_list(elements, identifier, stream):
     if identifier is not None:
         for item in elements:
-            stream.write("%s\t%s\n" % (identifier.upper(), item))
+            stream.write(f"{identifier.upper()}\t{item}\n")
     else:
         # For a bare list, just print the contents.
-        stream.write("\t".join([six.text_type(item) for item in elements]))
+        stream.write("\t".join([str(item) for item in elements]))
         stream.write("\n")
 
 
@@ -118,10 +115,10 @@ def _partition_dict(item_dict, scalar_keys):
             if isinstance(value, (dict, list)):
                 non_scalar.append((key, value))
             else:
-                scalar.append(six.text_type(value))
+                scalar.append(str(value))
     else:
         for key in scalar_keys:
-            scalar.append(six.text_type(item_dict.get(key, "")))
+            scalar.append(str(item_dict.get(key, "")))
         remaining_keys = sorted(set(item_dict.keys()) - set(scalar_keys))
         for remaining_key in remaining_keys:
             non_scalar.append((remaining_key, item_dict[remaining_key]))
@@ -133,7 +130,7 @@ def unix_formatted_print(data):
     format_text(data, sys.stdout)
     try:
         sys.stdout.flush()
-    except IOError as err:
+    except OSError as err:
         if err.errno is errno.EPIPE:
             pass
         else:

--- a/globus_cli/safeio/errors.py
+++ b/globus_cli/safeio/errors.py
@@ -6,7 +6,7 @@ from globus_sdk.base import safe_stringify
 from globus_cli.safeio.get_option_vals import outformat_is_json
 
 
-class PrintableErrorField(object):
+class PrintableErrorField:
     """
     A glorified tuple with a kwarg in its constructor.
     Coerces name and value fields to unicode for output consistency
@@ -31,10 +31,10 @@ class PrintableErrorField(object):
         """
         name = self.name + ":"
         if not self.multiline or "\n" not in val:
-            val = u"{0} {1}".format(name.ljust(self._text_prefix_len), val)
+            val = "{} {}".format(name.ljust(self._text_prefix_len), val)
         else:
             spacer = "\n" + " " * (self._text_prefix_len + 1)
-            val = u"{0}{1}{2}".format(name, spacer, spacer.join(val.split("\n")))
+            val = "{}{}{}".format(name, spacer, spacer.join(val.split("\n")))
 
         return val
 
@@ -56,11 +56,11 @@ def write_error_info(error_name, fields, message=None):
             fg="yellow",
         )
     if not message:
-        message = u"A{0} {1} Occurred.\n{2}".format(
+        message = "A{} {} Occurred.\n{}".format(
             "n" if error_name[0] in "aeiouAEIOU" else "",
             click.style(error_name, bold=True, fg="red"),
             click.style("\n".join(f.value for f in fields), fg="yellow"),
         )
-        message = u"{0} {1}".format(PrintableErrorField.TEXT_PREFIX, message)
+        message = f"{PrintableErrorField.TEXT_PREFIX} {message}"
 
     click.echo(message, err=True)

--- a/globus_cli/safeio/output_formatter.py
+++ b/globus_cli/safeio/output_formatter.py
@@ -1,9 +1,6 @@
-from __future__ import unicode_literals
-
 import json
 
 import click
-import six
 from globus_sdk import GlobusResponse
 
 from globus_cli.safeio.awscli_text import unix_formatted_print
@@ -46,7 +43,7 @@ def _key_to_keyfunc(k):
     """
     # if the key is a string, then the "keyfunc" is just a basic lookup
     # operation -- return that
-    if isinstance(k, six.string_types):
+    if isinstance(k, str):
 
         def lookup(x):
             return x[k]
@@ -63,7 +60,7 @@ def _jmespath_preprocess(res):
     if isinstance(res, GlobusResponse):
         res = res.data
 
-    if not isinstance(res, six.string_types):
+    if not isinstance(res, str):
         if jmespath_expr is not None:
             res = jmespath_expr.search(res)
 
@@ -240,7 +237,7 @@ def formatted_print(
         if text_epilog is not None:
             click.echo(text_epilog)
 
-    if isinstance(text_format, six.string_types):
+    if isinstance(text_format, str):
         text_format = text_format
         _custom_text_formatter = None
     else:

--- a/globus_cli/services/recursive_ls.py
+++ b/globus_cli/services/recursive_ls.py
@@ -86,20 +86,15 @@ class RecursiveLsResponse(PaginatedResource):
         # BFS is not done until the queue is empty
         while self.queue:
             logger.debug(
-                (
-                    "recursive_operation_ls BFS queue not empty, "
-                    "getting next path now."
-                )
+                "recursive_operation_ls BFS queue not empty, getting next path now."
             )
 
             # rate limit based on number of ls calls we have made
             self.ls_count += 1
             if self.ls_count % SLEEP_FREQUENCY == 0:
                 logger.debug(
-                    (
-                        "recursive_operation_ls sleeping {} seconds to "
-                        "rate limit itself.".format(SLEEP_LEN)
-                    )
+                    f"recursive_operation_ls sleeping {SLEEP_LEN} seconds to "
+                    "rate limit itself."
                 )
                 time.sleep(SLEEP_LEN)
 

--- a/globus_cli/services/transfer.py
+++ b/globus_cli/services/transfer.py
@@ -28,7 +28,7 @@ class RetryingTransferClient(TransferClient):
     default_retries = 10
 
     def __init__(self, tries=None, *args, **kwargs):
-        super(RetryingTransferClient, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.tries = tries or self.default_retries
 
     def retry(self, f, *args, **kwargs):
@@ -46,21 +46,17 @@ class RetryingTransferClient(TransferClient):
 
     # get and put should always be safe to retry
     def get(self, *args, **kwargs):
-        return self.retry(super(RetryingTransferClient, self).get, *args, **kwargs)
+        return self.retry(super().get, *args, **kwargs)
 
     def put(self, *args, **kwargs):
-        return self.retry(super(RetryingTransferClient, self).put, *args, **kwargs)
+        return self.retry(super().put, *args, **kwargs)
 
     # task submission is safe, as the data contains a unique submission-id
     def submit_transfer(self, *args, **kwargs):
-        return self.retry(
-            super(RetryingTransferClient, self).submit_transfer, *args, **kwargs
-        )
+        return self.retry(super().submit_transfer, *args, **kwargs)
 
     def submit_delete(self, *args, **kwargs):
-        return self.retry(
-            super(RetryingTransferClient, self).submit_delete, *args, **kwargs
-        )
+        return self.retry(super().submit_delete, *args, **kwargs)
 
     # TDOD: Remove this function when endpoints natively support recursive ls
     def recursive_operation_ls(
@@ -277,7 +273,7 @@ def get_endpoint_w_server_list(endpoint_id):
     if endpoint["host_endpoint_id"]:  # not GCS -- this is a share endpoint
         raise click.UsageError(
             dedent(
-                u"""\
+                """\
             {id} ({0}) is a share and does not have servers.
 
             To see details of the share, use
@@ -373,9 +369,7 @@ def task_wait_with_io(
 
     exit_code = 1
     if timed_out(waited_time):
-        click.echo(
-            "Task has yet to complete after {} seconds".format(timeout), err=True
-        )
+        click.echo(f"Task has yet to complete after {timeout} seconds", err=True)
         exit_code = timeout_exit_code
 
     # output json if requested, but nothing for text mode

--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -5,7 +5,7 @@ from distutils.version import LooseVersion
 __version__ = "1.16.0"
 
 # app name to send as part of SDK requests
-app_name = "Globus CLI v{}".format(__version__)
+app_name = f"Globus CLI v{__version__}"
 
 
 # pull down version data from PyPi

--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -26,10 +26,9 @@ def get_versions():
     regardless of runtime.
     """
     # import in the func (rather than top-level scope) so that at setup time,
-    # `requests` and `six` aren't required -- otherwise, setuptools will fail to run
-    # because they aren't installed yet.
+    # `requests` isn't required -- otherwise, setuptools will fail to run
+    # because it isn't installed yet.
     import requests
-    import six
 
     try:
         version_data = requests.get(
@@ -37,11 +36,6 @@ def get_versions():
         ).json()
         parsed_versions = [LooseVersion(v) for v in version_data["releases"]]
         upgrade_target = latest = max(parsed_versions)
-        # python2 only; limit the upgrade to only the latest v1
-        if six.PY2:
-            upgrade_target = max(
-                v for v in parsed_versions if v < LooseVersion("2.0.0")
-            )
         return upgrade_target, latest, LooseVersion(__version__)
     # if the fetch from pypi fails
     except requests.RequestException:

--- a/globus_cli/version.py
+++ b/globus_cli/version.py
@@ -12,18 +12,9 @@ app_name = f"Globus CLI v{__version__}"
 def get_versions():
     """
     Wrap in a function to ensure that we don't run this every time a CLI
-    command runs (yuck!)
+    command runs or when version number is loaded by setuptools.
 
-    Also protects import of `requests` from issues when grabbed by setuptools.
-    More on that inline
-
-    Returns a 3-tuple:
-      (upgrade_target, latest_version, current_version)
-
-    For CLI v1.x, upgrade_target is the latest v1 version IF you are on a python2
-    interpreter.
-    latest_version is the unbounded most recent version (could be 2.x, 3.x, etc)
-    regardless of runtime.
+    Returns a pair: (latest_version, current_version)
     """
     # import in the func (rather than top-level scope) so that at setup time,
     # `requests` isn't required -- otherwise, setuptools will fail to run
@@ -35,8 +26,8 @@ def get_versions():
             "https://pypi.python.org/pypi/globus-cli/json"
         ).json()
         parsed_versions = [LooseVersion(v) for v in version_data["releases"]]
-        upgrade_target = latest = max(parsed_versions)
-        return upgrade_target, latest, LooseVersion(__version__)
+        latest = max(parsed_versions)
+        return latest, LooseVersion(__version__)
     # if the fetch from pypi fails
     except requests.RequestException:
-        return None, None, LooseVersion(__version__)
+        return None, LooseVersion(__version__)

--- a/reference/_generate.py
+++ b/reference/_generate.py
@@ -69,11 +69,9 @@ def walk_contexts(name="globus", cmd=CLI, parent_ctx=None):
 
 def iter_all_commands(tree=None):
     ctx, subcmds, subgroups = tree or walk_contexts()
-    for cmd in subcmds:
-        yield cmd
+    yield from subcmds
     for g in subgroups:
-        for cmd in iter_all_commands(g):
-            yield cmd
+        yield from iter_all_commands(g)
 
 
 def _format_option(optstr):
@@ -156,8 +154,7 @@ def commands_with_headings(heading, tree=None):
         yield heading, subcmds
     for subgrouptree in subgroups:
         heading = f"== {subgrouptree[0].command_path} commands"
-        for subheading, subcommands in commands_with_headings(heading, subgrouptree):
-            yield subheading, subcommands
+        yield from commands_with_headings(heading, subgrouptree)
 
 
 def generate_index():

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,6 @@
 import os
-import sys
 
 from setuptools import find_packages, setup
-
-if sys.version_info < (2, 7):
-    raise NotImplementedError(
-        """\n
-##############################################################
-# globus-cli does not support python versions older than 2.7 #
-##############################################################"""
-    )
-
 
 # single source of truth for package version
 version_ns = {}
@@ -50,12 +40,11 @@ setup(
             "responses==0.12.1",
             # loading fixture data
             "ruamel.yaml==0.16.12",
-            # mock on py2
-            'mock==2.0.0;python_version<"3.6"',
-            'black==20.8b1;python_version>="3.6"',
-            'isort>=5.6.4,<6.0;python_version>="3.6"',
+            # linting tools
+            "black==20.8b1",
+            "isort>=5.6.4,<6.0",
             "flake8>=3.8.4,<4.0",
-            'flake8-bugbear==20.11.1;python_version>="3.6"',
+            "flake8-bugbear==20.11.1",
         ],
     },
     entry_points={"console_scripts": ["globus = globus_cli:main"]},
@@ -72,7 +61,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         "jmespath==0.10.0",
         "configobj>=5.0.6,<6.0.0",
         "requests>=2.0.0,<3.0.0",
-        "six>=1.10.0,<2.0.0",
         # cryptography has unusual versioning and compatibility rules:
         # https://cryptography.io/en/latest/api-stability/
         # we trust the two next major versions, per the Deprecation policy
@@ -28,9 +27,6 @@ setup(
         "cryptography>=1.8.1,<3.4.0",
     ],
     extras_require={
-        # deprecated, but do not remove -- doing so would break installs which
-        # are already using this extra
-        "delegate-proxy": [],
         # the development extra is for CLI developers only
         "development": [
             # testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,10 @@ import logging
 import os
 import shlex
 import time
+import urllib.parse
 
 import pytest
 import responses
-import six
 from click.testing import CliRunner
 from configobj import ConfigObj
 from globus_sdk.base import slash_join
@@ -103,11 +103,7 @@ def run_line(cli_runner, request, patch_config):
         patch_config(config)
 
         # split line into args and confirm line starts with "globus"
-        # python2 shlex can't handle non ascii unicode
-        if six.PY2 and isinstance(line, str):
-            args = [a for a in shlex.split(line.encode("utf-8"))]
-        else:
-            args = shlex.split(line)
+        args = shlex.split(line)
         assert args[0] == "globus"
 
         # run the line. globus_cli.main is the "globus" part of the line
@@ -236,9 +232,7 @@ def load_api_fixtures(register_api_route, test_file_dir, go_ep1_id, go_ep2_id, t
                     # copy and set match_querystring=True
                     params = dict(match_querystring=True, **params)
                     # remove and encode query params
-                    query_params = six.moves.urllib.parse.urlencode(
-                        params.pop("query_params")
-                    )
+                    query_params = urllib.parse.urlencode(params.pop("query_params"))
                     # modify path (assume no prior params)
                     use_path = use_path + "?" + query_params
                 register_api_route(service, use_path, method=method.upper(), **params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,7 @@ def run_line(cli_runner, request, patch_config):
 
         # split line into args and confirm line starts with "globus"
         # python2 shlex can't handle non ascii unicode
-        if six.PY2 and isinstance(line, six.text_type):
+        if six.PY2 and isinstance(line, str):
             args = [a for a in shlex.split(line.encode("utf-8"))]
         else:
             args = shlex.split(line)
@@ -119,22 +119,20 @@ def run_line(cli_runner, request, patch_config):
             raise (
                 Exception(
                     (
+                        "CliTest run_line exit_code assertion failed!\n"
+                        "Line:\n{}\nexited with {} when expecting {}\n"
+                        "stdout:\n{}\nstderr:\n{}\nnetwork calls recorded:"
+                        "\n  {}"
+                    ).format(
+                        line,
+                        result.exit_code,
+                        assert_exit_code,
+                        result.stdout,
+                        result.stderr,
                         (
-                            "CliTest run_line exit_code assertion failed!\n"
-                            "Line:\n{}\nexited with {} when expecting {}\n"
-                            "stdout:\n{}\nstderr:\n{}\nnetwork calls recorded:"
-                            "\n  {}"
-                        ).format(
-                            line,
-                            result.exit_code,
-                            assert_exit_code,
-                            result.stdout,
-                            result.stderr,
-                            (
-                                "\n  ".join(r.request.url for r in responses.calls)
-                                or "  <none>"
-                            ),
-                        )
+                            "\n  ".join(r.request.url for r in responses.calls)
+                            or "  <none>"
+                        ),
                     )
                 )
             )

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -111,7 +111,7 @@ def test_transfer_call(run_line, load_api_fixtures, register_api_route, go_ep1_i
     load_api_fixtures("transfer_activate_success.yaml")
     register_api_route(
         "transfer",
-        "/operation/endpoint/{}/ls".format(go_ep1_id),
+        f"/operation/endpoint/{go_ep1_id}/ls",
         json={
             # not *quite* verbatim data from the API, but very similar and in the right
             # format with all fields populated
@@ -147,14 +147,14 @@ def test_transfer_batchmode_dryrun(run_line, load_api_fixtures, go_ep1_id, go_ep
     load_api_fixtures("get_submission_id.yaml")
     load_api_fixtures("transfer_activate_success.yaml")
 
-    batch_input = u"abc /def\n/xyz p/q/r\n"
+    batch_input = "abc /def\n/xyz p/q/r\n"
     result = run_line(
         "globus transfer -F json --batch --dry-run " + go_ep1_id + " " + go_ep2_id,
         stdin=batch_input,
     )
     for src, dst in [("abc", "/def"), ("/xyz", "p/q/r")]:
-        assert '"source_path": "{}"'.format(src) in result.output
-        assert '"destination_path": "{}"'.format(dst) in result.output
+        assert f'"source_path": "{src}"' in result.output
+        assert f'"destination_path": "{dst}"' in result.output
 
 
 def test_delete_batchmode_dryrun(run_line, load_api_fixtures, go_ep1_id):
@@ -165,7 +165,7 @@ def test_delete_batchmode_dryrun(run_line, load_api_fixtures, go_ep1_id):
     load_api_fixtures("get_submission_id.yaml")
     load_api_fixtures("transfer_activate_success.yaml")
 
-    batch_input = u"abc/def\n/xyz\nabcdef\nabc/def/../xyz\n"
+    batch_input = "abc/def\n/xyz\nabcdef\nabc/def/../xyz\n"
     result = run_line("globus delete --batch --dry-run " + go_ep1_id, stdin=batch_input)
     assert (
         "\n".join(
@@ -174,9 +174,9 @@ def test_delete_batchmode_dryrun(run_line, load_api_fixtures, go_ep1_id):
         == result.output
     )
 
-    batch_input = u"abc/def\n/xyz\n../foo\n"
+    batch_input = "abc/def\n/xyz\n../foo\n"
     result = run_line(
-        "globus delete --batch --dry-run {}:foo/bar/./baz".format(go_ep1_id),
+        f"globus delete --batch --dry-run {go_ep1_id}:foo/bar/./baz",
         stdin=batch_input,
     )
     assert (

--- a/tests/functional/test_bookmark_commands.py
+++ b/tests/functional/test_bookmark_commands.py
@@ -7,14 +7,12 @@ def test_bookmark_create(run_line, load_api_fixtures, go_ep1_id):
     """
     data = load_api_fixtures("bookmark_operations.yaml")
     bookmark_id = data["metadata"]["bookmark_id"]
-    result = run_line("globus bookmark create {}:/share/ sharebm".format(go_ep1_id))
-    assert "Bookmark ID: {}".format(bookmark_id) in result.output
+    result = run_line(f"globus bookmark create {go_ep1_id}:/share/ sharebm")
+    assert f"Bookmark ID: {bookmark_id}" in result.output
 
     # repeat, but with JSON output
     json_output = json.loads(
-        run_line(
-            "globus bookmark create -Fjson {}:/share/ sharebm".format(go_ep1_id)
-        ).output
+        run_line(f"globus bookmark create -Fjson {go_ep1_id}:/share/ sharebm").output
     )
     assert json_output["id"] == bookmark_id
     assert json_output["name"] == "sharebm"
@@ -32,16 +30,16 @@ def test_bookmark_show(run_line, load_api_fixtures, go_ep1_id):
     bookmark_name = data["metadata"]["bookmark_name"]
 
     # id
-    result = run_line('globus bookmark show "{}"'.format(bookmark_id))
-    assert "{}:/share/\n".format(go_ep1_id) == result.output
+    result = run_line(f'globus bookmark show "{bookmark_id}"')
+    assert f"{go_ep1_id}:/share/\n" == result.output
 
     # name
-    result = run_line('globus bookmark show "{}"'.format(bookmark_name))
-    assert "{}:/share/\n".format(go_ep1_id) == result.output
+    result = run_line(f'globus bookmark show "{bookmark_name}"')
+    assert f"{go_ep1_id}:/share/\n" == result.output
 
     # verbose
-    result = run_line("globus bookmark show -v {}".format(bookmark_id))
-    assert "Endpoint ID: {}".format(go_ep1_id) in result.output
+    result = run_line(f"globus bookmark show -v {bookmark_id}")
+    assert f"Endpoint ID: {go_ep1_id}" in result.output
 
 
 def test_bookmark_rename_by_id(run_line, load_api_fixtures):
@@ -53,7 +51,7 @@ def test_bookmark_rename_by_id(run_line, load_api_fixtures):
     updated_bookmark_name = data["metadata"]["bookmark_name_after_update"]
 
     result = run_line(
-        'globus bookmark rename "{}" "{}"'.format(bookmark_id, updated_bookmark_name)
+        f'globus bookmark rename "{bookmark_id}" "{updated_bookmark_name}"'
     )
     assert "Success" in result.output
 
@@ -67,7 +65,7 @@ def test_bookmark_rename_by_name(run_line, load_api_fixtures):
     updated_bookmark_name = data["metadata"]["bookmark_name_after_update"]
 
     result = run_line(
-        'globus bookmark rename "{}" "{}"'.format(bookmark_name, updated_bookmark_name)
+        f'globus bookmark rename "{bookmark_name}" "{updated_bookmark_name}"'
     )
     assert "Success" in result.output
 
@@ -78,7 +76,7 @@ def test_bookmark_delete_by_id(run_line, load_api_fixtures):
     """
     data = load_api_fixtures("bookmark_operations.yaml")
     bookmark_id = data["metadata"]["bookmark_id"]
-    result = run_line('globus bookmark delete "{}"'.format(bookmark_id))
+    result = run_line(f'globus bookmark delete "{bookmark_id}"')
     assert "deleted successfully" in result.output
 
 
@@ -88,5 +86,5 @@ def test_bookmark_delete_by_name(run_line, load_api_fixtures):
     """
     data = load_api_fixtures("bookmark_operations.yaml")
     bookmark_name = data["metadata"]["bookmark_name"]
-    result = run_line('globus bookmark delete "{}"'.format(bookmark_name))
+    result = run_line(f'globus bookmark delete "{bookmark_name}"')
     assert "deleted successfully" in result.output

--- a/tests/functional/test_endpoint_create.py
+++ b/tests/functional/test_endpoint_create.py
@@ -67,7 +67,7 @@ def test_text_ouptut(run_line, load_api_fixtures, ep_type):
         ep_id = data["metadata"]["endpoint_id"]
         setup_key = None
 
-    result = run_line("globus endpoint create gcp_text {}".format(opt))
+    result = run_line(f"globus endpoint create gcp_text {opt}")
     got_ep_id = re.search(r"Endpoint ID:\s*(\S*)", result.output).group(1)
     assert got_ep_id == ep_id
 
@@ -204,7 +204,7 @@ def test_invalid_managed_only_options(run_line):
     ]
     for opt in options:
         result = run_line(
-            "globus endpoint create invalid_managed --server {}".format(opt),
+            f"globus endpoint create invalid_managed --server {opt}",
             assert_exit_code=2,
         )
         assert "managed endpoints" in result.stderr

--- a/tests/functional/test_endpoint_servers.py
+++ b/tests/functional/test_endpoint_servers.py
@@ -4,23 +4,21 @@ import pytest
 def test_gcs_server_add(run_line, load_api_fixtures):
     data = load_api_fixtures("endpoint_servers.yaml")
     epid = data["metadata"]["endpoint_id"]
-    result = run_line(
-        "globus endpoint server add {} --hostname example.org".format(epid)
-    )
+    result = run_line(f"globus endpoint server add {epid} --hostname example.org")
     assert "Server added to endpoint successfully" in result.output
 
 
 def test_gcs_server_list(run_line, load_api_fixtures):
     data = load_api_fixtures("endpoint_servers.yaml")
     epid = data["metadata"]["endpoint_id"]
-    result = run_line("globus endpoint server list {}".format(epid))
+    result = run_line(f"globus endpoint server list {epid}")
     assert "gsiftp://example.org:2811" in result.output
 
 
 def test_gcp_server_list(run_line, load_api_fixtures):
     data = load_api_fixtures("endpoint_servers.yaml")
     epid = data["metadata"]["gcp_endpoint_id"]
-    result = run_line("globus endpoint server list {}".format(epid))
+    result = run_line(f"globus endpoint server list {epid}")
     assert "none (Globus Connect Personal)" in result.output
 
 
@@ -40,7 +38,7 @@ def test_server_delete_various(run_line, load_api_fixtures, mode):
     else:
         raise NotImplementedError
 
-    result = run_line("globus endpoint server delete {} {}".format(epid, server))
+    result = run_line(f"globus endpoint server delete {epid} {server}")
     assert "Server deleted successfully" in result.output
 
 
@@ -52,7 +50,7 @@ def test_server_delete_by_hostname_many_matches(run_line, load_api_fixtures):
     dotcom_servers = server_ids["example.com"]
 
     result = run_line(
-        "globus endpoint server delete {} example.org".format(epid), assert_exit_code=2
+        f"globus endpoint server delete {epid} example.org", assert_exit_code=2
     )
     assert "Multiple servers matched" in result.stderr
     assert "example.com" not in result.stderr
@@ -66,7 +64,7 @@ def test_server_delete_on_gcp(run_line, load_api_fixtures):
     data = load_api_fixtures("endpoint_servers.yaml")
     epid = data["metadata"]["gcp_endpoint_id"]
     result = run_line(
-        "globus endpoint server delete {} example.com".format(epid), assert_exit_code=2
+        f"globus endpoint server delete {epid} example.com", assert_exit_code=2
     )
     assert (
         "You cannot delete servers from Globus Connect Personal endpoints"

--- a/tests/functional/test_endpoint_update.py
+++ b/tests/functional/test_endpoint_update.py
@@ -109,7 +109,7 @@ def test_invalid_gcs_only_options(run_line, load_api_fixtures, ep_type):
     ]
     for opt in options:
         result = run_line(
-            ("globus endpoint update {} {} ".format(epid, opt)),
+            (f"globus endpoint update {epid} {opt} "),
             assert_exit_code=2,
         )
         assert "Globus Connect Server" in result.stderr
@@ -132,7 +132,7 @@ def test_invalid_managed_only_options(run_line, load_api_fixtures):
     ]
     for opt in options:
         result = run_line(
-            ("globus endpoint update {} {} ".format(epid, opt)),
+            (f"globus endpoint update {epid} {opt} "),
             assert_exit_code=2,
         )
         assert "managed endpoints" in result.stderr

--- a/tests/functional/test_get_identities.py
+++ b/tests/functional/test_get_identities.py
@@ -8,7 +8,7 @@ def test_default_one_id(run_line, load_api_fixtures):
     data = load_api_fixtures("foo_user_info.yaml")
     user_id = data["metadata"]["user_id"]
     username = data["metadata"]["username"]
-    result = run_line("globus get-identities {}".format(user_id))
+    result = run_line(f"globus get-identities {user_id}")
     assert username + "\n" == result.output
 
 

--- a/tests/functional/test_jmespath_output.py
+++ b/tests/functional/test_jmespath_output.py
@@ -8,10 +8,8 @@ def test_jmespath_noop(run_line, load_api_fixtures):
     """
     data = load_api_fixtures("endpoint_operations.yaml")
     epid = data["metadata"]["endpoint_id"]
-    result = run_line("globus endpoint show {} -Fjson".format(epid))
-    jmespathresult = run_line(
-        "globus endpoint show {} -Ftext --jmespath '@'".format(epid)
-    )
+    result = run_line(f"globus endpoint show {epid} -Fjson")
+    jmespathresult = run_line(f"globus endpoint show {epid} -Ftext --jmespath '@'")
 
     assert result.output == jmespathresult.output
 
@@ -34,7 +32,7 @@ def test_jmespath_extract_from_list(run_line, load_api_fixtures, go_ep2_id):
     )
     outputdict = json.loads(result.output)
 
-    show_result = run_line("globus endpoint show {} -Fjson".format(go_ep2_id))
+    show_result = run_line(f"globus endpoint show {go_ep2_id} -Fjson")
     showdict = json.loads(show_result.output)
 
     # check specific keys because search includes `_rank` and doesn't

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -1,7 +1,4 @@
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 import globus_sdk
 

--- a/tests/functional/test_ls.py
+++ b/tests/functional/test_ls.py
@@ -4,7 +4,7 @@ def test_path(run_line, load_api_fixtures, go_ep1_id):
     """
     load_api_fixtures("transfer_activate_success.yaml")
     load_api_fixtures("ls_results.yaml")
-    result = run_line("globus ls {}:/".format(go_ep1_id))
+    result = run_line(f"globus ls {go_ep1_id}:/")
 
     expected = ["home/", "mnt/", "not shareable/", "share/"]
     for item in expected:
@@ -17,7 +17,7 @@ def test_recursive(run_line, load_api_fixtures, go_ep1_id):
     """
     load_api_fixtures("transfer_activate_success.yaml")
     load_api_fixtures("ls_results.yaml")
-    result = run_line("globus ls -r {}:/share".format(go_ep1_id))
+    result = run_line(f"globus ls -r {go_ep1_id}:/share")
     assert "file1.txt" in result.output
 
 
@@ -28,7 +28,7 @@ def test_depth(run_line, load_api_fixtures, go_ep1_id):
     """
     load_api_fixtures("transfer_activate_success.yaml")
     load_api_fixtures("ls_results.yaml")
-    result = run_line(("globus ls -r --recursive-depth-limit 1 {}:/".format(go_ep1_id)))
+    result = run_line(f"globus ls -r --recursive-depth-limit 1 {go_ep1_id}:/")
     assert "file1.txt" not in result.output
 
 
@@ -38,6 +38,6 @@ def test_recursive_json(run_line, load_api_fixtures, go_ep1_id):
     """
     load_api_fixtures("transfer_activate_success.yaml")
     load_api_fixtures("ls_results.yaml")
-    result = run_line("globus ls -r -F json {}:/share".format(go_ep1_id))
+    result = run_line(f"globus ls -r -F json {go_ep1_id}:/share")
     assert '"DATA":' in result.output
     assert '"name": "godata/file1.txt"' in result.output

--- a/tests/functional/test_rm.py
+++ b/tests/functional/test_rm.py
@@ -49,7 +49,7 @@ def test_recursive(run_line, load_api_fixtures, go_ep1_id):
     load_api_fixtures("get_submission_id.yaml")
     load_api_fixtures("submit_delete_success.yaml")
 
-    result = run_line("globus rm -r -F json {}:/foo".format(go_ep1_id))
+    result = run_line(f"globus rm -r -F json {go_ep1_id}:/foo")
     res = _load_probably_json_substring(result.output)
     assert res["status"] == "SUCCEEDED"
 
@@ -62,7 +62,7 @@ def test_no_file(run_line, load_api_fixtures, go_ep1_id):
     load_api_fixtures("get_submission_id.yaml")
     load_api_fixtures("submit_delete_failed.yaml")
 
-    run_line("globus rm {}:/nosuchfile.txt".format(go_ep1_id), assert_exit_code=1)
+    run_line(f"globus rm {go_ep1_id}:/nosuchfile.txt", assert_exit_code=1)
 
     # confirm that we sent `ignore_missing=False`
     # makes sense in context with the ignore-missing test below
@@ -80,7 +80,7 @@ def test_ignore_missing(run_line, load_api_fixtures, go_ep1_id):
     load_api_fixtures("submit_delete_success.yaml")
 
     path = "/~/nofilehere.txt"
-    result = run_line("globus rm -f {}:{}".format(go_ep1_id, path))
+    result = run_line(f"globus rm -f {go_ep1_id}:{path}")
     assert "Delete task submitted under ID " in result.stderr
 
     # confirm that we sent `ignore_missing=True`
@@ -97,7 +97,7 @@ def test_timeout(run_line, load_api_fixtures, patch_sleep, go_ep1_id):
     load_api_fixtures("submit_delete_queued.yaml")
 
     result = run_line(
-        "globus rm -r --timeout 2 {}:/foo/bar.txt".format(go_ep1_id),
+        f"globus rm -r --timeout 2 {go_ep1_id}:/foo/bar.txt",
         assert_exit_code=1,
     )
     assert "Task has yet to complete after 2 seconds" in result.stderr

--- a/tests/functional/test_task_show.py
+++ b/tests/functional/test_task_show.py
@@ -5,7 +5,7 @@ def test_skipped_errors(run_line, load_api_fixtures, task_id):
     """
     load_api_fixtures("skipped_error_list.yaml")
 
-    result = run_line("globus task show --skipped-errors {}".format(task_id))
+    result = run_line(f"globus task show --skipped-errors {task_id}")
     assert "/~/no-such-file" in result.output
     assert "FILE_NOT_FOUND" in result.output
     assert "/~/restricted-file" in result.output

--- a/tests/unit/test_bookmark_helpers.py
+++ b/tests/unit/test_bookmark_helpers.py
@@ -1,14 +1,10 @@
 import uuid
+from unittest import mock
 
 import pytest
 from globus_sdk.exc import TransferAPIError
 
 from globus_cli.commands.bookmark.helpers import resolve_id_or_name
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 def test_resolve_bookmarkid_not_found_does_name_match():

--- a/tests/unit/test_bookmark_helpers.py
+++ b/tests/unit/test_bookmark_helpers.py
@@ -59,4 +59,4 @@ def test_resolve_bookmark_no_match_in_list():
         resolve_id_or_name(client, bookmark_name)
 
         fakectx.exit.assert_called_once_with(1)
-        m.echo.assert_called_once_with(u'No bookmark found for "foo"', err=True)
+        m.echo.assert_called_once_with('No bookmark found for "foo"', err=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,38,37,36,27}
+envlist = py{39,38,37,36}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
This mirrors the work done in https://github.com/globus/globus-sdk-python/pull/396 , and I've even applied the changes in the same order.

The biggest difference between them is that this includes a final commit which rolls back the special treatment of version numbers on python2 interpreters.

As with the SDK work, this is for `main` and we have the `1.x-line` branch if needed.