### PR TITLE
Set python_requires in package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     name="globus-cli",
     version=version,
     packages=find_packages(exclude=["tests", "tests.*"]),
+    python_requires=">=3.6",
     install_requires=[
         "globus-sdk==2.0.1",
         "click>=7.1.1,<8.0",


### PR DESCRIPTION
We get this transitively from the SDK package, but we should still set it explicitly for the CLI.

In case you're concerned: a py3.5 venv running `pip install globus-cli` will get the 1.x version correctly.
This is just a bit of thoroughness -- also, I think we should be using this if/when we drop py3.6, etc. So having it in the package data is handy.