### PR TITLE
Add mypy to our lints, fix minor linting issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,7 @@ repos:
   hooks:
     - id: pyupgrade
       args: ["--py36-plus"]
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.800
+  hooks:
+    - id: mypy

--- a/globus_cli/commands/update.py
+++ b/globus_cli/commands/update.py
@@ -10,8 +10,8 @@ from globus_cli.version import get_versions
 
 # check if the source for this is inside of the USER_BASE
 # if so, a `pip install --user` was used
-# https://docs.python.org/2/library/site.html#site.USER_BASE
-IS_USER_INSTALL = __file__.startswith(site.USER_BASE)
+# https://docs.python.org/3/library/site.html#site.getuserbase
+IS_USER_INSTALL = __file__.startswith(site.getuserbase())
 
 
 def _call_pip(*args):

--- a/reference/_generate.py
+++ b/reference/_generate.py
@@ -18,11 +18,13 @@ try:
     last_release = requests.get(
         "https://api.github.com/repos/globus/globus-cli/releases/latest"
     )
-    REV_DATE = time.strptime(last_release.json()["published_at"], "%Y-%m-%dT%H:%M:%SZ")
+    REV_DATE_T = time.strptime(
+        last_release.json()["published_at"], "%Y-%m-%dT%H:%M:%SZ"
+    )
 except Exception:
     # fallback to current time
-    REV_DATE = time.gmtime()
-REV_DATE = time.strftime("%B %d, %Y", REV_DATE)
+    REV_DATE_T = time.gmtime()
+REV_DATE = time.strftime("%B %d, %Y", REV_DATE_T)
 
 EXIT_STATUS_TEXT = """0 on success.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,13 @@ profile = black
 exclude = .git,.tox,__pycache__,.eggs,dist,venv,.venv*,venv27,virtualenv,adoc,build
 max-line-length = 88
 ignore = W503,W504,E203
+
+
+[mypy]
+ignore_missing_imports = true
+warn_unreachable = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_no_return = true
+no_implicit_optional = true

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import find_packages, setup
 
 # single source of truth for package version
-version_ns = {}
+version_ns = {}  # type: ignore
 with open(os.path.join("globus_cli", "version.py")) as f:
     exec(f.read(), version_ns)
 version = version_ns["__version__"]

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
             "isort>=5.6.4,<6.0",
             "flake8>=3.8.4,<4.0",
             "flake8-bugbear==20.11.1",
+            "mypy==0.800",
         ],
     },
     entry_points={"console_scripts": ["globus = globus_cli:main"]},


### PR DESCRIPTION
Some background on motivation: I have a branch with some internal refactoring I think would be nice, and I wanted to type annotate (and, obviously, check) the new internal tooling it introduces. Having mypy linting properly in-place ahead of time seems the right way to go. Even without explicit plans to type-annotate the SDK, I'd like to introduce the same, or at least similar, config there too.

---

Introduce mypy with config to be as pedantic as we can be without causing unnecessary pain. That is, turn on all of the warnings we can which are either non-issues or easily resolved. Some settings like `check_untyped_defs` would be a huge PITA right now.

This identified three minor issues:
1. `site.USER_BASE` is actually an `Optional[str]`, so switch to `getuserbase()`
2. mypy wants a type for `version_ns` in setup.py -- `type: ignore` that one to keep complexity in setup.py down
3. `reference/_generate.py` changes the type of a variable, so do some minor name-munging to fix it