### PR TITLE
Cleanup 'endpoint server add'

### DIFF
--- a/globus_cli/commands/endpoint/server/add.py
+++ b/globus_cli/commands/endpoint/server/add.py
@@ -15,8 +15,8 @@ $ globus endpoint server add $ep_id --hostname gridftp.example.org
 ----
 """,
 )
-@server_add_and_update_opts(add=True)
 @endpoint_id_arg
+@server_add_and_update_opts(add=True)
 def server_add(
     endpoint_id,
     subject,

--- a/globus_cli/parsing/shared_options.py
+++ b/globus_cli/parsing/shared_options.py
@@ -710,7 +710,10 @@ def server_add_and_update_opts(*args, **kwargs):
         return (lower, upper) if lower <= upper else (upper, lower)
 
     def inner_decorator(f, add=False):
-        f = click.option("--hostname", required=add, help="Server Hostname.")(f)
+        if add:
+            f = click.argument("HOSTNAME")(f)
+        else:
+            f = click.option("--hostname", help="Server Hostname.")(f)
 
         default_scheme = "gsiftp" if add else None
         f = click.option(

--- a/tests/functional/test_endpoint_servers.py
+++ b/tests/functional/test_endpoint_servers.py
@@ -4,7 +4,7 @@ import pytest
 def test_gcs_server_add(run_line, load_api_fixtures):
     data = load_api_fixtures("endpoint_servers.yaml")
     epid = data["metadata"]["endpoint_id"]
-    result = run_line(f"globus endpoint server add {epid} --hostname example.org")
+    result = run_line(f"globus endpoint server add {epid} example.org")
     assert "Server added to endpoint successfully" in result.output
 
 


### PR DESCRIPTION
closes #390

EDIT: Clarification. The cleanup is that `hostname` is now a positional arg, not a required option.

Apparently somewhere along the way we renamed this command, so we should have fixed it then, but doing it now is fine. This is just backlogged cleanup we should ship as part of 3.0