### PR TITLE
`globus rename` takes EP ID only once

### DIFF
--- a/globus_cli/commands/rename.py
+++ b/globus_cli/commands/rename.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command
+from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
 from globus_cli.services.transfer import autoactivate, get_client
 
@@ -17,11 +17,10 @@ $ globus rename $ep_id:~/tempdir $ep_id:~/project-foo
 ----
 """,
 )
-@click.argument("source", metavar="ENDPOINT_ID:SOURCE_PATH", type=ENDPOINT_PLUS_REQPATH)
-@click.argument(
-    "destination", metavar="ENDPOINT_ID:DEST_PATH", type=ENDPOINT_PLUS_REQPATH
-)
-def rename_command(source, destination):
+@endpoint_id_arg
+@click.argument("source", metavar="SOURCE_PATH")
+@click.argument("destination", metavar="DEST_PATH")
+def rename_command(endpoint_id, source, destination):
     """Rename a file or directory on an endpoint.
 
     The old path must be an existing file or directory. The new path must not yet
@@ -29,23 +28,9 @@ def rename_command(source, destination):
 
     The new path does not have to be in the same directory as the old path, but
     most endpoints will require it to stay on the same filesystem.
-
-    The endpoint must be entered twice for the sake of path syntax consistency.
     """
-    source_ep, source_path = source
-    dest_ep, dest_path = destination
-
-    if source_ep != dest_ep:
-        raise click.UsageError(
-            (
-                "rename requires that the source and dest "
-                "endpoints are the same, {} != {}"
-            ).format(source_ep, dest_ep)
-        )
-    endpoint_id = source_ep
-
     client = get_client()
     autoactivate(client, endpoint_id, if_expires_in=60)
 
-    res = client.operation_rename(endpoint_id, oldpath=source_path, newpath=dest_path)
+    res = client.operation_rename(endpoint_id, oldpath=source, newpath=destination)
     formatted_print(res, text_format=FORMAT_TEXT_RAW, response_key="message")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,10 @@ def run_line(cli_runner, request, patch_config):
                         result.stdout,
                         result.stderr,
                         (
-                            "\n  ".join(r.request.url for r in responses.calls)
+                            "\n  ".join(
+                                f"{r.request.method} {r.request.url}"
+                                for r in responses.calls
+                            )
                             or "  <none>"
                         ),
                     )
@@ -165,7 +168,7 @@ def register_api_route(mocked_responses):
         adding_headers=None,
         replace=False,
         match_querystring=False,
-        **kwargs
+        **kwargs,
     ):
         base_url_map = {
             "auth": "https://auth.globus.org/",
@@ -187,7 +190,7 @@ def register_api_route(mocked_responses):
                 full_url,
                 headers=adding_headers,
                 match_querystring=match_querystring,
-                **kwargs
+                **kwargs,
             )
         else:
             responses.add(
@@ -195,7 +198,7 @@ def register_api_route(mocked_responses):
                 full_url,
                 headers=adding_headers,
                 match_querystring=match_querystring,
-                **kwargs
+                **kwargs,
             )
 
     return func
@@ -235,6 +238,9 @@ def load_api_fixtures(register_api_route, test_file_dir, go_ep1_id, go_ep2_id, t
                     query_params = urllib.parse.urlencode(params.pop("query_params"))
                     # modify path (assume no prior params)
                     use_path = use_path + "?" + query_params
+                print(
+                    f"debug: register_api_route({service}, {use_path}, {method}, ...)"
+                )
                 register_api_route(service, use_path, method=method.upper(), **params)
 
         # after registration, return the raw fixture data

--- a/tests/files/api_fixtures/rename_result.yaml
+++ b/tests/files/api_fixtures/rename_result.yaml
@@ -1,0 +1,11 @@
+transfer:
+  - path: /operation/endpoint/{GO_EP1_ID}/rename
+    method: post
+    json:
+      {
+        "DATA_TYPE": "result",
+        "code": "FileRenamed",
+        "message": "File or directory renamed successfully",
+        "request_id": "PL6I0Gsll",
+        "resource": "/operation/endpoint/ddb59aef-6d04-11e5-ba46-22000b92c6ec/rename"
+      }

--- a/tests/functional/test_rename.py
+++ b/tests/functional/test_rename.py
@@ -1,0 +1,10 @@
+def test_simple_rename_success(run_line, load_api_fixtures, go_ep1_id):
+    """
+    Just confirm that args make it through the command successfully and we render the
+    message as output.
+    """
+    load_api_fixtures("transfer_activate_success.yaml")
+    load_api_fixtures("rename_result.yaml")
+
+    result = run_line(f"globus rename {go_ep1_id} foo/bar /baz/buzz")
+    assert "File or directory renamed successfully" in result.output

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 usedevelop = true
 extras = development
-commands = pytest -v --cov=globus_cli
+commands = pytest -v --cov=globus_cli --no-cov-on-fail
 
 [testenv:lint]
 deps = pre-commit~=2.9.2


### PR DESCRIPTION
closes #342

Rather than two 'ep:path' args, take 'ep path path'. Part of the 3.0 cleanup.

Also add a test for the command, and tweak some of the test setup slightly (to help track down an issue with the first draft of the test).