### PR TITLE
Add `mutex_option_group` decorator

### DIFF
--- a/globus_cli/commands/endpoint/activate.py
+++ b/globus_cli/commands/endpoint/activate.py
@@ -7,7 +7,7 @@ from globus_cli.helpers import (
     fill_delegate_proxy_activation_requirements,
     is_remote_session,
 )
-from globus_cli.parsing import command, endpoint_id_arg
+from globus_cli.parsing import command, endpoint_id_arg, mutex_option_group
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
 from globus_cli.services.transfer import activation_requirements_help_text, get_client
 
@@ -115,6 +115,7 @@ $ globus endpoint activate $ep_id --myproxy -U username
     default=False,
     help="Force activation even if endpoint is already activated.",
 )
+@mutex_option_group("--web", "--myproxy", "--delegate-proxy")
 def endpoint_activate(
     endpoint_id,
     myproxy,
@@ -176,10 +177,6 @@ def endpoint_activate(
     client = get_client()
 
     # validate options
-    if web + myproxy + bool(delegate_proxy) > 1:
-        raise click.UsageError(
-            "--web, --myproxy, and --delegate-proxy are mutually exclusive."
-        )
     if no_autoactivate and not (myproxy or web or delegate_proxy):
         raise click.UsageError(
             "--no-autoactivate requires another activation method be given."

--- a/globus_cli/commands/task/show.py
+++ b/globus_cli/commands/task/show.py
@@ -1,6 +1,6 @@
 import click
 
-from globus_cli.parsing import command, task_id_arg
+from globus_cli.parsing import command, mutex_option_group, task_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print
 from globus_cli.services.transfer import get_client, iterable_response_to_dict
 
@@ -155,16 +155,13 @@ $ globus task show TASK_ID
         "Mutually exclusive with --successful-transfers"
     ),
 )
+@mutex_option_group("--successful-transfers", "--skipped-errors")
 def show_task(successful_transfers, skipped_errors, task_id):
     """
     Print information detailing the status and other info about a task.
 
     The task may be pending, completed, or in progress.
     """
-    if successful_transfers and skipped_errors:
-        raise click.UsageError(
-            "--successful-transfers and --skipped-errors are mutually exclusive"
-        )
     client = get_client()
 
     if successful_transfers:

--- a/globus_cli/commands/transfer.py
+++ b/globus_cli/commands/transfer.py
@@ -5,6 +5,7 @@ from globus_cli.parsing import (
     ENDPOINT_PLUS_OPTPATH,
     TaskPath,
     command,
+    mutex_option_group,
     shlex_process_stdin,
     task_submission_options,
 )
@@ -203,6 +204,7 @@ fi
 @click.option("--perf-p", type=int, hidden=True)
 @click.option("--perf-pp", type=int, hidden=True)
 @click.option("--perf-udt", is_flag=True, default=None, hidden=True)
+@mutex_option_group("--recursive", "--external-checksum")
 def transfer_command(
     batch,
     sync_level,
@@ -311,11 +313,6 @@ def transfer_command(
             "which need it"
         )
 
-    if recursive and external_checksum:
-        raise click.UsageError(
-            "--recursive and --external-checksum are mutually exclusive"
-        )
-
     if (cmd_source_path is None or cmd_dest_path is None) and (not batch):
         raise click.UsageError(
             "transfer requires either SOURCE_PATH and DEST_PATH or --batch"
@@ -365,15 +362,12 @@ def transfer_command(
         @click.option("--recursive", "-r", is_flag=True)
         @click.argument("source_path", type=TaskPath(base_dir=cmd_source_path))
         @click.argument("dest_path", type=TaskPath(base_dir=cmd_dest_path))
+        @mutex_option_group("--recursive", "--external-checksum")
         def process_batch_line(dest_path, source_path, recursive, external_checksum):
             """
             Parse a line of batch input and turn it into a transfer submission
             item.
             """
-            if recursive and external_checksum:
-                raise click.UsageError(
-                    "--recursive and --external-checksum are mutually exclusive"
-                )
             transfer_data.add_item(
                 str(source_path),
                 str(dest_path),

--- a/globus_cli/parsing/__init__.py
+++ b/globus_cli/parsing/__init__.py
@@ -4,6 +4,7 @@ from globus_cli.parsing.endpoint_plus_path import (
     ENDPOINT_PLUS_REQPATH,
 )
 from globus_cli.parsing.explicit_null import EXPLICIT_NULL
+from globus_cli.parsing.mutex_group import mutex_option_group
 from globus_cli.parsing.one_use_option import one_use_option
 from globus_cli.parsing.process_stdin import shlex_process_stdin
 from globus_cli.parsing.shared_options import (
@@ -30,6 +31,7 @@ __all__ = [
     "ENDPOINT_PLUS_REQPATH",
     "TaskPath",
     "one_use_option",
+    "mutex_option_group",
     "EXPLICIT_NULL",
     # Transfer options
     "endpoint_id_arg",

--- a/globus_cli/parsing/mutex_group.py
+++ b/globus_cli/parsing/mutex_group.py
@@ -1,0 +1,73 @@
+import functools
+import typing
+
+import click
+
+
+class MutexInfo:
+    def __init__(self, opt, param=None, present=None):
+        self.option_name = opt
+        if param:
+            self.param_name = param
+        else:
+            self.param_name = opt.lstrip("-").replace("-", "_")
+        self.is_present_callback = present
+
+    def is_present(self, d):
+        if self.is_present_callback is not None:
+            return self.is_present_callback(d)
+        val = d.get(self.param_name)
+        # None for options with values, False for boolean flags
+        # so we do normal "bool" conversion here
+        return bool(val)
+
+    def __str__(self):
+        return self.option_name
+
+
+def mutex_option_group(*options: typing.Union[str, MutexInfo]):
+    """
+    Given a mapping of param name to option string, decorate a command function to check
+    for the exclusivity of those options.
+
+    Options may be given as strings, in which case they are treated as the option name,
+    leading hyphens are stripped and hyphens are converted to underscores for the param
+    name. e.g.
+        mutex_option_group("--foo-bar", "--baz-buzz")
+
+    will assume the param names are "foo_bar" and "baz_buzz" respectively.
+
+    Or, if this deduction would be incorrect, options may be given as MutexInfo objects.
+    e.g.
+        mutex_option_group("--foo-bar", MutexInfo("--baz-buzz", param="buzz"))
+
+    to deduce param names of "foo_bar" and "buzz" respectively.
+
+    MutexInfo allows you to customize how an option is detected as present in a
+    dict of parameters by setting `present=...`.
+    """
+    opt_infos: typing.List[MutexInfo] = []
+    for opt in options:
+        if isinstance(opt, str):
+            opt_infos.append(MutexInfo(opt))
+        else:
+            opt_infos.append(opt)
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            found_opts = []
+            for opt in opt_infos:
+                if opt.is_present(kwargs):
+                    found_opts.append(opt)
+            if len(found_opts) > 1:
+                if len(opt_infos) == 2:
+                    option_str = "{} and {}".format(*opt_infos)
+                else:
+                    option_str = ", ".join(opt_infos[:-1]) + f", and {opt_infos[-1]}"
+                raise click.UsageError(f"{option_str} are mutually exclusive")
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/tests/functional/test_endpoint_create.py
+++ b/tests/functional/test_endpoint_create.py
@@ -208,3 +208,16 @@ def test_invalid_managed_only_options(run_line):
             assert_exit_code=2,
         )
         assert "managed endpoints" in result.stderr
+
+
+def test_mutex_options(run_line):
+    options = [
+        "--default-directory /foo/ --no-default-directory",
+        "--subscription-id aa3ccabf-d0dc-4ea8-b6aa-6c9b4ae9b0d3 --no-managed",
+    ]
+    for opts in options:
+        result = run_line(
+            f"globus endpoint create withbadopts --server {opts}",
+            assert_exit_code=2,
+        )
+        assert "mutually exclusive" in result.stderr

--- a/tests/functional/test_task_show.py
+++ b/tests/functional/test_task_show.py
@@ -10,3 +10,14 @@ def test_skipped_errors(run_line, load_api_fixtures, task_id):
     assert "FILE_NOT_FOUND" in result.output
     assert "/~/restricted-file" in result.output
     assert "PERMISSION_DENIED" in result.output
+
+
+def test_mutex_options(run_line, task_id):
+    result = run_line(
+        f"globus task show --skipped-errors --successful-transfers {task_id}",
+        assert_exit_code=2,
+    )
+    assert (
+        "--successful-transfers and --skipped-errors are mutually exclusive"
+        in result.stderr
+    )


### PR DESCRIPTION
Several commands check a series of options for mutual exclusivity.
This work is always the same, in essence, and removing it to a decorator simplifies logic in some of the more complex cases (see the changes in `validate_endpoint_create_and_update_params`).

Because we're now operating in 3.6+ this introduces some type annotations, which weren't available to us in the past. We can start making strictly typed internal APIs.

In the normal cases, `mutex_option_group` will just be given the option string and will deduce the param name and correctly check for its presence. However, for unusual cases (explicit underlying param names, etc) there is a `MutexInfo` object which can be populated with the correct fields/behaviors, and could be extended further in the future if necessary.

---

I think this is a good idea, but I'm open to the idea that we shouldn't bother. I wish `click` provided this and did option inspection to consistently map option strings to param names, but I'm not willing to build that out here. I think this is good enough and still an improvement over doing these checks ad-hoc.