### PR TITLE
Add --exclude option to transfer submit

### DIFF
--- a/globus_cli/commands/transfer.py
+++ b/globus_cli/commands/transfer.py
@@ -193,6 +193,18 @@ fi
         "during the transfer."
     ),
 )
+@click.option(
+    "--exclude",
+    multiple=True,
+    default=None,
+    show_default=True,
+    help=(
+        "Exclude files and directories found with names that match the given "
+        "pattern in recursive transfers. Pattern may include * ? or [] for "
+        "unix style globbing. Give this option multiple times to exclude "
+        "multiple patterns."
+    ),
+)
 @click.argument(
     "source", metavar="SOURCE_ENDPOINT_ID[:SOURCE_PATH]", type=ENDPOINT_PLUS_OPTPATH
 )
@@ -213,6 +225,7 @@ def transfer_command(
     external_checksum,
     skip_source_errors,
     fail_on_quota_errors,
+    exclude,
     label,
     preserve_mtime,
     verify_checksum,
@@ -339,6 +352,14 @@ def transfer_command(
     kwargs.update(perf_opts)
     kwargs.update(notify)
 
+    def _make_exclude_rule(name_pattern):
+        return {"DATA_TYPE": "filter_rule", "method": "exclude", "name": name_pattern}
+
+    if exclude:
+        filter_rules = [_make_exclude_rule(s) for s in exclude]
+    else:
+        filter_rules = None
+
     client = get_client()
     transfer_data = TransferData(
         client,
@@ -355,6 +376,7 @@ def transfer_command(
         skip_activation_check=skip_activation_check,
         skip_source_errors=skip_source_errors,
         fail_on_quota_errors=fail_on_quota_errors,
+        filter_rules=filter_rules,
         **kwargs
     )
 
@@ -374,6 +396,7 @@ def transfer_command(
                 raise click.UsageError(
                     "--recursive and --external-checksum are mutually exclusive"
                 )
+
             transfer_data.add_item(
                 str(source_path),
                 str(dest_path),
@@ -397,6 +420,16 @@ def transfer_command(
             checksum_algorithm=checksum_algorithm,
             recursive=recursive,
         )
+
+    for item in transfer_data["DATA"]:
+        if item["recursive"]:
+            has_recursive_items = True
+            break
+    else:
+        has_recursive_items = False
+
+    if exclude and not has_recursive_items:
+        raise click.UsageError("--exclude can only be used with --recursive transfers")
 
     if dry_run:
         formatted_print(

--- a/tests/functional/test_task_submit.py
+++ b/tests/functional/test_task_submit.py
@@ -1,0 +1,53 @@
+import json
+
+
+def test_exclude(run_line, load_api_fixtures, go_ep1_id, go_ep2_id):
+    """
+    Submits two --exclude options on a transfer, confirms they show up
+    in --dry-run output
+    """
+    # put a submission ID and autoactivate response in place
+    load_api_fixtures("get_submission_id.yaml")
+    load_api_fixtures("transfer_activate_success.yaml")
+
+    result = run_line(
+        "globus transfer -F json --dry-run -r "
+        "--exclude *.txt --exclude *.pdf "
+        "{}:/ {}:/".format(go_ep1_id, go_ep1_id)
+    )
+
+    expected_filter_rules = [
+        {"DATA_TYPE": "filter_rule", "method": "exclude", "name": "*.txt"},
+        {"DATA_TYPE": "filter_rule", "method": "exclude", "name": "*.pdf"},
+    ]
+
+    json_output = json.loads(result.output)
+    assert json_output["filter_rules"] == expected_filter_rules
+
+
+def test_exlude_recursive(run_line, load_api_fixtures, go_ep1_id, go_ep2_id):
+    """
+    Confirms using --exclude on non recursive transfers raises errors
+    """
+    # would be better if this could fail before we make any api calls, but
+    # we want to build the transfer_data object before we parse batch input
+    load_api_fixtures("get_submission_id.yaml")
+
+    expected_error = "--exclude can only be used with --recursive transfers"
+
+    # single
+    result = run_line(
+        "globus transfer --exclude *.txt " "{}:/ {}:/".format(go_ep1_id, go_ep1_id),
+        assert_exit_code=2,
+    )
+    assert expected_error in result.stderr
+
+    # batch
+    batch_input = "abc /def\n"
+    result = run_line(
+        "globus transfer --exclude *.txt --batch "
+        "{}:/ {}:/".format(go_ep1_id, go_ep1_id),
+        stdin=batch_input,
+        assert_exit_code=2,
+    )
+    assert expected_error in result.stderr


### PR DESCRIPTION
I think this is the simplest way to expose filter_rules to the cli, similar to how we only expose the name field in ls filtering.

If / when filter_rules become more complex and support more than just name and type, we could do something similar to the gcs cli and allow passing json documents for more complex use cases, but I think having --exclude <name> would still be a nice shorthand for the most common use case even then.