### PR TITLE
Begin using globus-sdk beta (v3.0b1) and update to tokenstorage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.6",
     install_requires=[
-        "globus-sdk==2.0.1",
+        "globus-sdk==3.0.0a1",
         "click>=7.1.1,<8.0",
         "jmespath==0.10.0",
         "configobj>=5.0.6,<6.0.0",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.6",
     install_requires=[
-        "globus-sdk==3.0.0a4",
+        "globus-sdk==3.0.0b1",
         "click>=7.1.1,<8.0",
         "jmespath==0.10.0",
         "requests>=2.0.0,<3.0.0",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.6",
     install_requires=[
-        "globus-sdk==3.0.0a2",
+        "globus-sdk==3.0.0a4",
         "click>=7.1.1,<8.0",
         "jmespath==0.10.0",
         "requests>=2.0.0,<3.0.0",

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,9 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.6",
     install_requires=[
-        "globus-sdk==3.0.0a1",
+        "globus-sdk==3.0.0a2",
         "click>=7.1.1,<8.0",
         "jmespath==0.10.0",
-        "configobj>=5.0.6,<6.0.0",
         "requests>=2.0.0,<3.0.0",
         # cryptography has unusual versioning and compatibility rules:
         # https://cryptography.io/en/latest/api-stability/

--- a/src/globus_cli/commands/bookmark/helpers.py
+++ b/src/globus_cli/commands/bookmark/helpers.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 import click
-from globus_sdk.exc import TransferAPIError
+from globus_sdk import TransferAPIError
 
 
 def resolve_id_or_name(client, bookmark_id_or_name):

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -130,12 +130,14 @@ def delete_command(
         endpoint_id,
         label=label,
         recursive=recursive,
-        ignore_missing=ignore_missing,
         submission_id=submission_id,
         deadline=deadline,
-        skip_activation_check=skip_activation_check,
-        interpret_globs=enable_globs,
-        **notify
+        additional_fields={
+            "ignore_missing": ignore_missing,
+            "skip_activation_check": skip_activation_check,
+            "interpret_globs": enable_globs,
+            **notify,
+        },
     )
 
     if batch:

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -2,7 +2,6 @@ import webbrowser
 
 import click
 
-from globus_cli.config import MYPROXY_USERNAME_OPTNAME, lookup_option
 from globus_cli.helpers import (
     fill_delegate_proxy_activation_requirements,
     is_remote_session,
@@ -66,10 +65,7 @@ $ globus endpoint activate $ep_id --myproxy -U username
 @click.option(
     "--myproxy-username",
     "-U",
-    help=(
-        "Give a username to use with --myproxy. "
-        "Overrides any default myproxy username set in config."
-    ),
+    help=("Give a username to use with --myproxy"),
 )
 @click.option("--myproxy-password", "-P", hidden=True)
 @click.option(
@@ -153,9 +149,8 @@ def endpoint_activate(
     server the endpoint is using for authentication. e.g. for default
     Globus Connect Server endpoints this will be your login credentials for the
     server the endpoint is hosted on.
-    You can enter your username when prompted, give your username with the
-    --myproxy-username option, or set a default myproxy username in config with
-    "globus config init" or "globus config set cli.default_myproxy_username".
+    You can enter your username when prompted or give your username with the
+    --myproxy-username option.
     For security it is recommended that you only enter your password when
     prompted to hide your inputs and keep your password out of your
     command history, but you may pass your password with the hidden
@@ -173,7 +168,6 @@ def endpoint_activate(
     user the error will not be detected until the user attempts to perform an
     operation on the endpoint.
     """
-    default_myproxy_username = lookup_option(MYPROXY_USERNAME_OPTNAME)
     client = get_client()
 
     # validate options
@@ -247,7 +241,7 @@ def endpoint_activate(
             )
 
         # get username and password
-        if not (myproxy_username or default_myproxy_username):
+        if not myproxy_username:
             myproxy_username = click.prompt("Myproxy username")
         if not myproxy_password:
             myproxy_password = click.prompt("Myproxy password", hide_input=True)
@@ -259,7 +253,7 @@ def endpoint_activate(
             if data["name"] == "passphrase":
                 data["value"] = myproxy_password
             if data["name"] == "username":
-                data["value"] = myproxy_username or default_myproxy_username
+                data["value"] = myproxy_username
             if data["name"] == "hostname" and data["value"] is None:
                 raise click.ClickException(
                     "This endpoint has no myproxy server "

--- a/src/globus_cli/commands/get_identities.py
+++ b/src/globus_cli/commands/get_identities.py
@@ -1,9 +1,9 @@
 import click
-from globus_sdk import GlobusResponse
 
 from globus_cli.parsing import IdentityType, command
 from globus_cli.safeio import FORMAT_TEXT_TABLE, formatted_print, is_verbose
 from globus_cli.services.auth import get_auth_client
+from globus_cli.stub_response import CLIStubResponse
 
 
 @command(
@@ -65,7 +65,7 @@ def get_identities_command(values, provision):
         results += client.get_identities(usernames=usernames, provision=provision)[
             "identities"
         ]
-    res = GlobusResponse({"identities": results})
+    res = CLIStubResponse({"identities": results})
 
     def _custom_text_format(identities):
         """

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -78,12 +78,14 @@ def rm_command(
         endpoint_id,
         label=label,
         recursive=recursive,
-        ignore_missing=ignore_missing,
         submission_id=submission_id,
         deadline=deadline,
-        skip_activation_check=skip_activation_check,
-        interpret_globs=enable_globs,
-        **notify,
+        additional_fields={
+            "ignore_missing": ignore_missing,
+            "skip_activation_check": skip_activation_check,
+            "interpret_globs": enable_globs,
+            **notify,
+        },
     )
 
     if not star_silent and enable_globs and path.endswith("*"):

--- a/src/globus_cli/commands/task/cancel.py
+++ b/src/globus_cli/commands/task/cancel.py
@@ -64,15 +64,12 @@ def cancel_task(all, task_id):
     client = get_client()
 
     if all:
-        from sys import maxsize
-
         task_ids = [
             task_row["task_id"]
-            for task_row in client.task_list(
+            for task_row in client.paginated.task_list(
                 filter="type:TRANSFER,DELETE/status:ACTIVE,INACTIVE",
                 fields="task_id",
-                num_results=maxsize,  # FIXME want to ask for "unlimited" set
-            )
+            ).items()
         ]
 
         task_count = len(task_ids)

--- a/src/globus_cli/commands/task/event_list.py
+++ b/src/globus_cli/commands/task/event_list.py
@@ -2,6 +2,7 @@ import json
 
 import click
 
+from globus_cli.paging_wrapper import PagingWrapper
 from globus_cli.parsing import command, task_id_arg
 from globus_cli.safeio import formatted_print
 from globus_cli.services.transfer import get_client, iterable_response_to_dict
@@ -65,8 +66,9 @@ def task_event_list(task_id, limit, filter_errors, filter_non_errors):
     else:
         filter_string = ""
 
-    event_iterator = client.task_event_list(
-        task_id, num_results=limit, filter=filter_string
+    event_iterator = PagingWrapper(
+        client.paginated.task_event_list(task_id, filter=filter_string).items(),
+        limit=limit,
     )
 
     def squashed_json_details(x):

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -1,5 +1,6 @@
 import click
 
+from globus_cli.paging_wrapper import PagingWrapper
 from globus_cli.parsing import command
 from globus_cli.safeio import formatted_print
 from globus_cli.services.transfer import get_client, iterable_response_to_dict
@@ -196,9 +197,12 @@ def task_list(
     )
 
     client = get_client()
-    task_iterator = client.task_list(
-        num_results=limit, filter=filter_string[:-1]
-    )  # ignore trailing /
+    task_iterator = PagingWrapper(
+        client.paginated.task_list(
+            filter=filter_string[:-1]  # remove trailing /
+        ).items(),
+        limit=limit,
+    )
 
     fields = [
         ("Task ID", "task_id"),

--- a/src/globus_cli/commands/task/show.py
+++ b/src/globus_cli/commands/task/show.py
@@ -55,7 +55,7 @@ SKIPPED_PATHS_FIELDS = [
 
 
 def print_successful_transfers(client, task_id):
-    res = client.task_successful_transfers(task_id, num_results=None)
+    res = client.paginated.task_successful_transfers(task_id).items()
     formatted_print(
         res,
         fields=SUCCESSFULL_TRANSFER_FIELDS,
@@ -64,7 +64,7 @@ def print_successful_transfers(client, task_id):
 
 
 def print_skipped_errors(client, task_id):
-    res = client.task_skipped_errors(task_id, num_results=None)
+    res = client.paginated.task_skipped_errors(task_id).items()
     formatted_print(
         res,
         fields=SKIPPED_PATHS_FIELDS,

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -331,14 +331,9 @@ def transfer_command(
             "transfer requires either SOURCE_PATH and DEST_PATH or --batch"
         )
 
-    # because python can't handle multiple **kwargs expansions in a single
-    # call, we need to get a little bit clever
-    # both the performance options (of which there are a few), and the
-    # notification options (also there are a few) have elements which should be
+    # the performance options (of which there are a few), have elements which should be
     # omitted in some cases
-    # notify comes to us clean, perf opts need more care
-    # put them together into a dict before passing to TransferData
-    kwargs = {}
+    # put them together before passing to TransferData
     perf_opts = {
         k: v
         for (k, v) in dict(
@@ -346,8 +341,6 @@ def transfer_command(
         ).items()
         if v is not None
     }
-    kwargs.update(perf_opts)
-    kwargs.update(notify)
 
     def _make_exclude_rule(name_pattern):
         return {"DATA_TYPE": "filter_rule", "method": "exclude", "name": name_pattern}
@@ -368,13 +361,16 @@ def transfer_command(
         preserve_timestamp=preserve_mtime,
         encrypt_data=encrypt,
         submission_id=submission_id,
-        delete_destination_extra=delete,
         deadline=deadline,
-        skip_activation_check=skip_activation_check,
         skip_source_errors=skip_source_errors,
         fail_on_quota_errors=fail_on_quota_errors,
-        filter_rules=filter_rules,
-        **kwargs
+        additional_fields={
+            "delete_destination_extra": delete,
+            "skip_activation_check": skip_activation_check,
+            "filter_rules": filter_rules,
+            **notify,
+            **perf_opts,
+        },
     )
 
     if batch:

--- a/src/globus_cli/commands/version.py
+++ b/src/globus_cli/commands/version.py
@@ -19,7 +19,6 @@ def _get_package_data():
     moddata = []
     modlist = (
         "click",
-        "configobj",
         "cryptography",
         "globus_cli",
         "globus_sdk",

--- a/src/globus_cli/commands/whoami.py
+++ b/src/globus_cli/commands/whoami.py
@@ -1,5 +1,5 @@
 import click
-from globus_sdk.exc import AuthAPIError
+from globus_sdk import AuthAPIError
 
 from globus_cli.parsing import command
 from globus_cli.safeio import (

--- a/src/globus_cli/config.py
+++ b/src/globus_cli/config.py
@@ -1,247 +1,10 @@
 import logging.config
 import os
+from configparser import ConfigParser
 
 import globus_sdk
-from configobj import ConfigObj
 
-__all__ = [
-    # option name constants
-    "OUTPUT_FORMAT_OPTNAME",
-    "MYPROXY_USERNAME_OPTNAME",
-    "AUTH_RT_OPTNAME",
-    "AUTH_AT_OPTNAME",
-    "AUTH_AT_EXPIRES_OPTNAME",
-    "TRANSFER_RT_OPTNAME",
-    "TRANSFER_AT_OPTNAME",
-    "AUTH_AT_EXPIRES_OPTNAME",
-    "CLIENT_ID_OPTNAME",
-    "CLIENT_SECRET_OPTNAME",
-    "GLOBUS_ENV",
-    "internal_native_client",
-    "internal_auth_client",
-    "get_output_format",
-    "get_auth_tokens",
-    "get_transfer_tokens",
-    "get_config_obj",
-    "write_option",
-    "remove_option",
-    "lookup_option",
-]
-
-
-# constants for use whenever we need to do things using
-# instance clients from the CLI Native App Template
-# primarily accessed via `internal_auth_client()`
-CLIENT_ID_OPTNAME = "client_id"
-CLIENT_SECRET_OPTNAME = "client_secret"
-TEMPLATE_ID_OPTNAME = "template_id"
-DEFAULT_TEMPLATE_ID = "95fdeba8-fac2-42bd-a357-e068d82ff78e"
-
-# constants for global use
-OUTPUT_FORMAT_OPTNAME = "output_format"
-MYPROXY_USERNAME_OPTNAME = "default_myproxy_username"
-AUTH_RT_OPTNAME = "auth_refresh_token"
-AUTH_AT_OPTNAME = "auth_access_token"
-AUTH_AT_EXPIRES_OPTNAME = "auth_access_token_expires"
-TRANSFER_RT_OPTNAME = "transfer_refresh_token"
-TRANSFER_AT_OPTNAME = "transfer_access_token"
-TRANSFER_AT_EXPIRES_OPTNAME = "transfer_access_token_expires"
-
-# get the environment from env var (not exported)
 GLOBUS_ENV = os.environ.get("GLOBUS_SDK_ENVIRONMENT")
-
-# if the env is set, rewrite the option names to have it as a prefix
-if GLOBUS_ENV:
-    AUTH_RT_OPTNAME = f"{GLOBUS_ENV}_auth_refresh_token"
-    AUTH_AT_OPTNAME = f"{GLOBUS_ENV}_auth_access_token"
-    AUTH_AT_EXPIRES_OPTNAME = f"{GLOBUS_ENV}_auth_access_token_expires"
-    TRANSFER_RT_OPTNAME = f"{GLOBUS_ENV}_transfer_refresh_token"
-    TRANSFER_AT_OPTNAME = f"{GLOBUS_ENV}_transfer_access_token"
-    TRANSFER_AT_EXPIRES_OPTNAME = f"{GLOBUS_ENV}_transfer_access_token_expires"
-
-    CLIENT_ID_OPTNAME = f"{GLOBUS_ENV}_client_id"
-    CLIENT_SECRET_OPTNAME = f"{GLOBUS_ENV}_client_secret"
-    TEMPLATE_ID_OPTNAME = f"{GLOBUS_ENV}_template_id"
-    DEFAULT_TEMPLATE_ID = {
-        "sandbox": "33b6a241-bce4-4359-9c6d-09f88b3c9eef",
-        "integration": "e0c31fd1-663b-44e1-840f-f4304bb9ee7a",
-        "test": "0ebfd058-452f-40c3-babf-5a6b16a7b337",
-        "staging": "3029c3cb-c8d9-4f2b-979c-c53330aa7327",
-        "preview": "b2867dbb-0846-4579-8486-dc70763d700b",
-    }.get(GLOBUS_ENV, DEFAULT_TEMPLATE_ID)
-
-
-def get_config_obj(system=False, file_error=False):
-    if system:
-        path = "/etc/globus.cfg"
-    else:
-        path = os.path.expanduser("~/.globus.cfg")
-
-    conf = ConfigObj(path, encoding="utf-8", file_error=file_error)
-
-    # delete any old whomai values in the cli section
-    for key in conf.get("cli", {}):
-        if "whoami_identity_" in key:
-            del conf["cli"][key]
-            conf.write()
-
-    return conf
-
-
-def lookup_option(option, section="cli", environment=None):
-    conf = get_config_obj()
-    try:
-        if environment:
-            return conf["environment " + environment][option]
-        else:
-            return conf[section][option]
-    except KeyError:
-        return None
-
-
-def remove_option(option, section="cli", system=False):
-    conf = get_config_obj(system=system)
-
-    # if there's no section for the option we're removing, just return None
-    try:
-        section = conf[section]
-    except KeyError:
-        return None
-
-    try:
-        opt_val = section[option]
-
-        # remove value and flush to disk
-        del section[option]
-        conf.write()
-    except KeyError:
-        opt_val = None
-
-    # return the just-deleted value
-    return opt_val
-
-
-def write_option(option, value, section="cli", system=False):
-    """
-    Write an option to disk -- doesn't handle config reloading
-    """
-    # deny rwx to Group and World -- don't bother storing the returned old mask
-    # value, since we'll never restore it in the CLI anyway
-    # do this on every call to ensure that we're always consistent about it
-    os.umask(0o077)
-
-    # FIXME: DRY violation with config_commands.helpers
-    conf = get_config_obj(system=system)
-
-    # add the section if absent
-    if section not in conf:
-        conf[section] = {}
-
-    conf[section][option] = value
-    conf.write()
-
-
-def get_output_format():
-    return lookup_option(OUTPUT_FORMAT_OPTNAME)
-
-
-def get_auth_tokens():
-    expires = lookup_option(AUTH_AT_EXPIRES_OPTNAME)
-    if expires is not None:
-        expires = int(expires)
-
-    return {
-        "refresh_token": lookup_option(AUTH_RT_OPTNAME),
-        "access_token": lookup_option(AUTH_AT_OPTNAME),
-        "access_token_expires": expires,
-    }
-
-
-def set_auth_tokens(access_token, refresh_token, expires_at):
-    write_option(AUTH_AT_OPTNAME, access_token)
-    write_option(AUTH_RT_OPTNAME, refresh_token)
-    write_option(AUTH_AT_EXPIRES_OPTNAME, expires_at)
-
-
-def get_transfer_tokens():
-    expires = lookup_option(TRANSFER_AT_EXPIRES_OPTNAME)
-    if expires is not None:
-        expires = int(expires)
-
-    return {
-        "refresh_token": lookup_option(TRANSFER_RT_OPTNAME),
-        "access_token": lookup_option(TRANSFER_AT_OPTNAME),
-        "access_token_expires": expires,
-    }
-
-
-def set_transfer_tokens(access_token, refresh_token, expires_at):
-    write_option(TRANSFER_AT_OPTNAME, access_token)
-    write_option(TRANSFER_RT_OPTNAME, refresh_token)
-    write_option(TRANSFER_AT_EXPIRES_OPTNAME, expires_at)
-
-
-def internal_native_client():
-    template_id = lookup_option(TEMPLATE_ID_OPTNAME) or DEFAULT_TEMPLATE_ID
-    return globus_sdk.NativeAppAuthClient(template_id)
-
-
-def internal_auth_client(requires_instance=False, force_new_client=False):
-    """
-    Looks up the values for this CLI's Instance Client in config
-
-    If none exists and requires_instance is True or force_new_client is True,
-    registers a new Instance Client with Globus Auth
-
-    If none exists and requires_instance is false, defaults to a Native Client
-    for backwards compatibility
-
-    Returns either a NativeAppAuthClient or a ConfidentialAppAuthClient
-    """
-    client_id = lookup_option(CLIENT_ID_OPTNAME)
-    client_secret = lookup_option(CLIENT_SECRET_OPTNAME)
-    template_id = lookup_option(TEMPLATE_ID_OPTNAME) or DEFAULT_TEMPLATE_ID
-    template_client = internal_native_client()
-    existing = client_id and client_secret
-
-    # if we are forcing a new client, delete any existing client
-    if force_new_client and existing:
-        existing_client = globus_sdk.ConfidentialAppAuthClient(client_id, client_secret)
-        try:
-            existing_client.delete(f"/v2/api/clients/{client_id}")
-
-        # if the client secret has been invalidated or the client has
-        # already been removed, we continue on
-        except globus_sdk.exc.AuthAPIError:
-            pass
-
-    # if we require a new client to be made
-    if force_new_client or (requires_instance and not existing):
-        # register a new instance client with auth
-        body = {"client": {"template_id": template_id, "name": "Globus CLI"}}
-        res = template_client.post("/v2/api/clients", json_body=body)
-
-        # get values and write to config
-        credential_data = res["included"]["client_credential"]
-        client_id = credential_data["client"]
-        client_secret = credential_data["secret"]
-        write_option(CLIENT_ID_OPTNAME, client_id)
-        write_option(CLIENT_SECRET_OPTNAME, client_secret)
-
-        return globus_sdk.ConfidentialAppAuthClient(
-            client_id, client_secret, app_name="Globus CLI"
-        )
-
-    # if we already have a client, just return it
-    elif existing:
-        return globus_sdk.ConfidentialAppAuthClient(
-            client_id, client_secret, app_name="Globus CLI"
-        )
-
-    # fall-back to a native client to not break old logins
-    # TOOD: eventually remove this behavior
-    else:
-        return template_client
 
 
 def setup_logging(level="DEBUG"):
@@ -261,3 +24,66 @@ def setup_logging(level="DEBUG"):
     }
 
     logging.config.dictConfig(conf)
+
+
+def _get_old_conf_path():
+    return os.path.expanduser("~/.globus.cfg")
+
+
+def _old_conf_parser():
+    conf = ConfigParser()
+    conf.read(_get_old_conf_path())
+    return conf
+
+
+def _token_conf_keys():
+    for k in [
+        "auth_refresh_token",
+        "auth_access_token",
+        "transfer_refresh_token",
+        "transfer_access_token",
+    ]:
+        # if the env is set, rewrite the option names to have it as a prefix
+        yield (f"{GLOBUS_ENV}_{k}" if GLOBUS_ENV else k)
+
+
+def _old_tokens_to_revoke(conf):
+    for key in _token_conf_keys():
+        tokenstr = conf.get("cli", key, fallback=None)
+        if tokenstr:
+            yield tokenstr
+
+
+def _get_client_creds(conf):
+    id_key, secret_key = ("client_id", "client_secret")
+    if GLOBUS_ENV:
+        id_key, secret_key = (f"{GLOBUS_ENV}_client_id", f"{GLOBUS_ENV}_client_secret")
+    client_id = conf.get("cli", id_key, fallback=None)
+    client_secret = conf.get("cli", secret_key, fallback=None)
+    if client_id and client_secret:
+        return (client_id, client_secret)
+    return None
+
+
+def invalidate_old_config(auth_client):
+    # revoke any old config-stored tokens (logout)
+    # and delete old client creds
+    conf = _old_conf_parser()
+    if not conf.has_section("cli"):
+        return
+
+    # Revoke any tokens found in ~/.globus.cfg
+    for token in _old_tokens_to_revoke(conf=conf):
+        auth_client.oauth2_revoke_token(token)
+
+    # Delete a templated client found configured in ~/.globus.cfg
+    creds = _get_client_creds(conf)
+    if creds:
+        client_id, client_secret = creds
+        old_client = globus_sdk.ConfidentialAppAuthClient(client_id, client_secret)
+        try:
+            old_client.delete(f"/v2/api/clients/{client_id}")
+        # if the client secret has been invalidated or the client has
+        # already been deleted, continue
+        except globus_sdk.AuthAPIError:
+            pass

--- a/src/globus_cli/helpers/auth_flows.py
+++ b/src/globus_cli/helpers/auth_flows.py
@@ -2,18 +2,8 @@ import webbrowser
 
 import click
 
-from globus_cli.config import (
-    AUTH_AT_EXPIRES_OPTNAME,
-    AUTH_AT_OPTNAME,
-    AUTH_RT_OPTNAME,
-    TRANSFER_AT_EXPIRES_OPTNAME,
-    TRANSFER_AT_OPTNAME,
-    TRANSFER_RT_OPTNAME,
-    internal_auth_client,
-    lookup_option,
-    write_option,
-)
 from globus_cli.helpers.local_server import LocalServerError, start_local_server
+from globus_cli.tokenstore import internal_auth_client, token_storage_adapter
 
 SCOPES = (
     "openid profile email "
@@ -22,7 +12,7 @@ SCOPES = (
 )
 
 
-def do_link_auth_flow(session_params=None, force_new_client=False):
+def do_link_auth_flow(session_params=None):
     """
     Prompts the user with a link to authenticate with globus auth
     and authorize the CLI to act on their behalf.
@@ -30,9 +20,7 @@ def do_link_auth_flow(session_params=None, force_new_client=False):
     session_params = session_params or {}
 
     # get the ConfidentialApp client object
-    auth_client = internal_auth_client(
-        requires_instance=True, force_new_client=force_new_client
-    )
+    auth_client = internal_auth_client()
 
     # start the Confidential App Grant flow
     auth_client.oauth2_start_flow(
@@ -57,11 +45,11 @@ def do_link_auth_flow(session_params=None, force_new_client=False):
     auth_code = click.prompt("Enter the resulting Authorization Code here").strip()
 
     # finish auth flow
-    exchange_code_and_store_config(auth_client, auth_code)
+    exchange_code_and_store(auth_client, auth_code)
     return True
 
 
-def do_local_server_auth_flow(session_params=None, force_new_client=False):
+def do_local_server_auth_flow(session_params=None):
     """
     Starts a local http server, opens a browser to have the user authenticate,
     and gets the code redirected to the server (no copy and pasting required)
@@ -74,9 +62,7 @@ def do_local_server_auth_flow(session_params=None, force_new_client=False):
         redirect_uri = f"http://localhost:{port}"
 
         # get the ConfidentialApp client object and start a flow
-        auth_client = internal_auth_client(
-            requires_instance=True, force_new_client=force_new_client
-        )
+        auth_client = internal_auth_client()
         auth_client.oauth2_start_flow(
             refresh_tokens=True, redirect_uri=redirect_uri, requested_scopes=SCOPES
         )
@@ -99,49 +85,15 @@ def do_local_server_auth_flow(session_params=None, force_new_client=False):
         click.get_current_context().exit(1)
 
     # finish auth flow and return true
-    exchange_code_and_store_config(auth_client, auth_code)
+    exchange_code_and_store(auth_client, auth_code)
     return True
 
 
-def exchange_code_and_store_config(auth_client, auth_code):
+def exchange_code_and_store(auth_client, auth_code):
     """
     Finishes auth flow after code is gotten from command line or local server.
-    Exchanges code for tokens and gets user info from auth.
-    Stores tokens and user info in config.
+    Exchanges code for tokens and stores them.
     """
-    # do a token exchange with the given code
+    adapter = token_storage_adapter()
     tkn = auth_client.oauth2_exchange_code_for_tokens(auth_code)
-    tkn = tkn.by_resource_server
-
-    store_queue = []
-
-    def _enqueue(optname, newval, revoke=True):
-        store_queue.append((optname, newval, revoke))
-
-    # extract access tokens from final response
-    if "transfer.api.globus.org" in tkn:
-        _enqueue(TRANSFER_RT_OPTNAME, tkn["transfer.api.globus.org"]["refresh_token"])
-        _enqueue(TRANSFER_AT_OPTNAME, tkn["transfer.api.globus.org"]["access_token"])
-        _enqueue(
-            TRANSFER_AT_EXPIRES_OPTNAME,
-            tkn["transfer.api.globus.org"]["expires_at_seconds"],
-            revoke=False,
-        )
-    if "auth.globus.org" in tkn:
-        _enqueue(AUTH_RT_OPTNAME, tkn["auth.globus.org"]["refresh_token"])
-        _enqueue(AUTH_AT_OPTNAME, tkn["auth.globus.org"]["access_token"])
-        _enqueue(
-            AUTH_AT_EXPIRES_OPTNAME,
-            tkn["auth.globus.org"]["expires_at_seconds"],
-            revoke=False,
-        )
-
-    # revoke any existing tokens
-    for optname in [optname for (optname, _val, revoke) in store_queue if revoke]:
-        token = lookup_option(optname)
-        if token:
-            auth_client.oauth2_revoke_token(token)
-
-    # write new data to config
-    for optname, newval, _revoke in store_queue:
-        write_option(optname, newval)
+    adapter.store(tkn)

--- a/src/globus_cli/paging_wrapper.py
+++ b/src/globus_cli/paging_wrapper.py
@@ -1,0 +1,27 @@
+from typing import Iterator, Optional
+
+
+# wrap to add a `has_next()` method and `limit` param to a naive iterator
+class PagingWrapper:
+    def __init__(self, iterator: Iterator, limit: Optional[int] = None):
+        self.iterator = iterator
+        self.next = None
+        self.limit = limit
+        self._step()
+
+    def _step(self):
+        try:
+            self.next = next(self.iterator)
+        except StopIteration:
+            self.next = None
+
+    def has_next(self):
+        return self.next is not None
+
+    def __iter__(self):
+        yielded = 0
+        while self.has_next() and (self.limit is None or yielded < self.limit):
+            cur = self.next
+            self._step()
+            yield cur
+            yielded += 1

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -14,8 +14,8 @@ UNIX_FORMAT = "unix"
 
 class CommandState:
     def __init__(self):
-        # default is config value, or TEXT if it's not set
-        self.output_format = config.get_output_format() or TEXT_FORMAT
+        # default is TEXT
+        self.output_format = TEXT_FORMAT
         # a jmespath expression to process on the json output
         self.jmespath_expr = None
         # default is always False

--- a/src/globus_cli/parsing/excepthook.py
+++ b/src/globus_cli/parsing/excepthook.py
@@ -11,7 +11,7 @@ import sys
 
 import click
 import click.exceptions
-from globus_sdk import exc
+import globus_sdk
 
 from globus_cli.parsing.command_state import CommandState
 from globus_cli.safeio import PrintableErrorField, write_error_info
@@ -204,7 +204,7 @@ def custom_except_hook(exc_info):
     # catch any session errors to give helpful instructions
     # on how to use globus session update
     if (
-        isinstance(exception, exc.GlobusAPIError)
+        isinstance(exception, globus_sdk.GlobusAPIError)
         and exception.raw_json
         and "authorization_parameters" in exception.raw_json
     ):
@@ -213,7 +213,7 @@ def custom_except_hook(exc_info):
     # catch any consent required errors to give helpful instructions
     # on how to use `globus session update --consents`
     if (
-        isinstance(exception, exc.GlobusAPIError)
+        isinstance(exception, globus_sdk.GlobusAPIError)
         and exception.raw_json
         and exception.raw_json.get("code") == "ConsentRequired"
     ):
@@ -221,13 +221,13 @@ def custom_except_hook(exc_info):
 
     # handle the Globus-raised errors with our special hooks
     # these will present the output (on stderr) as JSON
-    elif isinstance(exception, exc.TransferAPIError):
+    elif isinstance(exception, globus_sdk.TransferAPIError):
         if exception.code == "ClientError.AuthenticationFailed":
             authentication_hook(exception)
         else:
             transferapi_hook(exception)
 
-    elif isinstance(exception, exc.AuthAPIError):
+    elif isinstance(exception, globus_sdk.AuthAPIError):
         if exception.code == "UNAUTHORIZED":
             authentication_hook(exception)
         # invalid_grant occurs when the users refresh tokens are not valid
@@ -236,12 +236,12 @@ def custom_except_hook(exc_info):
         else:
             authapi_hook(exception)
 
-    elif isinstance(exception, exc.GlobusAPIError):
+    elif isinstance(exception, globus_sdk.GlobusAPIError):
         globusapi_hook(exception)
 
     # specific checks fell through -- now check if it's any kind of
     # GlobusError
-    elif isinstance(exception, exc.GlobusError):
+    elif isinstance(exception, globus_sdk.GlobusError):
         globus_generic_hook(exception)
 
     # if it's a click exception, re-raise as original -- Click's main

--- a/src/globus_cli/safeio/errors.py
+++ b/src/globus_cli/safeio/errors.py
@@ -1,7 +1,6 @@
 import json
 
 import click
-from globus_sdk.base import safe_stringify
 
 from globus_cli.safeio.get_option_vals import outformat_is_json
 
@@ -16,8 +15,8 @@ class PrintableErrorField:
 
     def __init__(self, name, value, multiline=False):
         self.multiline = multiline
-        self.name = safe_stringify(name)
-        self.raw_value = safe_stringify(value)
+        self.name = str(name)
+        self.raw_value = str(value)
         self.value = self._format_value(self.raw_value)
 
     @property

--- a/src/globus_cli/safeio/output_formatter.py
+++ b/src/globus_cli/safeio/output_formatter.py
@@ -2,7 +2,7 @@ import json
 import textwrap
 
 import click
-from globus_sdk import GlobusResponse
+from globus_sdk import GlobusHTTPResponse
 
 from globus_cli.safeio.awscli_text import unix_formatted_print
 from globus_cli.safeio.get_option_vals import (
@@ -10,6 +10,7 @@ from globus_cli.safeio.get_option_vals import (
     outformat_is_json,
     outformat_is_unix,
 )
+from globus_cli.stub_response import CLIStubResponse
 
 # make sure this is a tuple
 # if it's a list, pylint will freak out
@@ -94,7 +95,7 @@ def _key_to_keyfunc(k):
 def _jmespath_preprocess(res):
     jmespath_expr = get_jmespath_expression()
 
-    if isinstance(res, GlobusResponse):
+    if isinstance(res, (CLIStubResponse, GlobusHTTPResponse)):
         res = res.data
 
     if not isinstance(res, str):

--- a/src/globus_cli/services/recursive_ls.py
+++ b/src/globus_cli/services/recursive_ls.py
@@ -4,8 +4,6 @@ import logging
 import time
 from collections import deque
 
-from globus_sdk.services.transfer.paging import PaginatedResource
-
 logger = logging.getLogger(__name__)
 
 # constants for controlling rate limiting
@@ -13,14 +11,16 @@ SLEEP_FREQUENCY = 25
 SLEEP_LEN = 1
 
 
-class RecursiveLsResponse(PaginatedResource):
+class RecursiveLsResponse:
     """
     Response class for recursive_operation_ls
-    Uses PaginatedResource logic for iterating over potentially very
-    large file systems without keeping the whole filesystem in memory,
-    but rather than using Globus paging uses an internal queue
-    for BFS of the filesystem.
-    Rate limits calls to prevent getting back connection errors.
+
+    Used for iterating over potentially very large file systems without keeping the
+    whole filesystem tree in memory.
+
+    Uses an internal queue for BFS of the filesystem.
+
+    Rate limits calls to reduce the changes of connection errors.
     """
 
     def __init__(self, client, endpoint_id, max_depth, filter_after_first, ls_params):
@@ -72,6 +72,10 @@ class RecursiveLsResponse(PaginatedResource):
             # express this internally as "generator is null" -- just need some
             # way of making sure that it's clear
             self.generator = None
+
+    def __iter__(self):
+        yield self.first_elem
+        yield from self.generator
 
     def iterable_func(self):
         """

--- a/src/globus_cli/services/recursive_ls.py
+++ b/src/globus_cli/services/recursive_ls.py
@@ -4,8 +4,7 @@ import logging
 import time
 from collections import deque
 
-from globus_sdk.response import GlobusResponse
-from globus_sdk.transfer.paging import PaginatedResource
+from globus_sdk.services.transfer.paging import PaginatedResource
 
 logger = logging.getLogger(__name__)
 
@@ -141,4 +140,4 @@ class RecursiveLsResponse(PaginatedResource):
             # the relative path popped from the queue, and yield the item
             for item in res_data:
                 item["name"] = (rel_path + "/" if rel_path else "") + item["name"]
-                yield GlobusResponse(item)
+                yield item

--- a/src/globus_cli/stub_response.py
+++ b/src/globus_cli/stub_response.py
@@ -1,0 +1,11 @@
+class CLIStubResponse:
+    """
+    A stub response class to make arbitrary data accessible in a way similar to a
+    GlobusHTTPResponse object.
+    """
+
+    def __init__(self, data):
+        self.data = data
+
+    def __getitem__(self, key):
+        return self.data[key]

--- a/src/globus_cli/tokenstore.py
+++ b/src/globus_cli/tokenstore.py
@@ -1,0 +1,144 @@
+import os
+import sys
+
+import globus_sdk
+from globus_sdk.tokenstorage import SQLiteAdapter
+
+from .config import invalidate_old_config
+
+# internal constants
+_CLIENT_DATA_CONFIG_KEY = "auth_client_data"
+
+# env vars used throughout this module
+GLOBUS_ENV = os.environ.get("GLOBUS_SDK_ENVIRONMENT")
+GLOBUS_PROFILE = os.environ.get("GLOBUS_PROFILE")
+
+
+def _template_client_id():
+    template_id = "95fdeba8-fac2-42bd-a357-e068d82ff78e"
+    if GLOBUS_ENV:
+        template_id = {
+            "sandbox": "33b6a241-bce4-4359-9c6d-09f88b3c9eef",
+            "integration": "e0c31fd1-663b-44e1-840f-f4304bb9ee7a",
+            "test": "0ebfd058-452f-40c3-babf-5a6b16a7b337",
+            "staging": "3029c3cb-c8d9-4f2b-979c-c53330aa7327",
+            "preview": "b2867dbb-0846-4579-8486-dc70763d700b",
+        }.get(GLOBUS_ENV, template_id)
+    return template_id
+
+
+def internal_native_client():
+    """
+    This is the client that represents the CLI itself (prior to templating)
+    """
+    template_id = _template_client_id()
+    return globus_sdk.NativeAppAuthClient(
+        template_id, app_name="Globus CLI (native client)"
+    )
+
+
+def _get_data_dir():
+    # get the dir to store Globus CLI data
+    #
+    # on Windows, the datadir is typically
+    #   ~\AppData\Local\globus\cli
+    #
+    # on Linux and macOS, we use
+    #   ~/.globus/cli/
+    #
+    # This is not necessarily a match with XDG_DATA_HOME or macOS use of
+    # '~/Library/Application Support'. The simplified directories for non-Windows
+    # platforms will allow easier access to the dir if necessary in support of users
+    if sys.platform == "win32":
+        # try to get the app data dir, preferring the local appdata
+        datadir = os.getenv("LOCALAPPDATA", os.getenv("APPDATA"))
+        if not datadir:
+            home = os.path.expanduser("~")
+            datadir = os.path.join(home, "AppData", "Local")
+        return os.path.join(datadir, "globus", "cli")
+    return os.path.expanduser("~/.globus/cli/")
+
+
+def _ensure_data_dir():
+    dirname = _get_data_dir()
+    try:
+        os.makedirs(dirname)
+    except FileExistsError:
+        pass
+    return dirname
+
+
+def _get_storage_filename():
+    datadir = _ensure_data_dir()
+    return os.path.join(datadir, "storage.db")
+
+
+def _resolve_namespace():
+    env = GLOBUS_ENV if GLOBUS_ENV else "DEFAULT"
+    if GLOBUS_PROFILE:
+        return f"{env}/{GLOBUS_PROFILE}"
+    return env
+
+
+def token_storage_adapter():
+    if not hasattr(token_storage_adapter, "_instance"):
+        # when initializing the token storage adapter, check if the storage file exists
+        # if it does not, then use this as a flag to clean the old config
+        fname = _get_storage_filename()
+        if not os.path.exists(fname):
+            invalidate_old_config(internal_native_client())
+        # namespace is equal to the current environment
+        token_storage_adapter._instance = SQLiteAdapter(
+            fname, namespace=_resolve_namespace()
+        )
+    return token_storage_adapter._instance
+
+
+def internal_auth_client():
+    """
+    Pull template client credentials from storage and use them to create a
+    ConfidentialAppAuthClient.
+    In the event that credentials are not found, template a new client via the Auth API,
+    save the credentials for that client, and then build and return the
+    ConfidentialAppAuthClient.
+    """
+    adapter = token_storage_adapter()
+    client_data = adapter.read_config(_CLIENT_DATA_CONFIG_KEY)
+    if client_data is not None:
+        client_id = client_data["client_id"]
+        client_secret = client_data["client_secret"]
+    else:
+        # register a new instance client with auth
+        nc = internal_native_client()
+        res = nc.post(
+            "/v2/api/clients",
+            data={"client": {"template_id": nc.client_id, "name": "Globus CLI"}},
+        )
+        # get values and write to config
+        credential_data = res["included"]["client_credential"]
+        client_id = credential_data["client"]
+        client_secret = credential_data["secret"]
+
+        adapter.store_config(
+            _CLIENT_DATA_CONFIG_KEY,
+            {"client_id": client_id, "client_secret": client_secret},
+        )
+
+    return globus_sdk.ConfidentialAppAuthClient(
+        client_id, client_secret, app_name="Globus CLI"
+    )
+
+
+def delete_templated_client():
+    adapter = token_storage_adapter()
+
+    # first, get the templated credentialed client
+    ac = internal_auth_client()
+
+    # now, remove its relevant data from storage
+    adapter.remove_config(_CLIENT_DATA_CONFIG_KEY)
+
+    # finally, try to delete via the API
+    # note that this could raise an exception if the creds are already invalid -- the
+    # caller may or may not want to ignore, so allow it to raise from here
+    ac.delete(f"/v2/api/clients/{ac.client_id}")

--- a/src/globus_cli/tokenstore.py
+++ b/src/globus_cli/tokenstore.py
@@ -75,10 +75,16 @@ def _get_storage_filename():
 
 
 def _resolve_namespace():
-    env = GLOBUS_ENV if GLOBUS_ENV else "DEFAULT"
-    if GLOBUS_PROFILE:
-        return f"{env}/{GLOBUS_PROFILE}"
-    return env
+    env = GLOBUS_ENV if GLOBUS_ENV else "production"
+    # namespace any user profile so that non-user namespaces may be used in the future
+    # e.g. for client-credentials authenticated use of the CLI
+    #
+    # expected namespaces are
+    #
+    #     userprofile/production     (default)
+    #     userprofile/sandbox        (env is set to sandbox, profile is unset)
+    #     userprofile/test/myprofile (env is set to test, profile is set to myprofile)
+    return "userprofile/" + (f"{env}/{GLOBUS_PROFILE}" if GLOBUS_PROFILE else env)
 
 
 def token_storage_adapter():

--- a/src/globus_cli/tokenstore.py
+++ b/src/globus_cli/tokenstore.py
@@ -56,7 +56,8 @@ def _get_data_dir():
             home = os.path.expanduser("~")
             datadir = os.path.join(home, "AppData", "Local")
         return os.path.join(datadir, "globus", "cli")
-    return os.path.expanduser("~/.globus/cli/")
+    else:
+        return os.path.expanduser("~/.globus/cli/")
 
 
 def _ensure_data_dir():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 import responses
 from click.testing import CliRunner
 from globus_sdk.tokenstorage import SQLiteAdapter
-from globus_sdk.transport import RetryPolicy
+from globus_sdk.transport import RequestsTransport
 from globus_sdk.utils import slash_join
 from ruamel.yaml import YAML
 
@@ -258,13 +258,14 @@ def load_api_fixtures(register_api_route, test_file_dir, go_ep1_id, go_ep2_id, t
 
 @pytest.fixture(autouse=True)
 def disable_client_retries(monkeypatch):
-    class NoRetryPolicy(RetryPolicy):
-        def register_default_checks(self):
-            pass
+    class NoRetryTransport(RequestsTransport):
+        DEFAULT_MAX_RETRIES = 0
 
-    monkeypatch.setattr(globus_sdk.TransferClient, "retry_policy", NoRetryPolicy())
-    monkeypatch.setattr(globus_sdk.AuthClient, "retry_policy", NoRetryPolicy())
-    monkeypatch.setattr(globus_sdk.NativeAppAuthClient, "retry_policy", NoRetryPolicy())
+    monkeypatch.setattr(globus_sdk.TransferClient, "transport_class", NoRetryTransport)
+    monkeypatch.setattr(globus_sdk.AuthClient, "transport_class", NoRetryTransport)
     monkeypatch.setattr(
-        globus_sdk.ConfidentialAppAuthClient, "retry_policy", NoRetryPolicy()
+        globus_sdk.NativeAppAuthClient, "transport_class", NoRetryTransport
+    )
+    monkeypatch.setattr(
+        globus_sdk.ConfidentialAppAuthClient, "transport_class", NoRetryTransport
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ from globus_sdk.base import slash_join
 from ruamel.yaml import YAML
 
 import globus_cli.config
-from globus_cli.services.transfer import RetryingTransferClient
 
 yaml = YAML()
 log = logging.getLogger(__name__)
@@ -247,9 +246,3 @@ def load_api_fixtures(register_api_route, test_file_dir, go_ep1_id, go_ep2_id, t
         return data
 
     return func
-
-
-@pytest.fixture(autouse=True)
-def _reduce_transfer_client_retries(monkeypatch):
-    """to make tests fail faster on network errors"""
-    monkeypatch.setattr(RetryingTransferClient, "default_retries", 1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,15 @@ import os
 import shlex
 import time
 import urllib.parse
+from unittest import mock
 
+import globus_sdk
 import pytest
 import responses
 from click.testing import CliRunner
-from configobj import ConfigObj
-from globus_sdk.base import slash_join
+from globus_sdk.tokenstorage import SQLiteAdapter
+from globus_sdk.transport import RetryPolicy
+from globus_sdk.utils import slash_join
 from ruamel.yaml import YAML
 
 import globus_cli.config
@@ -33,43 +36,50 @@ def task_id():
 
 
 @pytest.fixture
-def default_test_config():
-    """
-    Returns a ConfigObj with the clitester's refresh tokens as if the
-    clitester was logged in and a call to get_config_obj was made.
-    """
-    # create a ConfgObj from a dict of testing constants. a ConfigObj created
-    # this way will not be tied to a config file on disk, meaning that
-    # ConfigObj.filename = None and ConfigObj.write() returns a string without
-    # writing anything to disk.
-    return ConfigObj(
-        {
-            "cli": {
-                globus_cli.config.CLIENT_ID_OPTNAME: "fakeClientIDString",
-                globus_cli.config.CLIENT_SECRET_OPTNAME: "fakeClientSecret",
-                globus_cli.config.AUTH_RT_OPTNAME: "AuthRT",
-                globus_cli.config.AUTH_AT_OPTNAME: "AuthAT",
-                globus_cli.config.AUTH_AT_EXPIRES_OPTNAME: int(time.time()) + 120,
-                globus_cli.config.TRANSFER_RT_OPTNAME: "TransferRT",
-                globus_cli.config.TRANSFER_AT_OPTNAME: "TransferAT",
-                globus_cli.config.TRANSFER_AT_EXPIRES_OPTNAME: int(time.time()) + 120,
-            }
-        }
-    )
+def mock_login_token_response():
+    mock_token_res = mock.Mock()
+    mock_token_res.by_resource_server = {
+        "auth.globus.org": {
+            "scope": "openid profile email "
+            "urn:globus:auth:scope:auth.globus.org:view_identity_set",
+            "refresh_token": "AuthRT",
+            "access_token": "AuthAT",
+            "token_type": "bearer",
+            "expires_at_seconds": int(time.time()) + 120,
+            "resource_server": "auth.globus.org",
+        },
+        "transfer.api.globus.org": {
+            "scope": "urn:globus:auth:scope:transfer.api.globus.org:all",
+            "refresh_token": "TransferRT",
+            "access_token": "TransferAT",
+            "token_type": "bearer",
+            "expires_at_seconds": int(time.time()) + 120,
+            "resource_server": "transfer.api.globus.org",
+        },
+    }
+    return mock_token_res
 
 
 @pytest.fixture
-def patch_config(monkeypatch, default_test_config):
-    def func(conf=None):
-        if conf is None:
-            conf = default_test_config
+def test_token_storage(mock_login_token_response):
+    """Put memory-backed sqlite token storage in place for the testsuite to use."""
+    mockstore = SQLiteAdapter(":memory:")
+    mockstore.store_config(
+        "auth_client_data",
+        {"client_id": "fakeClientIDString", "client_secret": "fakeClientSecret"},
+    )
+    mockstore.store(mock_login_token_response)
+    return mockstore
 
-        def mock_get_config():
-            return conf
 
-        monkeypatch.setattr(globus_cli.config, "get_config_obj", mock_get_config)
-
-    return func
+@pytest.fixture(autouse=True)
+def patch_tokenstorage(monkeypatch, test_token_storage):
+    monkeypatch.setattr(
+        globus_cli.tokenstore.token_storage_adapter,
+        "_instance",
+        test_token_storage,
+        raising=False,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -83,7 +93,7 @@ def cli_runner():
 
 
 @pytest.fixture
-def run_line(cli_runner, request, patch_config):
+def run_line(cli_runner, request, patch_tokenstorage):
     """
     Uses the CliRunner to run the given command line.
 
@@ -96,10 +106,8 @@ def run_line(cli_runner, request, patch_config):
     for easier debugging.
     """
 
-    def func(line, config=None, assert_exit_code=0, stdin=None):
+    def func(line, assert_exit_code=0, stdin=None):
         from globus_cli import main
-
-        patch_config(config)
 
         # split line into args and confirm line starts with "globus"
         args = shlex.split(line)
@@ -246,3 +254,17 @@ def load_api_fixtures(register_api_route, test_file_dir, go_ep1_id, go_ep2_id, t
         return data
 
     return func
+
+
+@pytest.fixture(autouse=True)
+def disable_client_retries(monkeypatch):
+    class NoRetryPolicy(RetryPolicy):
+        def register_default_checks(self):
+            pass
+
+    monkeypatch.setattr(globus_sdk.TransferClient, "retry_policy", NoRetryPolicy())
+    monkeypatch.setattr(globus_sdk.AuthClient, "retry_policy", NoRetryPolicy())
+    monkeypatch.setattr(globus_sdk.NativeAppAuthClient, "retry_policy", NoRetryPolicy())
+    monkeypatch.setattr(
+        globus_sdk.ConfidentialAppAuthClient, "retry_policy", NoRetryPolicy()
+    )

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -55,7 +55,7 @@ def test_whoami_no_auth(run_line, load_api_fixtures):
     Runs whoami with config set to be empty, confirms no login seen.
     """
     load_api_fixtures("all_authentication_failed.yaml")
-    result = run_line("globus whoami", config={}, assert_exit_code=1)
+    result = run_line("globus whoami", assert_exit_code=1)
     assert "Unable to get user information" in result.stderr
 
 
@@ -76,7 +76,6 @@ def test_auth_call_no_auth(run_line, load_api_fixtures):
     load_api_fixtures("all_authentication_failed.yaml")
     result = run_line(
         "globus get-identities foo@globusid.org",
-        config={},
         assert_exit_code=1,
     )
     assert "No Authentication provided." in result.stderr
@@ -99,7 +98,7 @@ def test_transfer_call_no_auth(run_line, load_api_fixtures, go_ep1_id):
     confirms No Authentication CLI error.
     """
     load_api_fixtures("all_authentication_failed.yaml")
-    result = run_line("globus ls " + go_ep1_id, config={}, assert_exit_code=1)
+    result = run_line("globus ls " + go_ep1_id, assert_exit_code=1)
     assert "No Authentication provided." in result.stderr
 
 

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -2,17 +2,16 @@ from unittest import mock
 
 import globus_sdk
 
-from globus_cli.config import AUTH_RT_OPTNAME, TRANSFER_RT_OPTNAME
 
-
-def test_login_validates_token(run_line, default_test_config):
+def test_login_validates_token(run_line, mock_login_token_response):
     with mock.patch("globus_cli.commands.login.internal_auth_client") as m:
         ac = mock.MagicMock(spec=globus_sdk.NativeAppAuthClient)
         m.return_value = ac
 
         run_line("globus login")
 
-        a_rt = default_test_config["cli"][AUTH_RT_OPTNAME]
-        t_rt = default_test_config["cli"][TRANSFER_RT_OPTNAME]
+        by_rs = mock_login_token_response.by_resource_server
+        a_rt = by_rs["auth.globus.org"]["refresh_token"]
+        t_rt = by_rs["transfer.api.globus.org"]["refresh_token"]
         ac.oauth2_validate_token.assert_any_call(a_rt)
         ac.oauth2_validate_token.assert_any_call(t_rt)

--- a/tests/functional/test_rm.py
+++ b/tests/functional/test_rm.py
@@ -3,8 +3,6 @@ import json
 import pytest
 import responses
 
-import globus_cli.services.transfer
-
 
 @pytest.fixture
 def patch_sleep(monkeypatch):
@@ -13,7 +11,7 @@ def patch_sleep(monkeypatch):
     def mock_sleep(*args, **kwargs):
         sleep_calls.append((args, kwargs))
 
-    monkeypatch.setattr(globus_cli.services.transfer.time, "sleep", mock_sleep)
+    monkeypatch.setattr("time.sleep", mock_sleep)
 
     return sleep_calls
 

--- a/tests/unit/test_bookmark_helpers.py
+++ b/tests/unit/test_bookmark_helpers.py
@@ -2,7 +2,7 @@ import uuid
 from unittest import mock
 
 import pytest
-from globus_sdk.exc import TransferAPIError
+from globus_sdk import TransferAPIError
 
 from globus_cli.commands.bookmark.helpers import resolve_id_or_name
 


### PR DESCRIPTION
I probably shouldn't have included the initial tokenstorage work in this, but I don't think it's worth backing it out.

- Update to use SDK v3.0 alphas (3.0a4 only in the last commit) and adapt various usages
- Switch to using tokenstorage (more on this below)
- Update to wrap paginators and such as necessary

There are a lot of small/minor tweaks throughout. e.g.  `globus_sdk.exc.TransferAPIError` -> `globus_sdk.TransferAPIError`

In order to not screw up our local dev workflow too much, the tokenstorage work will revoke tokens on first run only. Once the DB file exists, it won't try to do this again. So, you can try the new version, login, switch back to CLI v2, login again, and then both versions will work harmoniously thereafter.

Without trying overzealously to handle ever eventuality, I've also added an `--ignore-errors` flag to the logout command. That way, we can make the default behavior to fail if revocation fails, but have an easy bypass if users want to delete credentials from disk.

@rudyardrichter, @aaschaer, ideally, I wouldn't be dropping this as such a massive changeset. However, I would prefer to roll forward with it -- assuming we're comfortable with the tokenstorage behavior as a "first cut" -- and get it merged as-is rather than tying myself in knots to try to pick it apart into more bite-sized PRs. If we land this, we can move `main` incrementally to continue to keep pace with any new SDK alphas or betas.