### PR TITLE
Update to SDK v3.0b2; refactor excepthooks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.6",
     install_requires=[
-        "globus-sdk==3.0.0b1",
+        "globus-sdk==3.0.0b2",
         "click>=7.1.1,<8.0",
         "jmespath==0.10.0",
         "requests>=2.0.0,<3.0.0",

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -174,7 +174,9 @@ def delete_command(
         delete_data.add_item(path)
 
     if dry_run:
-        formatted_print(delete_data, response_key="DATA", fields=[("Path", "path")])
+        formatted_print(
+            delete_data.data, response_key="DATA", fields=[("Path", "path")]
+        )
         # exit safely
         return
 

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -422,7 +422,7 @@ def transfer_command(
 
     if dry_run:
         formatted_print(
-            transfer_data,
+            transfer_data.data,
             response_key="DATA",
             fields=(
                 ("Source Path", "source_path"),

--- a/src/globus_cli/parsing/excepthook.py
+++ b/src/globus_cli/parsing/excepthook.py
@@ -7,6 +7,7 @@ format an exception.
 Define an except hook per exception type that we want to treat specially,
 generally types of SDK errors, and dispatch onto tht set of hooks.
 """
+import functools
 import sys
 
 import click
@@ -16,39 +17,51 @@ import globus_sdk
 from globus_cli.parsing.command_state import CommandState
 from globus_cli.safeio import PrintableErrorField, write_error_info
 
+_REGISTERED_HOOKS = []
 
-def exit_with_mapped_status(http_status):
+
+def globusapi_excepthook(condition):
+    """decorator for excepthooks
+
+    register each one, in order, with any relevant "condition"
     """
-    Given an HTTP Status, exit with either an error status of 1 or the
-    status mapped by what we were given.
-    """
-    # get the mapping by looking up the state and getting the mapping attr
-    mapping = click.get_current_context().ensure_object(CommandState).http_status_map
 
-    # if there is a mapped exit code, exit with that. Otherwise, exit 1
-    if http_status in mapping:
-        sys.exit(mapping[http_status])
-    else:
-        sys.exit(1)
+    def inner_decorator(fn):
+        @functools.wraps(fn)
+        def wrapped(exception):
+            fn(exception)
+            # get the mapping by looking up the state and getting the mapping attr
+            mapping = (
+                click.get_current_context().ensure_object(CommandState).http_status_map
+            )
+
+            # if there is a mapped exit code, exit with that. Otherwise, exit 1
+            if exception.http_status in mapping:
+                sys.exit(mapping[exception.http_status])
+            sys.exit(1)
+
+        _REGISTERED_HOOKS.append((wrapped, condition))
+        return wrapped
+
+    return inner_decorator
 
 
+@globusapi_excepthook(lambda err: err.info.authorization_parameters)
 def session_hook(exception):
     """
-    Expects an exception with an authorization_paramaters field in its raw_json
+    Expects an exception with a valid authorization_paramaters info field
     """
     click.echo(
         "The resource you are trying to access requires you to "
         "re-authenticate with specific identities."
     )
 
-    params = exception.raw_json["authorization_parameters"]
-    message = params.get("session_message")
+    message = exception.info.authorization_parameters.session_message
     if message:
         click.echo(f"message: {message}")
 
-    identities = params.get("session_required_identities")
-    domains = params.get("session_required_single_domain")
-
+    identities = exception.info.authorization_parameters.session_required_identities
+    domains = exception.info.authorization_parameters.session_required_single_domain
     if identities or domains:
         click.echo(
             (
@@ -63,18 +76,15 @@ def session_hook(exception):
             "with specific identities"
         )
 
-    exit_with_mapped_status(exception.http_status)
 
-
+@globusapi_excepthook(lambda err: err.info.consent_required)
 def consent_required_hook(exception):
     """
     Expects an exception with a required_scopes field in its raw_json
     """
-    message = exception.raw_json.get("message")
-
     # specialized message for data_access errors
     # otherwise, use more generic phrasing
-    if message == "Missing required data_access consent":
+    if exception.message == "Missing required data_access consent":
         click.echo(
             "The collection you are trying to access data on requires you to "
             "grant consent for the Globus CLI to access it."
@@ -84,15 +94,14 @@ def consent_required_hook(exception):
             "The resource you are trying to access requires you to "
             "consent to additional access for the Globus CLI."
         )
+    click.echo(f"message: {exception.message}")
 
-    required_scopes = exception.raw_json.get("required_scopes")
+    required_scopes = exception.info.consent_required.required_scopes
     if not required_scopes:
         click.secho(
             "Fatal Error: ConsentRequired but no required_scopes!", bold=True, fg="red"
         )
         sys.exit(255)
-    if message:
-        click.echo(f"message: {message}")
 
     click.echo(
         "\nPlease run\n\n"
@@ -101,46 +110,17 @@ def consent_required_hook(exception):
         )
         + "to login with the required scopes"
     )
-    exit_with_mapped_status(exception.http_status)
 
 
-def transferapi_hook(exception):
-    write_error_info(
-        "Transfer API Error",
-        [
-            PrintableErrorField("HTTP status", exception.http_status),
-            PrintableErrorField("request_id", exception.request_id),
-            PrintableErrorField("code", exception.code),
-            PrintableErrorField("message", exception.message, multiline=True),
-        ],
+@globusapi_excepthook(
+    lambda err: (
+        (
+            isinstance(err, globus_sdk.TransferAPIError)
+            and err.code == "ClientError.AuthenticationFailed"
+        )
+        or (isinstance(err, globus_sdk.AuthAPIError) and err.code == "UNAUTHORIZED")
     )
-    exit_with_mapped_status(exception.http_status)
-
-
-def authapi_hook(exception):
-    write_error_info(
-        "Auth API Error",
-        [
-            PrintableErrorField("HTTP status", exception.http_status),
-            PrintableErrorField("code", exception.code),
-            PrintableErrorField("message", exception.message, multiline=True),
-        ],
-    )
-    exit_with_mapped_status(exception.http_status)
-
-
-def globusapi_hook(exception):
-    write_error_info(
-        "Globus API Error",
-        [
-            PrintableErrorField("HTTP status", exception.http_status),
-            PrintableErrorField("code", exception.code),
-            PrintableErrorField("message", exception.message, multiline=True),
-        ],
-    )
-    exit_with_mapped_status(exception.http_status)
-
-
+)
 def authentication_hook(exception):
     write_error_info(
         "No Authentication Error",
@@ -154,9 +134,25 @@ def authentication_hook(exception):
             "you have logged in with 'globus login'."
         ),
     )
-    exit_with_mapped_status(exception.http_status)
 
 
+@globusapi_excepthook(lambda err: isinstance(err, globus_sdk.TransferAPIError))
+def transferapi_hook(exception):
+    write_error_info(
+        "Transfer API Error",
+        [
+            PrintableErrorField("HTTP status", exception.http_status),
+            PrintableErrorField("request_id", exception.request_id),
+            PrintableErrorField("code", exception.code),
+            PrintableErrorField("message", exception.message, multiline=True),
+        ],
+    )
+
+
+@globusapi_excepthook(
+    lambda err: isinstance(err, globus_sdk.AuthAPIError)
+    and err.message == "invalid_grant"
+)
 def invalidrefresh_hook(exception):
     write_error_info(
         "Invalid Refresh Token",
@@ -170,18 +166,30 @@ def invalidrefresh_hook(exception):
             "valid. Please log in again with 'globus login'."
         ),
     )
-    exit_with_mapped_status(exception.http_status)
 
 
-def globus_generic_hook(exception):
+@globusapi_excepthook(lambda err: isinstance(err, globus_sdk.AuthAPIError))
+def authapi_hook(exception):
     write_error_info(
-        "Globus Error",
+        "Auth API Error",
         [
-            PrintableErrorField("error_type", exception.__class__.__name__),
-            PrintableErrorField("message", str(exception), multiline=True),
+            PrintableErrorField("HTTP status", exception.http_status),
+            PrintableErrorField("code", exception.code),
+            PrintableErrorField("message", exception.message, multiline=True),
         ],
     )
-    sys.exit(1)
+
+
+@globusapi_excepthook(lambda err: True)  # catch-all
+def globusapi_hook(exception):
+    write_error_info(
+        "Globus API Error",
+        [
+            PrintableErrorField("HTTP status", exception.http_status),
+            PrintableErrorField("code", exception.code),
+            PrintableErrorField("message", exception.message, multiline=True),
+        ],
+    )
 
 
 def custom_except_hook(exc_info):
@@ -201,63 +209,35 @@ def custom_except_hook(exc_info):
 
     # we're not in debug mode, do custom handling
 
-    # catch any session errors to give helpful instructions
-    # on how to use globus session update
-    if (
-        isinstance(exception, globus_sdk.GlobusAPIError)
-        and exception.raw_json
-        and "authorization_parameters" in exception.raw_json
-    ):
-        session_hook(exception)
+    if isinstance(exception, globus_sdk.GlobusAPIError):
+        for (handler, condition) in _REGISTERED_HOOKS:
+            if not condition(exception):
+                continue
+            handler(exception)
 
-    # catch any consent required errors to give helpful instructions
-    # on how to use `globus session update --consents`
-    if (
-        isinstance(exception, globus_sdk.GlobusAPIError)
-        and exception.raw_json
-        and exception.raw_json.get("code") == "ConsentRequired"
-    ):
-        consent_required_hook(exception)
-
-    # handle the Globus-raised errors with our special hooks
-    # these will present the output (on stderr) as JSON
-    elif isinstance(exception, globus_sdk.TransferAPIError):
-        if exception.code == "ClientError.AuthenticationFailed":
-            authentication_hook(exception)
-        else:
-            transferapi_hook(exception)
-
-    elif isinstance(exception, globus_sdk.AuthAPIError):
-        if exception.code == "UNAUTHORIZED":
-            authentication_hook(exception)
-        # invalid_grant occurs when the users refresh tokens are not valid
-        elif exception.message == "invalid_grant":
-            invalidrefresh_hook(exception)
-        else:
-            authapi_hook(exception)
-
-    elif isinstance(exception, globus_sdk.GlobusAPIError):
-        globusapi_hook(exception)
-
-    # specific checks fell through -- now check if it's any kind of
-    # GlobusError
-    elif isinstance(exception, globus_sdk.GlobusError):
-        globus_generic_hook(exception)
+    # specific checks fell through -- now check if it's any kind of GlobusError
+    if isinstance(exception, globus_sdk.GlobusError):
+        write_error_info(
+            "Globus Error",
+            [
+                PrintableErrorField("error_type", exception.__class__.__name__),
+                PrintableErrorField("message", str(exception), multiline=True),
+            ],
+        )
+        sys.exit(1)
 
     # if it's a click exception, re-raise as original -- Click's main
     # execution context will handle pretty-printing
-    elif isinstance(
+    if isinstance(
         exception, (click.ClickException, click.exceptions.Abort, click.exceptions.Exit)
     ):
         raise exception.with_traceback(traceback)
 
     # not a GlobusError, not a ClickException -- something like ValueError
-    # or NotImplementedError bubbled all the way up here: just print it
-    # out, basically
-    else:
-        click.echo(
-            "{}: {}".format(
-                click.style(exception_type.__name__, bold=True, fg="red"), exception
-            )
+    # or NotImplementedError bubbled all the way up here: just print it out
+    click.echo(
+        "{}: {}".format(
+            click.style(exception_type.__name__, bold=True, fg="red"), exception
         )
-        sys.exit(1)
+    )
+    sys.exit(1)


### PR DESCRIPTION
Update to 3.0b2 for the SDK. Adjust dry-run variants of transfer and delete commands to pull the `.data` attribute (inner dict) from the helper objects.

Update the excepthooks in two ways:
1. Use a decorator to write them in a more declarative style
2. Use the new error `info` attributes for consent_required and authorization_parameters parsing

---

Aside: since I'll be out of the office for ~2 weeks, it's fine by me if you decide to make changes and then merge without waiting for feedback, in order to get the update done.