### PR TITLE
Add requires_login decorator

### DIFF
--- a/src/globus_cli/commands/bookmark/create.py
+++ b/src/globus_cli/commands/bookmark/create.py
@@ -1,8 +1,9 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command
 from globus_cli.safeio import formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -32,6 +33,7 @@ $ globus bookmark create \
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
 @click.argument("bookmark_name")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def bookmark_create(endpoint_plus_path, bookmark_name):
     """
     Create a new bookmark. Given an endpoint plus a path, and a name for the bookmark,

--- a/src/globus_cli/commands/bookmark/delete.py
+++ b/src/globus_cli/commands/bookmark/delete.py
@@ -1,9 +1,10 @@
 import click
 
 from globus_cli.commands.bookmark.helpers import resolve_id_or_name
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -22,6 +23,7 @@ $ globus bookmark delete "Bookmark Name"
     short_help="Delete a bookmark",
 )
 @click.argument("bookmark_id_or_name")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def bookmark_delete(bookmark_id_or_name):
     """
     Delete one bookmark, given its ID or name.

--- a/src/globus_cli/commands/bookmark/list.py
+++ b/src/globus_cli/commands/bookmark/list.py
@@ -1,8 +1,10 @@
 from globus_sdk import TransferAPIError
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command
 from globus_cli.safeio import formatted_print
 from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
     display_name_or_cname,
     get_client,
     iterable_response_to_dict,
@@ -34,6 +36,7 @@ $ globus bookmark list --jmespath='DATA[*].[name, endpoint_id]' --format=unix
 """,
     short_help="List your bookmarks",
 )
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def bookmark_list():
     """List all bookmarks for the current user"""
     client = get_client()

--- a/src/globus_cli/commands/bookmark/rename.py
+++ b/src/globus_cli/commands/bookmark/rename.py
@@ -1,9 +1,10 @@
 import click
 
 from globus_cli.commands.bookmark.helpers import resolve_id_or_name
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command
 from globus_cli.safeio import formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -23,6 +24,7 @@ $ globus bookmark rename oldname newname
 )
 @click.argument("bookmark_id_or_name")
 @click.argument("new_bookmark_name")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def bookmark_rename(bookmark_id_or_name, new_bookmark_name):
     """Change a bookmark's name"""
     client = get_client()

--- a/src/globus_cli/commands/bookmark/show.py
+++ b/src/globus_cli/commands/bookmark/show.py
@@ -1,9 +1,10 @@
 import click
 
 from globus_cli.commands.bookmark.helpers import resolve_id_or_name
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print, is_verbose
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -30,6 +31,7 @@ $ globus ls "$(globus bookmark show BOOKMARK_NAME)"
     short_help="Resolve a bookmark name or ID to an endpoint:path",
 )
 @click.argument("bookmark_id_or_name")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def bookmark_show(bookmark_id_or_name):
     """
     Given a single bookmark ID or bookmark name, show the bookmark details. By default,

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -1,6 +1,7 @@
 import click
 from globus_sdk import DeleteData
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import (
     ENDPOINT_PLUS_OPTPATH,
     TaskPath,
@@ -15,7 +16,11 @@ from globus_cli.safeio import (
     formatted_print,
     term_is_interactive,
 )
-from globus_cli.services.transfer import autoactivate, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    autoactivate,
+    get_client,
+)
 
 
 @command(
@@ -65,6 +70,7 @@ $ globus task wait "$task_id"
 @task_submission_options
 @delete_and_rm_options
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_OPTPATH)
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def delete_command(
     batch,
     ignore_missing,

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -6,9 +6,14 @@ from globus_cli.helpers import (
     fill_delegate_proxy_activation_requirements,
     is_remote_session,
 )
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg, mutex_option_group
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import activation_requirements_help_text, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    activation_requirements_help_text,
+    get_client,
+)
 
 
 @command(
@@ -112,6 +117,7 @@ $ globus endpoint activate $ep_id --myproxy -U username
     help="Force activation even if endpoint is already activated.",
 )
 @mutex_option_group("--web", "--myproxy", "--delegate-proxy")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def endpoint_activate(
     endpoint_id,
     myproxy,

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -1,5 +1,6 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import (
     ENDPOINT_PLUS_REQPATH,
     command,
@@ -8,7 +9,12 @@ from globus_cli.parsing import (
     validate_endpoint_create_and_update_params,
 )
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print
-from globus_cli.services.transfer import assemble_generic_doc, autoactivate, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    assemble_generic_doc,
+    autoactivate,
+    get_client,
+)
 
 COMMON_FIELDS = [("Message", "message"), ("Endpoint ID", "id")]
 
@@ -68,6 +74,7 @@ $ globus endpoint create --shared host_ep:~/ my_shared_endpoint
         "--server."
     ),
 )
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def endpoint_create(**kwargs):
     """
     Create a new endpoint.

--- a/src/globus_cli/commands/endpoint/deactivate.py
+++ b/src/globus_cli/commands/endpoint/deactivate.py
@@ -1,6 +1,7 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -16,6 +17,7 @@ $ globus endpoint deactivate $ep_id
 """,
 )
 @endpoint_id_arg
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def endpoint_deactivate(endpoint_id):
     """
     Remove the credential previously assigned to an endpoint via

--- a/src/globus_cli/commands/endpoint/delete.py
+++ b/src/globus_cli/commands/endpoint/delete.py
@@ -1,6 +1,7 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -14,6 +15,7 @@ $ globus endpoint delete $ep_id
 """,
 )
 @endpoint_id_arg
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def endpoint_delete(endpoint_id):
     """Delete a given endpoint.
 

--- a/src/globus_cli/commands/endpoint/is_activated.py
+++ b/src/globus_cli/commands/endpoint/is_activated.py
@@ -1,8 +1,13 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import formatted_print
-from globus_cli.services.transfer import activation_requirements_help_text, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    activation_requirements_help_text,
+    get_client,
+)
 
 
 @command(
@@ -77,6 +82,7 @@ fi
         "since Epoch), not a number of seconds into the future."
     ),
 )
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def endpoint_is_activated(endpoint_id, until, absolute_time):
     """
     Check if an endpoint is activated or requires activation.

--- a/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
+++ b/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
@@ -1,6 +1,11 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import formatted_print
-from globus_cli.services.transfer import ENDPOINT_LIST_FIELDS, get_client
+from globus_cli.services.transfer import (
+    ENDPOINT_LIST_FIELDS,
+    TRANSFER_RESOURCE_SERVER,
+    get_client,
+)
 
 
 @command(
@@ -14,6 +19,7 @@ $ globus endpoint my-shared-endpoint-list $ep_id
 """,
 )
 @endpoint_id_arg
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def my_shared_endpoint_list(endpoint_id):
     """
     Show a list of all shared endpoints hosted on the target endpoint for which the user

--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -1,9 +1,14 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command, security_principal_opts
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print
-from globus_cli.services.auth import maybe_lookup_identity_id
-from globus_cli.services.transfer import assemble_generic_doc, get_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, maybe_lookup_identity_id
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    assemble_generic_doc,
+    get_client,
+)
 
 
 @command(
@@ -46,6 +51,7 @@ $ globus endpoint permission create $ep_id:/ --permissions rw --identity go@glob
     help="A custom message to add to email notifications",
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
+@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
 def create_command(
     principal, permissions, endpoint_plus_path, notify_email, notify_message
 ):

--- a/src/globus_cli/commands/endpoint/permission/delete.py
+++ b/src/globus_cli/commands/endpoint/permission/delete.py
@@ -1,8 +1,9 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -18,6 +19,7 @@ $ globus endpoint permission delete $ep_id $rule_id
 )
 @endpoint_id_arg
 @click.argument("rule_id")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def delete_command(endpoint_id, rule_id):
     """
     Delete an existing access control rule, removing whatever permissions it previously

--- a/src/globus_cli/commands/endpoint/permission/list.py
+++ b/src/globus_cli/commands/endpoint/permission/list.py
@@ -1,9 +1,10 @@
 from globus_sdk import IdentityMap
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import formatted_print
-from globus_cli.services.auth import get_auth_client
-from globus_cli.services.transfer import get_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -17,6 +18,7 @@ $ globus endpoint permission list $ep_id
 """,
 )
 @endpoint_id_arg
+@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
 def list_command(endpoint_id):
     """List all rules in an endpoint's access control list."""
     client = get_client()

--- a/src/globus_cli/commands/endpoint/permission/show.py
+++ b/src/globus_cli/commands/endpoint/permission/show.py
@@ -1,9 +1,10 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print
-from globus_cli.services.auth import lookup_identity_name
-from globus_cli.services.transfer import get_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, lookup_identity_name
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 def _shared_with_keyfunc(rule):
@@ -28,6 +29,7 @@ $ globus endpoint permission show $ep_id $rule_id
 )
 @endpoint_id_arg
 @click.argument("rule_id")
+@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
 def show_command(endpoint_id, rule_id):
     """
     Show detailed information about a single access control rule on an endpoint.

--- a/src/globus_cli/commands/endpoint/permission/update.py
+++ b/src/globus_cli/commands/endpoint/permission/update.py
@@ -1,8 +1,13 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import assemble_generic_doc, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    assemble_generic_doc,
+    get_client,
+)
 
 
 @command(
@@ -26,6 +31,7 @@ $ globus endpoint permission update $ep_id $rule_id --permissions r
     type=click.Choice(("r", "rw"), case_sensitive=False),
     help="Permissions to add. Read-Only or Read/Write",
 )
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def update_command(permissions, rule_id, endpoint_id):
     """
     Update an existing access control rule's permissions.

--- a/src/globus_cli/commands/endpoint/role/create.py
+++ b/src/globus_cli/commands/endpoint/role/create.py
@@ -1,9 +1,14 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg, security_principal_opts
 from globus_cli.safeio import formatted_print
-from globus_cli.services.auth import maybe_lookup_identity_id
-from globus_cli.services.transfer import assemble_generic_doc, get_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, maybe_lookup_identity_id
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    assemble_generic_doc,
+    get_client,
+)
 
 
 @command(
@@ -34,6 +39,7 @@ $ globus endpoint role create 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
     ),
     help="A role to assign.",
 )
+@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
 def role_create(role, principal, endpoint_id):
     """
     Create a role on an endpoint.

--- a/src/globus_cli/commands/endpoint/role/delete.py
+++ b/src/globus_cli/commands/endpoint/role/delete.py
@@ -1,6 +1,7 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg, role_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -19,6 +20,7 @@ $ globus endpoint role delete 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
 )
 @endpoint_id_arg
 @role_id_arg
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def role_delete(role_id, endpoint_id):
     """
     Remove a role from an endpoint.

--- a/src/globus_cli/commands/endpoint/role/list.py
+++ b/src/globus_cli/commands/endpoint/role/list.py
@@ -1,9 +1,10 @@
 from globus_sdk import IdentityMap
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import formatted_print
-from globus_cli.services.auth import get_auth_client
-from globus_cli.services.transfer import get_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -29,6 +30,7 @@ $ globus endpoint role list 'ddb59aef-6d04-11e5-ba46-22000b92c6ec'
 """,
 )
 @endpoint_id_arg
+@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
 def role_list(endpoint_id):
     """
     List the assigned roles on an endpoint.

--- a/src/globus_cli/commands/endpoint/role/show.py
+++ b/src/globus_cli/commands/endpoint/role/show.py
@@ -1,7 +1,8 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg, role_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print
-from globus_cli.services.auth import lookup_identity_name
-from globus_cli.services.transfer import get_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, lookup_identity_name
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 def lookup_principal(role):
@@ -31,6 +32,7 @@ $ globus endpoint role show EP_ID ROLE_ID
 )
 @endpoint_id_arg
 @role_id_arg
+@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
 def role_show(endpoint_id, role_id):
     """
     Show full info for a role on an endpoint.

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -1,11 +1,13 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.paging_wrapper import PagingWrapper
 from globus_cli.parsing import command
 from globus_cli.safeio import formatted_print
-from globus_cli.services.auth import maybe_lookup_identity_id
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, maybe_lookup_identity_id
 from globus_cli.services.transfer import (
     ENDPOINT_LIST_FIELDS,
+    TRANSFER_RESOURCE_SERVER,
     get_client,
     iterable_response_to_dict,
 )
@@ -69,6 +71,7 @@ $ globus endpoint search --filter-scope my-endpoints
     help="The maximum number of results to return.",
 )
 @click.argument("filter_fulltext", required=False)
+@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
 def endpoint_search(filter_fulltext, limit, filter_owner_id, filter_scope):
     """
     Search for Globus endpoints with search filters. If --filter-scope is set to the

--- a/src/globus_cli/commands/endpoint/server/add.py
+++ b/src/globus_cli/commands/endpoint/server/add.py
@@ -1,6 +1,11 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg, server_add_and_update_opts
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import assemble_generic_doc, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    assemble_generic_doc,
+    get_client,
+)
 
 
 @command(
@@ -17,6 +22,7 @@ $ globus endpoint server add $ep_id --hostname gridftp.example.org
 )
 @endpoint_id_arg
 @server_add_and_update_opts(add=True)
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def server_add(
     endpoint_id,
     subject,

--- a/src/globus_cli/commands/endpoint/server/delete.py
+++ b/src/globus_cli/commands/endpoint/server/delete.py
@@ -2,9 +2,14 @@ from textwrap import dedent
 
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import get_client, get_endpoint_w_server_list
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    get_client,
+    get_endpoint_w_server_list,
+)
 
 
 def _spec_to_matches(server_list, server_spec, mode):
@@ -62,6 +67,7 @@ $ globus endpoint server delete $ep_id $server_id
 )
 @endpoint_id_arg
 @click.argument("server")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def server_delete(endpoint_id, server):
     """
     Delete a server belonging to an endpoint.

--- a/src/globus_cli/commands/endpoint/server/list.py
+++ b/src/globus_cli/commands/endpoint/server/list.py
@@ -1,6 +1,10 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RECORD, FORMAT_TEXT_TABLE, formatted_print
-from globus_cli.services.transfer import get_endpoint_w_server_list
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    get_endpoint_w_server_list,
+)
 
 
 @command(
@@ -14,6 +18,7 @@ $ globus endpoint server list $ep_id
 """,
 )
 @endpoint_id_arg
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def server_list(endpoint_id):
     """List all servers belonging to an endpoint."""
     # raises usage error on shares for us

--- a/src/globus_cli/commands/endpoint/server/show.py
+++ b/src/globus_cli/commands/endpoint/server/show.py
@@ -1,8 +1,9 @@
 from textwrap import dedent
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg, server_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -18,6 +19,7 @@ $ globus endpoint server show $ep_id $server_id
 )
 @endpoint_id_arg
 @server_id_arg
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def server_show(endpoint_id, server_id):
     """
     Display inofrmation about a server belonging to an endpoint.

--- a/src/globus_cli/commands/endpoint/server/update.py
+++ b/src/globus_cli/commands/endpoint/server/update.py
@@ -1,3 +1,4 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import (
     command,
     endpoint_id_arg,
@@ -5,7 +6,11 @@ from globus_cli.parsing import (
     server_id_arg,
 )
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import assemble_generic_doc, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    assemble_generic_doc,
+    get_client,
+)
 
 
 @command(
@@ -24,6 +29,7 @@ $ globus endpoint server update $ep_id $server_id --scheme ftp
 @server_add_and_update_opts
 @endpoint_id_arg
 @server_id_arg
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def server_update(
     endpoint_id,
     server_id,

--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -2,9 +2,10 @@ import uuid
 
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import EXPLICIT_NULL, command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 class SubscriptionIdType(click.ParamType):
@@ -23,6 +24,7 @@ class SubscriptionIdType(click.ParamType):
 @command("set-subscription-id", short_help="Set an endpoint's subscription")
 @endpoint_id_arg
 @click.argument("SUBSCRIPTION_ID", type=SubscriptionIdType())
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def set_endpoint_subscription_id(**kwargs):
     """
     Set an endpoint's subscription ID.

--- a/src/globus_cli/commands/endpoint/show.py
+++ b/src/globus_cli/commands/endpoint/show.py
@@ -1,10 +1,12 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RECORD, FormatField, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command("show")
 @endpoint_id_arg
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def endpoint_show(endpoint_id):
     """Display a detailed endpoint definition"""
     client = get_client()

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -1,3 +1,4 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import (
     command,
     endpoint_create_and_update_params,
@@ -5,12 +6,17 @@ from globus_cli.parsing import (
     validate_endpoint_create_and_update_params,
 )
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import assemble_generic_doc, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    assemble_generic_doc,
+    get_client,
+)
 
 
 @command("update")
 @endpoint_id_arg
 @endpoint_create_and_update_params(create=False)
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def endpoint_update(**kwargs):
     """Update attributes of an endpoint"""
     # validate params. Requires a get call to check the endpoint type

--- a/src/globus_cli/commands/get_identities.py
+++ b/src/globus_cli/commands/get_identities.py
@@ -1,8 +1,9 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import IdentityType, command
 from globus_cli.safeio import FORMAT_TEXT_TABLE, formatted_print, is_verbose
-from globus_cli.services.auth import get_auth_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
 from globus_cli.stub_response import CLIStubResponse
 
 
@@ -36,6 +37,9 @@ $ globus get-identities --verbose go@globusid.org clitester1a@globusid.org \
     "values", type=IdentityType(allow_b32_usernames=True), required=True, nargs=-1
 )
 @click.option("--provision", hidden=True, is_flag=True)
+@requires_login(
+    AUTH_RESOURCE_SERVER,
+)
 def get_identities_command(values, provision):
     """
     Lookup Globus Auth Identities given one or more uuids

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -1,8 +1,10 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import ENDPOINT_PLUS_OPTPATH, command
 from globus_cli.safeio import formatted_print, is_verbose, outformat_is_text
 from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
     autoactivate,
     get_client,
     iterable_response_to_dict,
@@ -115,6 +117,7 @@ $ globus ls $ep_id:/share/godata/ --filter '~*.txt'  # done with --filter, bette
         "this should behave like a non-recursive `ls`"
     ),
 )
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def ls_command(
     endpoint_plus_path,
     recursive_depth_limit,

--- a/src/globus_cli/commands/mkdir.py
+++ b/src/globus_cli/commands/mkdir.py
@@ -1,8 +1,13 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import autoactivate, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    autoactivate,
+    get_client,
+)
 
 
 @command(
@@ -18,6 +23,7 @@ $ mkdir ep_id:~/testfolder
 """,
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def mkdir_command(endpoint_plus_path):
     """Make a directory on an endpoint at the given path.
 

--- a/src/globus_cli/commands/rename.py
+++ b/src/globus_cli/commands/rename.py
@@ -1,8 +1,13 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import autoactivate, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    autoactivate,
+    get_client,
+)
 
 
 @command(
@@ -20,6 +25,7 @@ $ globus rename $ep_id:~/tempdir $ep_id:~/project-foo
 @endpoint_id_arg
 @click.argument("source", metavar="SOURCE_PATH")
 @click.argument("destination", metavar="DEST_PATH")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def rename_command(endpoint_id, source, destination):
     """Rename a file or directory on an endpoint.
 

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -1,6 +1,7 @@
 import click
 from globus_sdk import DeleteData
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import (
     ENDPOINT_PLUS_REQPATH,
     command,
@@ -9,7 +10,12 @@ from globus_cli.parsing import (
     task_submission_options,
 )
 from globus_cli.safeio import err_is_terminal, formatted_print, term_is_interactive
-from globus_cli.services.transfer import autoactivate, get_client, task_wait_with_io
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    autoactivate,
+    get_client,
+    task_wait_with_io,
+)
 
 
 @command(
@@ -36,6 +42,7 @@ $ globus rm $ep_id:~/mydir --recursive
 @delete_and_rm_options(supports_batch=False, default_enable_globs=True)
 @synchronous_task_wait_options
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def rm_command(
     ignore_missing,
     star_silent,

--- a/src/globus_cli/commands/session/show.py
+++ b/src/globus_cli/commands/session/show.py
@@ -2,9 +2,10 @@ import time
 
 import globus_sdk
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command
 from globus_cli.safeio import formatted_print, print_command_hint
-from globus_cli.services.auth import get_auth_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
 from globus_cli.tokenstore import internal_auth_client, token_storage_adapter
 
 
@@ -32,6 +33,7 @@ $ globus session show --format json
 ----
 """,
 )
+@requires_login(AUTH_RESOURCE_SERVER)
 def session_show():
     """List all identities in your current CLI auth session.
 

--- a/src/globus_cli/commands/session/update.py
+++ b/src/globus_cli/commands/session/update.py
@@ -5,8 +5,9 @@ from globus_cli.helpers import (
     do_local_server_auth_flow,
     is_remote_session,
 )
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import IdentityType, command, no_local_server_option
-from globus_cli.services.auth import get_auth_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
 
 
 def _update_session_params_all_case(identity_set, session_params):
@@ -79,6 +80,7 @@ def _update_session_params_identities_case(identity_set, session_params, identit
     is_flag=True,
     help="Add every identity in your identity set to your session",
 )
+@requires_login(AUTH_RESOURCE_SERVER)
 def session_update(identities, no_local_server, all):
     """
     Update your current CLI auth session by authenticating

--- a/src/globus_cli/commands/task/cancel.py
+++ b/src/globus_cli/commands/task/cancel.py
@@ -1,8 +1,9 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, task_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -44,6 +45,7 @@ $ globus task cancel --all
 @click.option(
     "--all", "-a", is_flag=True, help="Cancel all in-progress tasks that you own"
 )
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def cancel_task(all, task_id):
     """
     Cancel a task you own or all tasks which you own.

--- a/src/globus_cli/commands/task/event_list.py
+++ b/src/globus_cli/commands/task/event_list.py
@@ -2,10 +2,15 @@ import json
 
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.paging_wrapper import PagingWrapper
 from globus_cli.parsing import command, task_id_arg
 from globus_cli.safeio import formatted_print
-from globus_cli.services.transfer import get_client, iterable_response_to_dict
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    get_client,
+    iterable_response_to_dict,
+)
 
 
 @command(
@@ -37,6 +42,7 @@ $ globus task pause-info TASK_ID --format JSON
 @click.option("--limit", default=10, show_default=True, help="Limit number of results.")
 @click.option("--filter-errors", is_flag=True, help="Filter results to errors")
 @click.option("--filter-non-errors", is_flag=True, help="Filter results to non errors")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def task_event_list(task_id, limit, filter_errors, filter_non_errors):
     """
     This command shows the recent events for a running task.

--- a/src/globus_cli/commands/task/generate_submission_id.py
+++ b/src/globus_cli/commands/task/generate_submission_id.py
@@ -1,6 +1,7 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command
 from globus_cli.safeio import FORMAT_TEXT_RAW, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 
 @command(
@@ -18,6 +19,7 @@ $ globus transfer --submission-id "$sub_id" ...
 ----
 """,
 )
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def generate_submission_id():
     """
     Generate a new task submission ID for use in  `globus transfer` and `gloubs delete`.

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -1,9 +1,14 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.paging_wrapper import PagingWrapper
 from globus_cli.parsing import command
 from globus_cli.safeio import formatted_print
-from globus_cli.services.transfer import get_client, iterable_response_to_dict
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    get_client,
+    iterable_response_to_dict,
+)
 
 
 def _format_date_callback(ctx, param, value):
@@ -142,6 +147,7 @@ globus task list --format=unix --jmespath='DATA[*].[task_id, status]' | \
     callback=_format_date_callback,
     help="Filter results to tasks that were completed before given time.",
 )
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def task_list(
     limit,
     filter_task_id,

--- a/src/globus_cli/commands/task/pause_info.py
+++ b/src/globus_cli/commands/task/pause_info.py
@@ -1,8 +1,9 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, task_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print
-from globus_cli.services.transfer import get_client
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
 
 EXPLICIT_PAUSE_MSG_FIELDS = [
     ("Source Endpoint", "source_pause_message"),
@@ -66,6 +67,7 @@ $ globus task pause-info TASK_ID --format JSON
 """,
 )
 @task_id_arg
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def task_pause_info(task_id):
     """
     Show messages from activity managers who have explicitly paused the given

--- a/src/globus_cli/commands/task/show.py
+++ b/src/globus_cli/commands/task/show.py
@@ -1,8 +1,13 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, mutex_option_group, task_id_arg
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print
-from globus_cli.services.transfer import get_client, iterable_response_to_dict
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    get_client,
+    iterable_response_to_dict,
+)
 
 COMMON_FIELDS = [
     ("Label", "label"),
@@ -156,6 +161,7 @@ $ globus task show TASK_ID
     ),
 )
 @mutex_option_group("--successful-transfers", "--skipped-errors")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def show_task(successful_transfers, skipped_errors, task_id):
     """
     Print information detailing the status and other info about a task.

--- a/src/globus_cli/commands/task/update.py
+++ b/src/globus_cli/commands/task/update.py
@@ -1,8 +1,13 @@
 import click
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, task_id_arg
 from globus_cli.safeio import formatted_print
-from globus_cli.services.transfer import assemble_generic_doc, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    assemble_generic_doc,
+    get_client,
+)
 
 
 @command(
@@ -24,6 +29,7 @@ $ globus task update TASK_ID --label 'my task updated by me' \
 @task_id_arg
 @click.option("--label", help="New Label for the task")
 @click.option("--deadline", help="New Deadline for the task")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def update_task(deadline, label, task_id):
     """
     Update label and/or deadline on an active task.

--- a/src/globus_cli/commands/task/wait.py
+++ b/src/globus_cli/commands/task/wait.py
@@ -1,5 +1,6 @@
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command, synchronous_task_wait_options, task_id_arg
-from globus_cli.services.transfer import task_wait_with_io
+from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, task_wait_with_io
 
 
 @command(
@@ -31,6 +32,7 @@ $ globus task wait --polling-interval 300 TASK_ID
 )
 @task_id_arg
 @synchronous_task_wait_options
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def task_wait(meow, heartbeat, polling_interval, timeout, task_id, timeout_exit_code):
     """
     Wait for a task to complete.

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -1,6 +1,7 @@
 import click
 from globus_sdk import TransferData
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import (
     ENDPOINT_PLUS_OPTPATH,
     TaskPath,
@@ -10,7 +11,11 @@ from globus_cli.parsing import (
     task_submission_options,
 )
 from globus_cli.safeio import FORMAT_TEXT_RECORD, formatted_print
-from globus_cli.services.transfer import autoactivate, get_client
+from globus_cli.services.transfer import (
+    TRANSFER_RESOURCE_SERVER,
+    autoactivate,
+    get_client,
+)
 
 
 @command(
@@ -217,6 +222,7 @@ fi
 @click.option("--perf-pp", type=int, hidden=True)
 @click.option("--perf-udt", is_flag=True, default=None, hidden=True)
 @mutex_option_group("--recursive", "--external-checksum")
+@requires_login(TRANSFER_RESOURCE_SERVER)
 def transfer_command(
     batch,
     sync_level,

--- a/src/globus_cli/commands/whoami.py
+++ b/src/globus_cli/commands/whoami.py
@@ -1,6 +1,7 @@
 import click
 from globus_sdk import AuthAPIError
 
+from globus_cli.login_manager import requires_login
 from globus_cli.parsing import command
 from globus_cli.safeio import (
     FORMAT_TEXT_RECORD,
@@ -8,7 +9,7 @@ from globus_cli.safeio import (
     is_verbose,
     print_command_hint,
 )
-from globus_cli.services.auth import get_auth_client
+from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
 
 
 @command(
@@ -52,6 +53,7 @@ $ globus whoami --linked-identities
     is_flag=True,
     help="Also show identities linked to the currently logged-in primary identity.",
 )
+@requires_login(AUTH_RESOURCE_SERVER)
 def whoami_command(linked_identities):
     """
     Display information for the currently logged-in user.

--- a/src/globus_cli/helpers/auth_flows.py
+++ b/src/globus_cli/helpers/auth_flows.py
@@ -66,9 +66,9 @@ def do_local_server_auth_flow(session_params=None):
         auth_client.oauth2_start_flow(
             refresh_tokens=True, redirect_uri=redirect_uri, requested_scopes=SCOPES
         )
-        additional_params = {"prompt": "login"}
-        additional_params.update(session_params)
-        url = auth_client.oauth2_get_authorize_url(additional_params=additional_params)
+        query_params = {"prompt": "login"}
+        query_params.update(session_params)
+        url = auth_client.oauth2_get_authorize_url(query_params=query_params)
 
         # open web-browser for user to log in, get auth code
         webbrowser.open(url, new=1)

--- a/src/globus_cli/login_manager.py
+++ b/src/globus_cli/login_manager.py
@@ -47,10 +47,7 @@ def requires_login(*args: str, pass_manager: bool = False):
             manager = LoginManager()
 
             # determine the set of resource servers missing logins
-            missing_servers = set()
-            for server_name in resource_servers:
-                if not manager.has_login(server_name):
-                    missing_servers.add(server_name)
+            missing_servers = {s for s in resource_servers if not manager.has_login(s)}
 
             # if we are missing logins, assemble error text
             # text is slightly different for 1, 2, or 3+ missing servers

--- a/src/globus_cli/login_manager.py
+++ b/src/globus_cli/login_manager.py
@@ -1,0 +1,93 @@
+import functools
+
+import click
+
+from .tokenstore import token_storage_adapter
+
+
+class LoginManager:
+    def __init__(self):
+        self._token_storage = token_storage_adapter()
+
+    def has_login(self, resource_server: str):
+        """
+        Determines if the user has a refresh token for the given
+        resource server
+        """
+        tokens = self._token_storage.get_token_data(resource_server)
+        if tokens is None or "refresh_token" not in tokens:
+            return False
+
+        return True
+
+
+def requires_login(*args: str, pass_manager: bool = False):
+    """
+    Command decorator for specifying a resource server that the user must have
+    tokens for in order to run the command.
+
+    Simple usage for commands that have static resource needs: simply list all
+    needed resource servers as args:
+
+    @requries_login("auth.globus.org")
+
+    @requires_login("auth.globus.org", "transfer.api.globus.org")
+
+    Usage for commands which have dynamic resource servers depending
+    on the arguments passed to the command (e.g. commands for the GCS API)
+
+    @requies_login(pass_manager=True)
+    def command(login_manager, endpoint_id)
+
+        login_manager.<do the thing>(endpoint_id)
+
+    """
+    resource_servers = args
+
+    def inner(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            manager = LoginManager()
+
+            # determine the set of resource servers missing logins
+            missing_servers = set()
+            for server_name in resource_servers:
+                if not manager.has_login(server_name):
+                    missing_servers.add(server_name)
+
+            # if we are missing logins, assemble error text
+            # text is slightly different for 1, 2, or 3+ missing servers
+            if missing_servers:
+
+                if len(missing_servers) == 1:
+                    plural_string = ""
+                    server_string = missing_servers.pop()
+
+                elif len(missing_servers) == 2:
+                    plural_string = "s"
+                    server_string = "{} and {}".format(
+                        missing_servers.pop(), missing_servers.pop()
+                    )
+
+                else:
+                    plural_string = "s"
+                    single_server = missing_servers.pop()
+                    server_string = ", ".join(missing_servers) + ", and {}".format(
+                        single_server
+                    )
+
+                raise click.ClickException(
+                    "Missing login{} for {}, please run 'globus login'".format(
+                        plural_string, server_string
+                    )
+                )
+
+            # if pass_manager is True, pass it as an additional positional arg
+            if pass_manager:
+                return func(*args, manager, **kwargs)
+            else:
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return inner

--- a/src/globus_cli/login_manager.py
+++ b/src/globus_cli/login_manager.py
@@ -15,10 +15,7 @@ class LoginManager:
         resource server
         """
         tokens = self._token_storage.get_token_data(resource_server)
-        if tokens is None or "refresh_token" not in tokens:
-            return False
-
-        return True
+        return tokens is not None and "refresh_token" in tokens
 
 
 def requires_login(*args: str, pass_manager: bool = False):

--- a/src/globus_cli/services/auth.py
+++ b/src/globus_cli/services/auth.py
@@ -8,6 +8,9 @@ from globus_cli.tokenstore import internal_auth_client, token_storage_adapter
 # what qualifies as a valid Identity Name?
 _IDENTITY_NAME_REGEX = r"^[a-zA-Z0-9]+.*@[a-zA-z0-9-]+\..*[a-zA-Z]+$"
 
+# constant for token and login management
+AUTH_RESOURCE_SERVER = "auth.globus.org"
+
 
 def _is_uuid(s):
     try:

--- a/src/globus_cli/services/transfer.py
+++ b/src/globus_cli/services/transfer.py
@@ -14,6 +14,9 @@ from globus_cli.tokenstore import internal_auth_client, token_storage_adapter
 
 log = logging.getLogger(__name__)
 
+# constant for token and login management
+TRANSFER_RESOURCE_SERVER = "transfer.api.globus.org"
+
 
 class CustomTransferClient(TransferClient):
     # TDOD: Remove this function when endpoints natively support recursive ls

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -1,0 +1,116 @@
+import re
+from unittest.mock import patch
+
+import click
+import pytest
+
+from globus_cli.login_manager import requires_login
+
+
+def mock_get_tokens(resource_server):
+    fake_tokens = {
+        "a.globus.org": {
+            "access_token": "fake_a_access_token",
+            "refresh_token": "fake_a_refresh_token",
+        },
+        "b.globus.org": {
+            "access_token": "fake_b_access_token",
+            "refresh_token": "fake_b_refresh_token",
+        },
+    }
+
+    return fake_tokens.get(resource_server)
+
+
+@patch("globus_cli.tokenstore.token_storage_adapter")
+def test_requires_login_success(mock_get_adapter):
+    mock_get_adapter._instance.get_token_data = mock_get_tokens
+
+    # single server
+    @requires_login("a.globus.org")
+    def dummy_command():
+        return True
+
+    assert dummy_command()
+
+
+@patch("globus_cli.tokenstore.token_storage_adapter")
+def test_requires_login_multi_server_success(mock_get_adapter):
+    mock_get_adapter._instance.get_token_data = mock_get_tokens
+
+    @requires_login("a.globus.org", "b.globus.org")
+    def dummy_command():
+        return True
+
+    assert dummy_command()
+
+
+@patch("globus_cli.tokenstore.token_storage_adapter")
+def test_requires_login_single_server_fail(mock_get_adapter):
+    mock_get_adapter._instance.get_token_data = mock_get_tokens
+
+    @requires_login("c.globus.org")
+    def dummy_command():
+        return True
+
+    with pytest.raises(click.ClickException) as ex:
+        dummy_command()
+
+    assert str(ex.value) == (
+        "Missing login for c.globus.org, please run 'globus login'"
+    )
+
+
+@patch("globus_cli.tokenstore.token_storage_adapter")
+def test_requires_login_fail_two_servers(mock_get_adapter):
+    mock_get_adapter._instance.get_token_data = mock_get_tokens
+
+    @requires_login("c.globus.org", "d.globus.org")
+    def dummy_command():
+        return True
+
+    with pytest.raises(click.ClickException) as ex:
+        dummy_command()
+
+    assert re.match(
+        "Missing logins for ..globus.org and ..globus.org, "
+        "please run 'globus login'",
+        str(ex.value),
+    )
+    for server in ("c.globus.org", "d.globus.org"):
+        assert server in str(ex.value)
+
+
+@patch("globus_cli.tokenstore.token_storage_adapter")
+def test_requires_login_fail_multi_server(mock_get_adapter):
+    mock_get_adapter._instance.get_token_data = mock_get_tokens
+
+    @requires_login("c.globus.org", "d.globus.org", "e.globus.org")
+    def dummy_command():
+        return True
+
+    with pytest.raises(click.ClickException) as ex:
+        dummy_command()
+
+    assert re.match(
+        "Missing logins for ..globus.org, ..globus.org, "
+        "and ..globus.org, please run 'globus login'",
+        str(ex.value),
+    )
+    for server in ("c.globus.org", "d.globus.org", "e.globus.org"):
+        assert server in str(ex.value)
+
+
+@patch("globus_cli.tokenstore.token_storage_adapter")
+def test_requires_login_pass_manager(mock_get_adapter):
+    mock_get_adapter._instance.get_token_data = mock_get_tokens
+
+    @requires_login(pass_manager=True)
+    def dummy_command(manager):
+
+        assert manager.has_login("a.globus.org")
+        assert not manager.has_login("c.globus.org")
+
+        return True
+
+    assert dummy_command

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -113,4 +113,4 @@ def test_requires_login_pass_manager(mock_get_adapter):
 
         return True
 
-    assert dummy_command
+    assert dummy_command()


### PR DESCRIPTION
For https://app.clubhouse.io/globus/story/9065/add-a-first-draft-of-cli-loginmanager-component-providing-requires-login-decorator

As we discussed this doesn't fully handle gcs login logic, but it should provide the framework needed for that via the pass_manager option and the LoginManager class.

Two questions came up while I was applying the decorator to our commands, which both kinda boil down to will the user always have tokens scoped for auth in this new incremental login world
1. Many commands only need auth tokens if they are given a username they need to resolve to an id, do we want to make auth a hard requirement for those?
2. whoami and session commands introspect the auth token, but presumably they could use a token for any resource server, would we want to do something like introspect the first token found in storage?