### PR TITLE
Add string listifying helpers

### DIFF
--- a/src/globus_cli/login_manager.py
+++ b/src/globus_cli/login_manager.py
@@ -3,6 +3,7 @@ import functools
 import click
 
 from .tokenstore import token_storage_adapter
+from .utils import format_list_of_words, format_plural_str
 
 
 class LoginManager:
@@ -52,28 +53,13 @@ def requires_login(*args: str, pass_manager: bool = False):
             # if we are missing logins, assemble error text
             # text is slightly different for 1, 2, or 3+ missing servers
             if missing_servers:
-
-                if len(missing_servers) == 1:
-                    plural_string = ""
-                    server_string = missing_servers.pop()
-
-                elif len(missing_servers) == 2:
-                    plural_string = "s"
-                    server_string = "{} and {}".format(
-                        missing_servers.pop(), missing_servers.pop()
-                    )
-
-                else:
-                    plural_string = "s"
-                    single_server = missing_servers.pop()
-                    server_string = ", ".join(missing_servers) + ", and {}".format(
-                        single_server
-                    )
+                server_string = format_list_of_words(*missing_servers)
+                message_prefix = format_plural_str(
+                    "Missing {login}", {"login": "logins"}, len(missing_servers) != 1
+                )
 
                 raise click.ClickException(
-                    "Missing login{} for {}, please run 'globus login'".format(
-                        plural_string, server_string
-                    )
+                    message_prefix + f" for {server_string}, please run 'globus login'"
                 )
 
             # if pass_manager is True, pass it as an additional positional arg

--- a/src/globus_cli/parsing/mutex_group.py
+++ b/src/globus_cli/parsing/mutex_group.py
@@ -3,6 +3,8 @@ import typing
 
 import click
 
+from ..utils import format_list_of_words
+
 
 class MutexInfo:
     def __init__(self, opt, param=None, present=None):
@@ -61,10 +63,7 @@ def mutex_option_group(*options: typing.Union[str, MutexInfo]):
                 if opt.is_present(kwargs):
                     found_opts.append(opt)
             if len(found_opts) > 1:
-                if len(opt_infos) == 2:
-                    option_str = "{} and {}".format(*opt_infos)
-                else:
-                    option_str = ", ".join(opt_infos[:-1]) + f", and {opt_infos[-1]}"
+                option_str = format_list_of_words(*opt_infos)
                 raise click.UsageError(f"{option_str} are mutually exclusive")
             return func(*args, **kwargs)
 

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -1,0 +1,34 @@
+from typing import Dict
+
+
+def format_list_of_words(first: str, *rest: str):
+    if not rest:
+        return first
+    if len(rest) == 1:
+        return f"{first} and {rest[0]}"
+    return ", ".join([first] + list(rest[:-1])) + f", and {rest[-1]}"
+
+
+def format_plural_str(formatstr: str, pluralizable: Dict[str, str], use_plural: bool):
+    """
+    Format text with singular or plural forms of words. Use the singular forms as
+    keys in the format string.
+
+    Usage:
+
+    >>> command_list = [...]
+    >>> fmtstr = "you need to run {this} {command}:"
+    >>> print(
+    ...     format_plural_str(
+    ...         fmtstr,
+    ...         {"this": "these", "command": "commands"},
+    ...         len(command_list) == 1
+    ...     )
+    ... )
+    >>> print("  " + "\n  ".join(command_list))
+    """
+    argdict = {
+        singular: plural if use_plural else singular
+        for singular, plural in pluralizable.items()
+    }
+    return formatstr.format(**argdict)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,18 @@
+from globus_cli.utils import format_list_of_words, format_plural_str
+
+
+def test_format_word_list():
+    assert format_list_of_words("alpha") == "alpha"
+    assert format_list_of_words("alpha", "beta") == "alpha and beta"
+    assert format_list_of_words("alpha", "beta", "gamma") == "alpha, beta, and gamma"
+    assert (
+        format_list_of_words("alpha", "beta", "gamma", "delta")
+        == "alpha, beta, gamma, and delta"
+    )
+
+
+def test_format_plural_str():
+    fmt = "you need to run {this} {command}"
+    wordforms = {"this": "these", "command": "commands"}
+    assert format_plural_str(fmt, wordforms, True) == "you need to run these commands"
+    assert format_plural_str(fmt, wordforms, False) == "you need to run this command"


### PR DESCRIPTION
Used by login_manager and mutex options.

I thought we had needed this formatting elsewhere in the CLI but these were the only cases I could find.