### PR TITLE
Don't declare wheels as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[bdist_wheel]
-universal = 1
-
-
 [isort]
 profile = black
 


### PR DESCRIPTION
Corollary to https://github.com/globus/globus-sdk-python/pull/444