### PR TITLE
add determine_endpoint_type helper

### DIFF
--- a/src/globus_cli/helpers/endpoint_type.py
+++ b/src/globus_cli/helpers/endpoint_type.py
@@ -1,0 +1,42 @@
+from enum import Enum, auto
+
+
+class EndpointType(Enum):
+    # endpoint / collection types
+    GCP = auto()
+    GCSV5_ENDPOINT = auto()
+    GUEST_COLLECTION = auto()
+    MAPPED_COLLECTION = auto()
+    SHARE = auto()
+    NON_GCSV5_ENDPOINT = auto()  # most likely GCSv4, but not necessarily
+
+
+def determine_endpoint_type(ep_doc: dict) -> EndpointType:
+    """
+    Given an endpoint document from transfer, determine what type of
+    endpoint or collection it is for
+    """
+    if ep_doc["is_globus_connect"] is True:
+        return EndpointType.GCP
+
+    if ep_doc["non_functional"] is True:
+        return EndpointType.GCSV5_ENDPOINT
+
+    shared = ep_doc["host_endpoint_id"] is not None
+
+    if ep_doc["gcs_version"]:
+        major, minor, patch = ep_doc["gcs_version"].split(".")
+        gcsv5 = major == "5"
+    else:
+        gcsv5 = False
+
+    if gcsv5:
+        if shared:
+            return EndpointType.GUEST_COLLECTION
+        else:
+            return EndpointType.MAPPED_COLLECTION
+
+    elif shared:
+        return EndpointType.SHARE
+
+    return EndpointType.NON_GCSV5_ENDPOINT

--- a/src/globus_cli/helpers/endpoint_type.py
+++ b/src/globus_cli/helpers/endpoint_type.py
@@ -16,15 +16,15 @@ class EndpointType(Enum):
         Given an endpoint document from transfer, determine what type of
         endpoint or collection it is for
         """
-        if ep_doc["is_globus_connect"] is True:
+        if ep_doc.get("is_globus_connect") is True:
             return EndpointType.GCP
 
-        if ep_doc["non_functional"] is True:
+        if ep_doc.get("non_functional") is True:
             return EndpointType.GCSV5_ENDPOINT
 
-        shared = ep_doc["host_endpoint_id"] is not None
+        shared = ep_doc.get("host_endpoint_id") is not None
 
-        if ep_doc["gcs_version"]:
+        if ep_doc.get("gcs_version"):
             major, minor, patch = ep_doc["gcs_version"].split(".")
             gcsv5 = major == "5"
         else:

--- a/src/globus_cli/helpers/endpoint_type.py
+++ b/src/globus_cli/helpers/endpoint_type.py
@@ -10,33 +10,33 @@ class EndpointType(Enum):
     SHARE = auto()
     NON_GCSV5_ENDPOINT = auto()  # most likely GCSv4, but not necessarily
 
+    @classmethod
+    def determine_endpoint_type(cls, ep_doc: dict) -> "EndpointType":
+        """
+        Given an endpoint document from transfer, determine what type of
+        endpoint or collection it is for
+        """
+        if ep_doc["is_globus_connect"] is True:
+            return EndpointType.GCP
 
-def determine_endpoint_type(ep_doc: dict) -> EndpointType:
-    """
-    Given an endpoint document from transfer, determine what type of
-    endpoint or collection it is for
-    """
-    if ep_doc["is_globus_connect"] is True:
-        return EndpointType.GCP
+        if ep_doc["non_functional"] is True:
+            return EndpointType.GCSV5_ENDPOINT
 
-    if ep_doc["non_functional"] is True:
-        return EndpointType.GCSV5_ENDPOINT
+        shared = ep_doc["host_endpoint_id"] is not None
 
-    shared = ep_doc["host_endpoint_id"] is not None
-
-    if ep_doc["gcs_version"]:
-        major, minor, patch = ep_doc["gcs_version"].split(".")
-        gcsv5 = major == "5"
-    else:
-        gcsv5 = False
-
-    if gcsv5:
-        if shared:
-            return EndpointType.GUEST_COLLECTION
+        if ep_doc["gcs_version"]:
+            major, minor, patch = ep_doc["gcs_version"].split(".")
+            gcsv5 = major == "5"
         else:
-            return EndpointType.MAPPED_COLLECTION
+            gcsv5 = False
 
-    elif shared:
-        return EndpointType.SHARE
+        if gcsv5:
+            if shared:
+                return EndpointType.GUEST_COLLECTION
+            else:
+                return EndpointType.MAPPED_COLLECTION
 
-    return EndpointType.NON_GCSV5_ENDPOINT
+        elif shared:
+            return EndpointType.SHARE
+
+        return EndpointType.NON_GCSV5_ENDPOINT

--- a/tests/unit/test_endpoint_type.py
+++ b/tests/unit/test_endpoint_type.py
@@ -1,0 +1,23 @@
+import uuid
+
+import pytest
+
+from globus_cli.helpers.endpoint_type import EndpointType
+
+
+@pytest.mark.parametrize(
+    "doc,expected",
+    [
+        ({}, EndpointType.NON_GCSV5_ENDPOINT),
+        ({"is_globus_connect": True}, EndpointType.GCP),
+        ({"non_functional": True}, EndpointType.GCSV5_ENDPOINT),
+        ({"host_endpoint_id": str(uuid.uuid4())}, EndpointType.SHARE),
+        ({"gcs_version": "5.4.1"}, EndpointType.MAPPED_COLLECTION),
+        (
+            {"gcs_version": "5.4.1", "host_endpoint_id": str(uuid.uuid4())},
+            EndpointType.GUEST_COLLECTION,
+        ),
+    ],
+)
+def test_determine_endpoint_type(doc, expected):
+    assert EndpointType.determine_endpoint_type(doc) == expected


### PR DESCRIPTION
Turns out what I mentioned about `gcs_version` being dependent on FEAT parsing is incorrect, we changed it to be set on endpoint document creation time, so this logic should be valid for all 5.3+ GCS installs as soon as they create the endpoint in transfer.

I tested this on live data using a locally modified `globus endpoint show` and everything worked as expected.

I could add unit tests if we want, but I'm not sure they would test anything other than my ability to make dicts that match what this helper is looking for.