### PR TITLE
Reorganize login manager logic to encapsulate login flows and static requirements

### DIFF
--- a/src/globus_cli/commands/bookmark/create.py
+++ b/src/globus_cli/commands/bookmark/create.py
@@ -1,8 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import formatted_print
 
 
@@ -33,7 +33,7 @@ $ globus bookmark create \
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
 @click.argument("bookmark_name")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def bookmark_create(endpoint_plus_path, bookmark_name):
     """
     Create a new bookmark. Given an endpoint plus a path, and a name for the bookmark,

--- a/src/globus_cli/commands/bookmark/delete.py
+++ b/src/globus_cli/commands/bookmark/delete.py
@@ -1,8 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 from ._common import resolve_id_or_name
@@ -24,7 +24,7 @@ $ globus bookmark delete "Bookmark Name"
     short_help="Delete a bookmark",
 )
 @click.argument("bookmark_id_or_name")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def bookmark_delete(bookmark_id_or_name):
     """
     Delete one bookmark, given its ID or name.

--- a/src/globus_cli/commands/bookmark/list.py
+++ b/src/globus_cli/commands/bookmark/list.py
@@ -1,9 +1,8 @@
 from globus_sdk import TransferAPIError
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
     display_name_or_cname,
     get_client,
     iterable_response_to_dict,
@@ -36,7 +35,7 @@ $ globus bookmark list --jmespath='DATA[*].[name, endpoint_id]' --format=unix
 """,
     short_help="List your bookmarks",
 )
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def bookmark_list():
     """List all bookmarks for the current user"""
     client = get_client()

--- a/src/globus_cli/commands/bookmark/rename.py
+++ b/src/globus_cli/commands/bookmark/rename.py
@@ -1,8 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import formatted_print
 
 from ._common import resolve_id_or_name
@@ -25,7 +25,7 @@ $ globus bookmark rename oldname newname
 )
 @click.argument("bookmark_id_or_name")
 @click.argument("new_bookmark_name")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def bookmark_rename(bookmark_id_or_name, new_bookmark_name):
     """Change a bookmark's name"""
     client = get_client()

--- a/src/globus_cli/commands/bookmark/show.py
+++ b/src/globus_cli/commands/bookmark/show.py
@@ -1,8 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print, is_verbose
 
 from ._common import resolve_id_or_name
@@ -32,7 +32,7 @@ $ globus ls "$(globus bookmark show BOOKMARK_NAME)"
     short_help="Resolve a bookmark name or ID to an endpoint:path",
 )
 @click.argument("bookmark_id_or_name")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def bookmark_show(bookmark_id_or_name):
     """
     Given a single bookmark ID or bookmark name, show the bookmark details. By default,

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -1,7 +1,7 @@
 import click
 from globus_sdk import DeleteData
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
     ENDPOINT_PLUS_OPTPATH,
     TaskPath,
@@ -10,11 +10,7 @@ from globus_cli.parsing import (
     shlex_process_stdin,
     task_submission_options,
 )
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    autoactivate,
-    get_client,
-)
+from globus_cli.services.transfer import autoactivate, get_client
 from globus_cli.termio import (
     FORMAT_TEXT_RECORD,
     err_is_terminal,
@@ -70,7 +66,7 @@ $ globus task wait "$task_id"
 @task_submission_options
 @delete_and_rm_options
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_OPTPATH)
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def delete_command(
     batch,
     ignore_missing,

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -2,10 +2,9 @@ import webbrowser
 
 import click
 
-from globus_cli.login_manager import is_remote_session, requires_login
+from globus_cli.login_manager import LoginManager, is_remote_session
 from globus_cli.parsing import command, endpoint_id_arg, mutex_option_group
 from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
     activation_requirements_help_text,
     fill_delegate_proxy_activation_requirements,
     get_client,
@@ -114,7 +113,7 @@ $ globus endpoint activate $ep_id --myproxy -U username
     help="Force activation even if endpoint is already activated.",
 )
 @mutex_option_group("--web", "--myproxy", "--delegate-proxy")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_activate(
     endpoint_id,
     myproxy,

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -1,13 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command, one_use_option
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    assemble_generic_doc,
-    autoactivate,
-    get_client,
-)
+from globus_cli.services.transfer import assemble_generic_doc, autoactivate, get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 from ._common import (
@@ -73,7 +68,7 @@ $ globus endpoint create --shared host_ep:~/ my_shared_endpoint
         "--server."
     ),
 )
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_create(**kwargs):
     """
     Create a new endpoint.

--- a/src/globus_cli/commands/endpoint/deactivate.py
+++ b/src/globus_cli/commands/endpoint/deactivate.py
@@ -1,6 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -17,7 +17,7 @@ $ globus endpoint deactivate $ep_id
 """,
 )
 @endpoint_id_arg
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_deactivate(endpoint_id):
     """
     Remove the credential previously assigned to an endpoint via

--- a/src/globus_cli/commands/endpoint/delete.py
+++ b/src/globus_cli/commands/endpoint/delete.py
@@ -1,6 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -15,7 +15,7 @@ $ globus endpoint delete $ep_id
 """,
 )
 @endpoint_id_arg
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_delete(endpoint_id):
     """Delete a given endpoint.
 

--- a/src/globus_cli/commands/endpoint/is_activated.py
+++ b/src/globus_cli/commands/endpoint/is_activated.py
@@ -1,12 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    activation_requirements_help_text,
-    get_client,
-)
+from globus_cli.services.transfer import activation_requirements_help_text, get_client
 from globus_cli.termio import formatted_print
 
 
@@ -82,7 +78,7 @@ fi
         "since Epoch), not a number of seconds into the future."
     ),
 )
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_is_activated(endpoint_id, until, absolute_time):
     """
     Check if an endpoint is activated or requires activation.

--- a/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
+++ b/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
@@ -1,10 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import (
-    ENDPOINT_LIST_FIELDS,
-    TRANSFER_RESOURCE_SERVER,
-    get_client,
-)
+from globus_cli.services.transfer import ENDPOINT_LIST_FIELDS, get_client
 from globus_cli.termio import formatted_print
 
 
@@ -19,7 +15,7 @@ $ globus endpoint my-shared-endpoint-list $ep_id
 """,
 )
 @endpoint_id_arg
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def my_shared_endpoint_list(endpoint_id):
     """
     Show a list of all shared endpoints hosted on the target endpoint for which the user

--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -1,13 +1,9 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command, security_principal_opts
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, maybe_lookup_identity_id
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    assemble_generic_doc,
-    get_client,
-)
+from globus_cli.services.auth import maybe_lookup_identity_id
+from globus_cli.services.transfer import assemble_generic_doc, get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 
@@ -51,7 +47,7 @@ $ globus endpoint permission create $ep_id:/ --permissions rw --identity go@glob
     help="A custom message to add to email notifications",
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
-@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
 def create_command(
     principal, permissions, endpoint_plus_path, notify_email, notify_message
 ):

--- a/src/globus_cli/commands/endpoint/permission/delete.py
+++ b/src/globus_cli/commands/endpoint/permission/delete.py
@@ -1,8 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -19,7 +19,7 @@ $ globus endpoint permission delete $ep_id $rule_id
 )
 @endpoint_id_arg
 @click.argument("rule_id")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def delete_command(endpoint_id, rule_id):
     """
     Delete an existing access control rule, removing whatever permissions it previously

--- a/src/globus_cli/commands/endpoint/permission/list.py
+++ b/src/globus_cli/commands/endpoint/permission/list.py
@@ -1,9 +1,9 @@
 from globus_sdk import IdentityMap
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.auth import get_auth_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import formatted_print
 
 
@@ -18,7 +18,7 @@ $ globus endpoint permission list $ep_id
 """,
 )
 @endpoint_id_arg
-@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
 def list_command(endpoint_id):
     """List all rules in an endpoint's access control list."""
     client = get_client()

--- a/src/globus_cli/commands/endpoint/permission/show.py
+++ b/src/globus_cli/commands/endpoint/permission/show.py
@@ -1,9 +1,9 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, lookup_identity_name
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.auth import lookup_identity_name
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 
@@ -29,7 +29,7 @@ $ globus endpoint permission show $ep_id $rule_id
 )
 @endpoint_id_arg
 @click.argument("rule_id")
-@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
 def show_command(endpoint_id, rule_id):
     """
     Show detailed information about a single access control rule on an endpoint.

--- a/src/globus_cli/commands/endpoint/permission/update.py
+++ b/src/globus_cli/commands/endpoint/permission/update.py
@@ -1,12 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    assemble_generic_doc,
-    get_client,
-)
+from globus_cli.services.transfer import assemble_generic_doc, get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -31,7 +27,7 @@ $ globus endpoint permission update $ep_id $rule_id --permissions r
     type=click.Choice(("r", "rw"), case_sensitive=False),
     help="Permissions to add. Read-Only or Read/Write",
 )
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def update_command(permissions, rule_id, endpoint_id):
     """
     Update an existing access control rule's permissions.

--- a/src/globus_cli/commands/endpoint/role/create.py
+++ b/src/globus_cli/commands/endpoint/role/create.py
@@ -1,13 +1,9 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg, security_principal_opts
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, maybe_lookup_identity_id
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    assemble_generic_doc,
-    get_client,
-)
+from globus_cli.services.auth import maybe_lookup_identity_id
+from globus_cli.services.transfer import assemble_generic_doc, get_client
 from globus_cli.termio import formatted_print
 
 
@@ -39,7 +35,7 @@ $ globus endpoint role create 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
     ),
     help="A role to assign.",
 )
-@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
 def role_create(role, principal, endpoint_id):
     """
     Create a role on an endpoint.

--- a/src/globus_cli/commands/endpoint/role/delete.py
+++ b/src/globus_cli/commands/endpoint/role/delete.py
@@ -1,6 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 from ._common import role_id_arg
@@ -22,7 +22,7 @@ $ globus endpoint role delete 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
 )
 @endpoint_id_arg
 @role_id_arg
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def role_delete(role_id, endpoint_id):
     """
     Remove a role from an endpoint.

--- a/src/globus_cli/commands/endpoint/role/list.py
+++ b/src/globus_cli/commands/endpoint/role/list.py
@@ -1,9 +1,9 @@
 from globus_sdk import IdentityMap
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.auth import get_auth_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import formatted_print
 
 
@@ -30,7 +30,7 @@ $ globus endpoint role list 'ddb59aef-6d04-11e5-ba46-22000b92c6ec'
 """,
 )
 @endpoint_id_arg
-@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
 def role_list(endpoint_id):
     """
     List the assigned roles on an endpoint.

--- a/src/globus_cli/commands/endpoint/role/show.py
+++ b/src/globus_cli/commands/endpoint/role/show.py
@@ -1,7 +1,7 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, lookup_identity_name
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.auth import lookup_identity_name
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 from ._common import role_id_arg
@@ -34,7 +34,7 @@ $ globus endpoint role show EP_ID ROLE_ID
 )
 @endpoint_id_arg
 @role_id_arg
-@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
 def role_show(endpoint_id, role_id):
     """
     Show full info for a role on an endpoint.

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -1,11 +1,10 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, maybe_lookup_identity_id
+from globus_cli.services.auth import maybe_lookup_identity_id
 from globus_cli.services.transfer import (
     ENDPOINT_LIST_FIELDS,
-    TRANSFER_RESOURCE_SERVER,
     get_client,
     iterable_response_to_dict,
 )
@@ -71,7 +70,7 @@ $ globus endpoint search --filter-scope my-endpoints
     help="The maximum number of results to return.",
 )
 @click.argument("filter_fulltext", required=False)
-@requires_login(AUTH_RESOURCE_SERVER, TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
 def endpoint_search(filter_fulltext, limit, filter_owner_id, filter_scope):
     """
     Search for Globus endpoints with search filters. If --filter-scope is set to the

--- a/src/globus_cli/commands/endpoint/server/add.py
+++ b/src/globus_cli/commands/endpoint/server/add.py
@@ -1,10 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    assemble_generic_doc,
-    get_client,
-)
+from globus_cli.services.transfer import assemble_generic_doc, get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 from ._common import server_add_and_update_opts
@@ -24,7 +20,7 @@ $ globus endpoint server add $ep_id --hostname gridftp.example.org
 )
 @endpoint_id_arg
 @server_add_and_update_opts(add=True)
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def server_add(
     endpoint_id,
     subject,

--- a/src/globus_cli/commands/endpoint/server/delete.py
+++ b/src/globus_cli/commands/endpoint/server/delete.py
@@ -2,9 +2,9 @@ from textwrap import dedent
 
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -63,7 +63,7 @@ $ globus endpoint server delete $ep_id $server_id
 )
 @endpoint_id_arg
 @click.argument("server")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def server_delete(endpoint_id, server):
     """
     Delete a server belonging to an endpoint.

--- a/src/globus_cli/commands/endpoint/server/list.py
+++ b/src/globus_cli/commands/endpoint/server/list.py
@@ -1,6 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, FORMAT_TEXT_TABLE, formatted_print
 
 
@@ -15,7 +15,7 @@ $ globus endpoint server list $ep_id
 """,
 )
 @endpoint_id_arg
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def server_list(endpoint_id):
     """List all servers belonging to an endpoint."""
     client = get_client()

--- a/src/globus_cli/commands/endpoint/server/show.py
+++ b/src/globus_cli/commands/endpoint/server/show.py
@@ -1,8 +1,8 @@
 from textwrap import dedent
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 from ._common import server_id_arg
@@ -21,7 +21,7 @@ $ globus endpoint server show $ep_id $server_id
 )
 @endpoint_id_arg
 @server_id_arg
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def server_show(endpoint_id, server_id):
     """
     Display inofrmation about a server belonging to an endpoint.

--- a/src/globus_cli/commands/endpoint/server/update.py
+++ b/src/globus_cli/commands/endpoint/server/update.py
@@ -1,10 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    assemble_generic_doc,
-    get_client,
-)
+from globus_cli.services.transfer import assemble_generic_doc, get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 from ._common import server_add_and_update_opts, server_id_arg
@@ -26,7 +22,7 @@ $ globus endpoint server update $ep_id $server_id --scheme ftp
 @server_add_and_update_opts
 @endpoint_id_arg
 @server_id_arg
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def server_update(
     endpoint_id,
     server_id,

--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -2,9 +2,9 @@ import uuid
 
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import EXPLICIT_NULL, command, endpoint_id_arg
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -24,7 +24,7 @@ class SubscriptionIdType(click.ParamType):
 @command("set-subscription-id", short_help="Set an endpoint's subscription")
 @endpoint_id_arg
 @click.argument("SUBSCRIPTION_ID", type=SubscriptionIdType())
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def set_endpoint_subscription_id(**kwargs):
     """
     Set an endpoint's subscription ID.

--- a/src/globus_cli/commands/endpoint/show.py
+++ b/src/globus_cli/commands/endpoint/show.py
@@ -1,12 +1,12 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, FormatField, formatted_print
 
 
 @command("show")
 @endpoint_id_arg
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_show(endpoint_id):
     """Display a detailed endpoint definition"""
     client = get_client()

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -1,10 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    assemble_generic_doc,
-    get_client,
-)
+from globus_cli.services.transfer import assemble_generic_doc, get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 from ._common import (
@@ -16,7 +12,7 @@ from ._common import (
 @command("update")
 @endpoint_id_arg
 @endpoint_create_and_update_params(create=False)
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_update(**kwargs):
     """Update attributes of an endpoint"""
     # validate params. Requires a get call to check the endpoint type

--- a/src/globus_cli/commands/get_identities.py
+++ b/src/globus_cli/commands/get_identities.py
@@ -1,8 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import IdentityType, command
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
+from globus_cli.services.auth import get_auth_client
 from globus_cli.termio import FORMAT_TEXT_TABLE, formatted_print, is_verbose
 from globus_cli.utils import CLIStubResponse
 
@@ -37,8 +37,8 @@ $ globus get-identities --verbose go@globusid.org clitester1a@globusid.org \
     "values", type=IdentityType(allow_b32_usernames=True), required=True, nargs=-1
 )
 @click.option("--provision", hidden=True, is_flag=True)
-@requires_login(
-    AUTH_RESOURCE_SERVER,
+@LoginManager.requires_login(
+    LoginManager.AUTH_RS,
 )
 def get_identities_command(values, provision):
     """

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -1,9 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_OPTPATH, command
 from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
     autoactivate,
     get_client,
     iterable_response_to_dict,
@@ -117,7 +116,7 @@ $ globus ls $ep_id:/share/godata/ --filter '~*.txt'  # done with --filter, bette
         "this should behave like a non-recursive `ls`"
     ),
 )
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def ls_command(
     endpoint_plus_path,
     recursive_depth_limit,

--- a/src/globus_cli/commands/mkdir.py
+++ b/src/globus_cli/commands/mkdir.py
@@ -1,12 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    autoactivate,
-    get_client,
-)
+from globus_cli.services.transfer import autoactivate, get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -23,7 +19,7 @@ $ mkdir ep_id:~/testfolder
 """,
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def mkdir_command(endpoint_plus_path):
     """Make a directory on an endpoint at the given path.
 

--- a/src/globus_cli/commands/rename.py
+++ b/src/globus_cli/commands/rename.py
@@ -1,12 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    autoactivate,
-    get_client,
-)
+from globus_cli.services.transfer import autoactivate, get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -25,7 +21,7 @@ $ globus rename $ep_id:~/tempdir $ep_id:~/project-foo
 @endpoint_id_arg
 @click.argument("source", metavar="SOURCE_PATH")
 @click.argument("destination", metavar="DEST_PATH")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def rename_command(endpoint_id, source, destination):
     """Rename a file or directory on an endpoint.
 

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -1,7 +1,7 @@
 import click
 from globus_sdk import DeleteData
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
     ENDPOINT_PLUS_REQPATH,
     command,
@@ -9,11 +9,7 @@ from globus_cli.parsing import (
     synchronous_task_wait_options,
     task_submission_options,
 )
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    autoactivate,
-    get_client,
-)
+from globus_cli.services.transfer import autoactivate, get_client
 from globus_cli.termio import err_is_terminal, formatted_print, term_is_interactive
 
 
@@ -41,7 +37,7 @@ $ globus rm $ep_id:~/mydir --recursive
 @delete_and_rm_options(supports_batch=False, default_enable_globs=True)
 @synchronous_task_wait_options
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def rm_command(
     ignore_missing,
     star_silent,

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -1,10 +1,6 @@
 import click
 
-from globus_cli.login_manager import (
-    do_link_auth_flow,
-    do_local_server_auth_flow,
-    is_remote_session,
-)
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, no_local_server_option
 
 
@@ -25,20 +21,17 @@ def session_consent(scopes, no_local_server):
     """
     session_params = {"scope": " ".join(scopes)}
 
-    # use a link login if remote session or user requested
-    if no_local_server or is_remote_session():
-        do_link_auth_flow(session_params=session_params)
-
-    # otherwise default to a local server login flow
-    else:
-        click.echo(
+    manager = LoginManager()
+    manager.run_login_flow(
+        no_local_server=no_local_server,
+        local_server_message=(
             "You are running 'globus session consent', "
             "which should automatically open a browser window for you to "
             "authenticate with specific identities.\n"
             "If this fails or you experience difficulty, try "
             "'globus session consent --no-local-server'"
             "\n---"
-        )
-        do_local_server_auth_flow(session_params=session_params)
-
-    click.echo("\nYou have successfully updated your CLI session.\n")
+        ),
+        epilog="\nYou have successfully updated your CLI session.\n",
+        session_params=session_params,
+    )

--- a/src/globus_cli/commands/session/show.py
+++ b/src/globus_cli/commands/session/show.py
@@ -3,12 +3,12 @@ import time
 import globus_sdk
 
 from globus_cli.login_manager import (
+    LoginManager,
     internal_auth_client,
-    requires_login,
     token_storage_adapter,
 )
 from globus_cli.parsing import command
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
+from globus_cli.services.auth import get_auth_client
 from globus_cli.termio import formatted_print, print_command_hint
 
 
@@ -36,7 +36,7 @@ $ globus session show --format json
 ----
 """,
 )
-@requires_login(AUTH_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.AUTH_RS)
 def session_show():
     """List all identities in your current CLI auth session.
 
@@ -53,7 +53,7 @@ def session_show():
     except AttributeError:  # if we have no RefreshTokenAuthorizor
         pass
 
-    tokendata = adapter.get_token_data("auth.globus.org")
+    tokendata = adapter.get_token_data(LoginManager.AUTH_RS)
     # if there's no token (e.g. not logged in), stub with empty data
     if not tokendata:
         session_info = {}

--- a/src/globus_cli/commands/task/cancel.py
+++ b/src/globus_cli/commands/task/cancel.py
@@ -1,8 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 from ._common import task_id_arg
@@ -47,7 +47,7 @@ $ globus task cancel --all
 @click.option(
     "--all", "-a", is_flag=True, help="Cancel all in-progress tasks that you own"
 )
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def cancel_task(all, task_id):
     """
     Cancel a task you own or all tasks which you own.

--- a/src/globus_cli/commands/task/event_list.py
+++ b/src/globus_cli/commands/task/event_list.py
@@ -2,13 +2,9 @@ import json
 
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    get_client,
-    iterable_response_to_dict,
-)
+from globus_cli.services.transfer import get_client, iterable_response_to_dict
 from globus_cli.termio import formatted_print
 from globus_cli.utils import PagingWrapper
 
@@ -44,7 +40,7 @@ $ globus task pause-info TASK_ID --format JSON
 @click.option("--limit", default=10, show_default=True, help="Limit number of results.")
 @click.option("--filter-errors", is_flag=True, help="Filter results to errors")
 @click.option("--filter-non-errors", is_flag=True, help="Filter results to non errors")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def task_event_list(task_id, limit, filter_errors, filter_non_errors):
     """
     This command shows the recent events for a running task.

--- a/src/globus_cli/commands/task/generate_submission_id.py
+++ b/src/globus_cli/commands/task/generate_submission_id.py
@@ -1,6 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -19,7 +19,7 @@ $ globus transfer --submission-id "$sub_id" ...
 ----
 """,
 )
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def generate_submission_id():
     """
     Generate a new task submission ID for use in  `globus transfer` and `globus delete`.

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -1,12 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    get_client,
-    iterable_response_to_dict,
-)
+from globus_cli.services.transfer import get_client, iterable_response_to_dict
 from globus_cli.termio import formatted_print
 from globus_cli.utils import PagingWrapper
 
@@ -147,7 +143,7 @@ globus task list --format=unix --jmespath='DATA[*].[task_id, status]' | \
     callback=_format_date_callback,
     help="Filter results to tasks that were completed before given time.",
 )
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def task_list(
     limit,
     filter_task_id,

--- a/src/globus_cli/commands/task/pause_info.py
+++ b/src/globus_cli/commands/task/pause_info.py
@@ -1,8 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 from ._common import task_id_arg
@@ -69,7 +69,7 @@ $ globus task pause-info TASK_ID --format JSON
 """,
 )
 @task_id_arg
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def task_pause_info(task_id):
     """
     Show messages from activity managers who have explicitly paused the given

--- a/src/globus_cli/commands/task/show.py
+++ b/src/globus_cli/commands/task/show.py
@@ -1,12 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, mutex_option_group
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    get_client,
-    iterable_response_to_dict,
-)
+from globus_cli.services.transfer import get_client, iterable_response_to_dict
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 from ._common import task_id_arg
@@ -163,7 +159,7 @@ $ globus task show TASK_ID
     ),
 )
 @mutex_option_group("--successful-transfers", "--skipped-errors")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def show_task(successful_transfers, skipped_errors, task_id):
     """
     Print information detailing the status and other info about a task.

--- a/src/globus_cli/commands/task/update.py
+++ b/src/globus_cli/commands/task/update.py
@@ -1,12 +1,8 @@
 import click
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    assemble_generic_doc,
-    get_client,
-)
+from globus_cli.services.transfer import assemble_generic_doc, get_client
 from globus_cli.termio import formatted_print
 
 from ._common import task_id_arg
@@ -31,7 +27,7 @@ $ globus task update TASK_ID --label 'my task updated by me' \
 @task_id_arg
 @click.option("--label", help="New Label for the task")
 @click.option("--deadline", help="New Deadline for the task")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def update_task(deadline, label, task_id):
     """
     Update label and/or deadline on an active task.

--- a/src/globus_cli/commands/task/wait.py
+++ b/src/globus_cli/commands/task/wait.py
@@ -1,6 +1,6 @@
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, synchronous_task_wait_options
-from globus_cli.services.transfer import TRANSFER_RESOURCE_SERVER, get_client
+from globus_cli.services.transfer import get_client
 
 from ._common import task_id_arg
 
@@ -34,7 +34,7 @@ $ globus task wait --polling-interval 300 TASK_ID
 )
 @task_id_arg
 @synchronous_task_wait_options
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def task_wait(meow, heartbeat, polling_interval, timeout, task_id, timeout_exit_code):
     """
     Wait for a task to complete.

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -1,7 +1,7 @@
 import click
 from globus_sdk import TransferData
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
     ENDPOINT_PLUS_OPTPATH,
     TaskPath,
@@ -10,11 +10,7 @@ from globus_cli.parsing import (
     shlex_process_stdin,
     task_submission_options,
 )
-from globus_cli.services.transfer import (
-    TRANSFER_RESOURCE_SERVER,
-    autoactivate,
-    get_client,
-)
+from globus_cli.services.transfer import autoactivate, get_client
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 
@@ -222,7 +218,7 @@ fi
 @click.option("--perf-pp", type=int, hidden=True)
 @click.option("--perf-udt", is_flag=True, default=None, hidden=True)
 @mutex_option_group("--recursive", "--external-checksum")
-@requires_login(TRANSFER_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def transfer_command(
     batch,
     sync_level,

--- a/src/globus_cli/commands/whoami.py
+++ b/src/globus_cli/commands/whoami.py
@@ -1,9 +1,9 @@
 import click
 from globus_sdk import AuthAPIError
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.auth import AUTH_RESOURCE_SERVER, get_auth_client
+from globus_cli.services.auth import get_auth_client
 from globus_cli.termio import (
     FORMAT_TEXT_RECORD,
     formatted_print,
@@ -53,7 +53,7 @@ $ globus whoami --linked-identities
     is_flag=True,
     help="Also show identities linked to the currently logged-in primary identity.",
 )
-@requires_login(AUTH_RESOURCE_SERVER)
+@LoginManager.requires_login(LoginManager.AUTH_RS)
 def whoami_command(linked_identities):
     """
     Display information for the currently logged-in user.

--- a/src/globus_cli/login_manager/__init__.py
+++ b/src/globus_cli/login_manager/__init__.py
@@ -1,6 +1,5 @@
-from .auth_flows import do_link_auth_flow, do_local_server_auth_flow
 from .local_server import is_remote_session
-from .manager import LoginManager, requires_login
+from .manager import LoginManager
 from .tokenstore import (
     delete_templated_client,
     internal_auth_client,
@@ -9,11 +8,8 @@ from .tokenstore import (
 )
 
 __all__ = [
-    "do_link_auth_flow",
-    "do_local_server_auth_flow",
     "is_remote_session",
     "LoginManager",
-    "requires_login",
     "delete_templated_client",
     "internal_auth_client",
     "internal_native_client",

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -5,14 +5,8 @@ import click
 from .local_server import LocalServerError, start_local_server
 from .tokenstore import internal_auth_client, token_storage_adapter
 
-SCOPES = (
-    "openid profile email "
-    "urn:globus:auth:scope:auth.globus.org:view_identity_set "
-    "urn:globus:auth:scope:transfer.api.globus.org:all"
-)
 
-
-def do_link_auth_flow(session_params=None):
+def do_link_auth_flow(scopes, *, session_params=None):
     """
     Prompts the user with a link to authenticate with globus auth
     and authorize the CLI to act on their behalf.
@@ -26,7 +20,7 @@ def do_link_auth_flow(session_params=None):
     auth_client.oauth2_start_flow(
         redirect_uri=auth_client.base_url + "v2/web/auth-code",
         refresh_tokens=True,
-        requested_scopes=SCOPES,
+        requested_scopes=scopes,
     )
 
     # prompt
@@ -49,7 +43,7 @@ def do_link_auth_flow(session_params=None):
     return True
 
 
-def do_local_server_auth_flow(session_params=None):
+def do_local_server_auth_flow(scopes, *, session_params=None):
     """
     Starts a local http server, opens a browser to have the user authenticate,
     and gets the code redirected to the server (no copy and pasting required)
@@ -64,7 +58,7 @@ def do_local_server_auth_flow(session_params=None):
         # get the ConfidentialApp client object and start a flow
         auth_client = internal_auth_client()
         auth_client.oauth2_start_flow(
-            refresh_tokens=True, redirect_uri=redirect_uri, requested_scopes=SCOPES
+            refresh_tokens=True, redirect_uri=redirect_uri, requested_scopes=scopes
         )
         query_params = {"prompt": "login"}
         query_params.update(session_params)

--- a/src/globus_cli/services/auth.py
+++ b/src/globus_cli/services/auth.py
@@ -8,9 +8,6 @@ from globus_cli.login_manager import internal_auth_client, token_storage_adapter
 # what qualifies as a valid Identity Name?
 _IDENTITY_NAME_REGEX = r"^[a-zA-Z0-9]+.*@[a-zA-z0-9-]+\..*[a-zA-Z]+$"
 
-# constant for token and login management
-AUTH_RESOURCE_SERVER = "auth.globus.org"
-
 
 def _is_uuid(s):
     try:

--- a/src/globus_cli/services/transfer/__init__.py
+++ b/src/globus_cli/services/transfer/__init__.py
@@ -8,9 +8,6 @@ from .data import assemble_generic_doc, display_name_or_cname, iterable_response
 from .delegate_proxy import fill_delegate_proxy_activation_requirements
 from .endpoint_type import EndpointType
 
-# constant for token and login management
-TRANSFER_RESOURCE_SERVER = "transfer.api.globus.org"
-
 ENDPOINT_LIST_FIELDS = (
     ("ID", "id"),
     ("Owner", "owner_string"),
@@ -19,7 +16,6 @@ ENDPOINT_LIST_FIELDS = (
 
 
 __all__ = (
-    "TRANSFER_RESOURCE_SERVER",
     "ENDPOINT_LIST_FIELDS",
     "CustomTransferClient",
     "get_client",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ yaml = YAML()
 log = logging.getLogger(__name__)
 
 
+@pytest.fixture(autouse=True)
+def set_login_manager_testmode():
+    globus_cli.login_manager.LoginManager._TEST_MODE = True
+
+
 @pytest.fixture(scope="session")
 def go_ep1_id():
     return "ddb59aef-6d04-11e5-ba46-22000b92c6ec"

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -2,9 +2,14 @@ from unittest import mock
 
 import globus_sdk
 
+from globus_cli.login_manager import LoginManager
+
 
 def test_login_validates_token(run_line, mock_login_token_response):
-    with mock.patch("globus_cli.commands.login.internal_auth_client") as m:
+    # turn off test mode, to allow token validation
+    LoginManager._TEST_MODE = False
+
+    with mock.patch("globus_cli.login_manager.manager.internal_auth_client") as m:
         ac = mock.MagicMock(spec=globus_sdk.NativeAppAuthClient)
         m.return_value = ac
 

--- a/tests/functional/test_session_update.py
+++ b/tests/functional/test_session_update.py
@@ -5,21 +5,19 @@ import pytest
 
 @pytest.fixture
 def mock_remote_session():
-    with mock.patch("globus_cli.commands.session.update.is_remote_session") as m:
+    with mock.patch("globus_cli.login_manager.manager.is_remote_session") as m:
         yield m
 
 
 @pytest.fixture
 def mock_link_flow():
-    with mock.patch("globus_cli.commands.session.update.do_link_auth_flow") as m:
+    with mock.patch("globus_cli.login_manager.manager.do_link_auth_flow") as m:
         yield m
 
 
 @pytest.fixture
 def mock_local_server_flow():
-    with mock.patch(
-        "globus_cli.commands.session.update.do_local_server_auth_flow"
-    ) as m:
+    with mock.patch("globus_cli.login_manager.manager.do_local_server_auth_flow") as m:
         yield m
 
 

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import click
 import pytest
 
-from globus_cli.login_manager import requires_login
+from globus_cli.login_manager import LoginManager
 
 
 def mock_get_tokens(resource_server):
@@ -27,7 +27,7 @@ def test_requires_login_success(mock_get_adapter):
     mock_get_adapter._instance.get_token_data = mock_get_tokens
 
     # single server
-    @requires_login("a.globus.org")
+    @LoginManager.requires_login("a.globus.org")
     def dummy_command():
         return True
 
@@ -38,7 +38,7 @@ def test_requires_login_success(mock_get_adapter):
 def test_requires_login_multi_server_success(mock_get_adapter):
     mock_get_adapter._instance.get_token_data = mock_get_tokens
 
-    @requires_login("a.globus.org", "b.globus.org")
+    @LoginManager.requires_login("a.globus.org", "b.globus.org")
     def dummy_command():
         return True
 
@@ -49,7 +49,7 @@ def test_requires_login_multi_server_success(mock_get_adapter):
 def test_requires_login_single_server_fail(mock_get_adapter):
     mock_get_adapter._instance.get_token_data = mock_get_tokens
 
-    @requires_login("c.globus.org")
+    @LoginManager.requires_login("c.globus.org")
     def dummy_command():
         return True
 
@@ -65,7 +65,7 @@ def test_requires_login_single_server_fail(mock_get_adapter):
 def test_requires_login_fail_two_servers(mock_get_adapter):
     mock_get_adapter._instance.get_token_data = mock_get_tokens
 
-    @requires_login("c.globus.org", "d.globus.org")
+    @LoginManager.requires_login("c.globus.org", "d.globus.org")
     def dummy_command():
         return True
 
@@ -85,7 +85,7 @@ def test_requires_login_fail_two_servers(mock_get_adapter):
 def test_requires_login_fail_multi_server(mock_get_adapter):
     mock_get_adapter._instance.get_token_data = mock_get_tokens
 
-    @requires_login("c.globus.org", "d.globus.org", "e.globus.org")
+    @LoginManager.requires_login("c.globus.org", "d.globus.org", "e.globus.org")
     def dummy_command():
         return True
 
@@ -105,7 +105,7 @@ def test_requires_login_fail_multi_server(mock_get_adapter):
 def test_requires_login_pass_manager(mock_get_adapter):
     mock_get_adapter._instance.get_token_data = mock_get_tokens
 
-    @requires_login(pass_manager=True)
+    @LoginManager.requires_login(pass_manager=True)
     def dummy_command(manager):
 
         assert manager.has_login("a.globus.org")


### PR DESCRIPTION
This is based on #540 (it is part of the purpose behind that cleanup).
Marking it blocked until that merges. I'll rebase as necessary.

---

This is a "simple" reorg of the login flow logic as follows:
- requires_login, AUTH_RS, and TRANSFER_RS are attributes of the LoginManager class (classmethod and class vars)
- Dispatch between local webserver and text link login flows is always done by LoginManager.run_login_flow. Parameters cover session params and messages printed during the flow.
- LoginManager.is_logged_in_static() provides "check login" functionality for the static token requirements. It includes a token validation callout for each refresh token
- LoginManager._TEST_MODE is a bool (class var) which disables the validation call to simplify testing

The result is simpler imports -- most things that need some kind of login flow can just ask for `from globus_cli.login_manager import LoginManager` and rely on the class attributes for the relevant logic and data.

This should set the stage for us to have extra flags on `run_login_flow()` for passing new required scopes and resource servers. `globus login` would be able to take `--gcs <ID>` to expand to a `manage_collections` scope and pass this through to the `LoginManager`.