### PR TITLE
Fix misspelling typos

### DIFF
--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -35,7 +35,7 @@ $ ep_id=ddb59aef-6d04-11e5-ba46-22000b92c6ec
 $ globus endpoint activate $ep_id --web
 ----
 
-Activate an endpoiont using Myproxy activation, skipping the username prompt.
+Activate an endpoint using Myproxy activation, skipping the username prompt.
 
 [source,bash]
 ----

--- a/src/globus_cli/commands/task/generate_submission_id.py
+++ b/src/globus_cli/commands/task/generate_submission_id.py
@@ -22,7 +22,7 @@ $ globus transfer --submission-id "$sub_id" ...
 @requires_login(TRANSFER_RESOURCE_SERVER)
 def generate_submission_id():
     """
-    Generate a new task submission ID for use in  `globus transfer` and `gloubs delete`.
+    Generate a new task submission ID for use in  `globus transfer` and `globus delete`.
     Submission IDs allow you to safely retry submission of a task in the presence of
     network errors. No matter how many times you submit a task with a given ID, it will
     only be accepted and executed once. The response status may change between

--- a/src/globus_cli/parsing/endpoint_plus_path.py
+++ b/src/globus_cli/parsing/endpoint_plus_path.py
@@ -54,7 +54,7 @@ class EndpointPlusPath(click.ParamType):
         except IndexError:
             path = None
         # coerce path="" to path=None
-        # means that we treat "enpdoint_id" and "endpoint_id:" equivalently
+        # means that we treat "endpoint_id" and "endpoint_id:" equivalently
         path = path or None
 
         if path is None and self.path_required:


### PR DESCRIPTION
The actual PR here is boring, but the meta is interesting.

---

I found these with a bit of an experiment in spellchecking against a known corpus (because `globus` is so frequently typo-ed).

I originally wanted to suggest this as part of our CI setup, but I don't think it's reliable enough yet.
[check-misspellings source](https://github.com/sirosen/check-misspellings)
with a corpus of
```
globus
endpoint
gateway
collection

# avoid incorrect misspelling matches on these words
# 'globus'
globs
# 'collection'
connection
```

If anyone is interested, I'm happy to work on extending this in various ways.