### PR TITLE
Add explicit control for CLI interactivity

### DIFF
--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from distutils.util import strtobool
 
 import click
 
@@ -68,5 +69,11 @@ def err_is_terminal():
     return sys.stderr.isatty()
 
 
-def term_is_interactive():
+def term_is_interactive() -> bool:
+    explicit_val = os.getenv("GLOBUS_CLI_INTERACTIVE")
+    if explicit_val is not None:
+        try:
+            return strtobool(explicit_val.lower())
+        except ValueError:
+            pass
     return os.getenv("PS1") is not None

--- a/tests/unit/test_termio.py
+++ b/tests/unit/test_termio.py
@@ -1,0 +1,32 @@
+import os
+
+import pytest
+
+from globus_cli.termio import term_is_interactive
+
+
+@pytest.mark.parametrize(
+    "ps1, force_flag, expect",
+    [
+        (None, None, False),
+        (None, "TRUE", True),
+        (None, "0", False),
+        ("$ ", None, True),
+        ("$ ", "off", False),
+        ("$ ", "on", True),
+        ("$ ", "", True),
+        ("", "", True),
+        ("", None, True),
+    ],
+)
+def test_term_interactive(ps1, force_flag, expect, monkeypatch):
+    if ps1 is not None:
+        monkeypatch.setitem(os.environ, "PS1", ps1)
+    else:
+        monkeypatch.delitem(os.environ, "PS1", raising=False)
+    if force_flag is not None:
+        monkeypatch.setitem(os.environ, "GLOBUS_CLI_INTERACTIVE", force_flag)
+    else:
+        monkeypatch.delitem(os.environ, "GLOBUS_CLI_INTERACTIVE", raising=False)
+
+    assert term_is_interactive() == expect


### PR DESCRIPTION
The CLI currently uses a heuristic for determining an interactive session of "is PS1 set?"

This has proven solid and accurate for many years, in spite of there not being any standard method for determining if a TTY is interactive.

This PR introduces an explicit flag which can be used to force interactive mode on or off (strtobool conversion). Set `GLOBUS_CLI_INTERACTIVE=0` and you won't get any interactive behaviors.

As the 3.x line will potentially introduce more auto-prompt behaviors, this will be useful for testing, and may prove important for some users as well.