### PR TITLE
Change filter value handling to ignore lists of empty values

### DIFF
--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -166,6 +166,8 @@ def task_list(
 
     def _process_filterval(prefix, value, default=None):
         if value:
+            if isinstance(value, list) and not any(value):
+                return default or ""
             if isinstance(value, str):
                 return f"{prefix}:{value}/"
             return "{}:{}/".format(prefix, ",".join(str(x) for x in value))

--- a/tests/functional/test_task_list.py
+++ b/tests/functional/test_task_list.py
@@ -1,5 +1,14 @@
+import responses
+
+
 def test_task_list_success(run_line, load_api_fixtures):
     load_api_fixtures("task_list.yaml")
     result = run_line("globus task list")
     assert "SUCCEEDED" in result.output
     assert "TRANSFER" in result.output
+    # check that empty filters aren't passed through
+    filters = dict(
+        x.split(":") for x in responses.calls[0].request.params["filter"].split("/")
+    )
+    assert "completion_time" not in filters
+    assert "request_time" not in filters


### PR DESCRIPTION
- Use default or `""` if a list of filter values is all empty strings (`["", ""]` should translate to `""` not `","`)
- Extend `task_list` test to check that completion/request time filters are empty instead of `","`