### PR TITLE
Change --batch flag to take - to specify stdin

### DIFF
--- a/src/globus_cli/parsing/__init__.py
+++ b/src/globus_cli/parsing/__init__.py
@@ -2,7 +2,7 @@ from globus_cli.parsing.commands import command, group, main_group
 from globus_cli.parsing.explicit_null import EXPLICIT_NULL
 from globus_cli.parsing.mutex_group import MutexInfo, mutex_option_group
 from globus_cli.parsing.one_use_option import one_use_option
-from globus_cli.parsing.process_stdin import shlex_process_stdin
+from globus_cli.parsing.process_stdin import shlex_process_stream
 from globus_cli.parsing.shared_options import (
     collection_id_arg,
     delete_and_rm_options,
@@ -46,5 +46,5 @@ __all__ = [
     "synchronous_task_wait_options",
     "security_principal_opts",
     "no_local_server_option",
-    "shlex_process_stdin",
+    "shlex_process_stream",
 ]

--- a/src/globus_cli/parsing/process_stdin.py
+++ b/src/globus_cli/parsing/process_stdin.py
@@ -4,7 +4,7 @@ import sys
 import click
 
 
-def shlex_process_stdin(process_command, helptext):
+def shlex_process_stream(process_command, stream, helptext):
     """
     Use shlex to process stdin line-by-line.
     Also prints help text.
@@ -28,7 +28,7 @@ Terminate input with Ctrl+D or <EOF>
     # use readlines() rather than implicit file read line looping to force
     # python to properly capture EOF (otherwise, EOF acts as a flush and
     # things get weird)
-    for line in sys.stdin.readlines():
+    for line in stream.readlines():
         # get the argument vector:
         # do a shlex split to handle quoted paths with spaces in them
         # also lets us have comments with #

--- a/src/globus_cli/parsing/shared_options.py
+++ b/src/globus_cli/parsing/shared_options.py
@@ -240,12 +240,14 @@ def delete_and_rm_options(
     if supports_batch:
         f = click.option(
             "--batch",
-            is_flag=True,
+            type=click.File("r"),
             help=(
-                "Accept a batch of paths on stdin (i.e. run in "
-                "batchmode). Uses ENDPOINT_ID as passed on the "
-                "commandline. Any commandline PATH given will be used "
-                "as a prefix to all paths given"
+                "Accept a batch of source/dest path pairs from a file. Use the "
+                " special `-` value to read from stdin; otherwise opens the file from "
+                "the argument and passes through lines from that file. Uses "
+                "SOURCE_ENDPOINT_ID and DEST_ENDPOINT_ID as passed on the commandline. "
+                "Commandline paths are still allowed and are used as prefixes to the "
+                "batchmode inputs. "
             ),
         )(f)
     return f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,7 @@ def run_line(cli_runner, request, patch_tokenstorage):
         from globus_cli import main
 
         # split line into args and confirm line starts with "globus"
-        args = shlex.split(line)
+        args = shlex.split(line) if isinstance(line, str) else line
         assert args[0] == "globus"
 
         # run the line. globus_cli.main is the "globus" part of the line

--- a/tests/functional/test_task_submit.py
+++ b/tests/functional/test_task_submit.py
@@ -1,6 +1,4 @@
 import json
-import os
-import tempfile
 
 
 def test_exclude(run_line, load_api_fixtures, go_ep1_id, go_ep2_id):
@@ -34,39 +32,43 @@ def test_exlude_recursive(run_line, load_api_fixtures, go_ep1_id, go_ep2_id):
     # would be better if this could fail before we make any api calls, but
     # we want to build the transfer_data object before we parse batch input
     load_api_fixtures("get_submission_id.yaml")
-
-    expected_error = "--exclude can only be used with --recursive transfers"
-
-    # single
     result = run_line(
         "globus transfer --exclude *.txt " "{}:/ {}:/".format(go_ep1_id, go_ep1_id),
         assert_exit_code=2,
     )
-    assert expected_error in result.stderr
+    assert "--exclude can only be used with --recursive transfers" in result.stderr
 
-    # batch
-    batch_input = "abc /def\n"
+
+def test_exlude_recursive_batch_stdin(
+    run_line, load_api_fixtures, go_ep1_id, go_ep2_id
+):
+    load_api_fixtures("get_submission_id.yaml")
     result = run_line(
         "globus transfer --exclude *.txt --batch - "
         "{}:/ {}:/".format(go_ep1_id, go_ep1_id),
-        stdin=batch_input,
+        stdin="abc /def\n",
         assert_exit_code=2,
     )
+    assert "--exclude can only be used with --recursive transfers" in result.stderr
 
-    with tempfile.NamedTemporaryFile(mode="r+b", buffering=0, delete=False) as temp:
-        temp_name = temp.name
-        temp.write(bytes(batch_input, "utf-8"))
-        result = run_line(
-            [
-                "globus",
-                "transfer",
-                "--exclude",
-                "*.txt",
-                "--batch",
-                temp_name,
-                f"{go_ep1_id}:/",
-                "{go_ep1_id}:/",
-            ],
-            assert_exit_code=2,
-        )
-    os.unlink(temp_name)
+
+def test_exlude_recursive_batch_file(
+    run_line, load_api_fixtures, go_ep1_id, go_ep2_id, tmp_path
+):
+    load_api_fixtures("get_submission_id.yaml")
+    temp = tmp_path / "batch"
+    temp.write_text("abc /def\n")
+    result = run_line(
+        [
+            "globus",
+            "transfer",
+            "--exclude",
+            "*.txt",
+            "--batch",
+            temp,
+            f"{go_ep1_id}:/",
+            f"{go_ep1_id}:/",
+        ],
+        assert_exit_code=2,
+    )
+    assert "--exclude can only be used with --recursive transfers" in result.stderr


### PR DESCRIPTION
This would change the behavior of `--batch` to resolve #222: it would require a filename argument, from which it reads source/dest arguments, and to instead use stdin to pass these one specifies the `-` value.