### PR TITLE
Prevent account switch on incremental auth

### DIFF
--- a/src/globus_cli/commands/logout.py
+++ b/src/globus_cli/commands/logout.py
@@ -7,7 +7,7 @@ from globus_cli.login_manager import (
     internal_native_client,
     token_storage_adapter,
 )
-from globus_cli.login_manager.auth_flows import _STORE_CONFIG_SUB_NAME
+from globus_cli.login_manager.auth_flows import _STORE_CONFIG_USERINFO
 from globus_cli.parsing import command
 from globus_cli.services.auth import get_auth_client
 
@@ -117,6 +117,6 @@ def logout_command(ignore_errors):
 
         adapter.remove_tokens_for_resource_server(rs)
 
-    adapter.remove_config(_STORE_CONFIG_SUB_NAME)
+    adapter.remove_config(_STORE_CONFIG_USERINFO)
 
     click.echo(_LOGOUT_EPILOG)

--- a/src/globus_cli/commands/logout.py
+++ b/src/globus_cli/commands/logout.py
@@ -7,6 +7,7 @@ from globus_cli.login_manager import (
     internal_native_client,
     token_storage_adapter,
 )
+from globus_cli.login_manager.auth_flows import _STORE_CONFIG_SUB_NAME
 from globus_cli.parsing import command
 from globus_cli.services.auth import get_auth_client
 
@@ -115,5 +116,7 @@ def logout_command(ignore_errors):
                     )
 
         adapter.remove_tokens_for_resource_server(rs)
+
+    adapter.remove_config(_STORE_CONFIG_SUB_NAME)
 
     click.echo(_LOGOUT_EPILOG)

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -5,7 +5,7 @@ import click
 from .local_server import LocalServerError, start_local_server
 from .tokenstore import internal_auth_client, token_storage_adapter
 
-_STORE_CONFIG_SUB_NAME = "auth_user_data"
+_STORE_CONFIG_USERINFO = "auth_user_data"
 
 
 def do_link_auth_flow(scopes, *, session_params=None):
@@ -97,7 +97,7 @@ def exchange_code_and_store(auth_client, auth_code):
     adapter = token_storage_adapter()
     tkn = auth_client.oauth2_exchange_code_for_tokens(auth_code)
     sub_new = tkn.decode_id_token()["sub"]
-    auth_user_data = adapter.read_config(_STORE_CONFIG_SUB_NAME)
+    auth_user_data = adapter.read_config(_STORE_CONFIG_USERINFO)
     if auth_user_data and sub_new != auth_user_data.get("sub"):
         auth_client.oauth2_revoke_token(tkn["access_token"])
         auth_client.oauth2_revoke_token(tkn["refresh_token"])
@@ -109,5 +109,5 @@ def exchange_code_and_store(auth_client, auth_code):
         )
         click.get_current_context().exit(1)
     if not auth_user_data:
-        adapter.store_config(_STORE_CONFIG_SUB_NAME, {"sub": sub_new})
+        adapter.store_config(_STORE_CONFIG_USERINFO, {"sub": sub_new})
     adapter.store(tkn)

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -100,14 +100,14 @@ def exchange_code_and_store(auth_client, auth_code):
     auth_user_data = adapter.read_config(_STORE_CONFIG_USERINFO)
     if auth_user_data and sub_new != auth_user_data.get("sub"):
         try:
-            for resource_server, tokens in tkn.by_resource_server.items():
+            for tokens in tkn.by_resource_server.values():
                 auth_client.oauth2_revoke_token(tokens["access_token"])
                 auth_client.oauth2_revoke_token(tokens["refresh_token"])
         finally:
             click.echo(
-                "Authorization failed: tried to login with an account that didn't match "
-                "existing credentials. If you meant to do this, first `globus logout`, "
-                "then try again.",
+                "Authorization failed: tried to login with an account that didn't "
+                "match existing credentials. If you meant to do this, first `globus "
+                "logout`, then try again. ",
                 err=True,
             )
         click.get_current_context().exit(1)

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -5,6 +5,8 @@ import click
 from .local_server import LocalServerError, start_local_server
 from .tokenstore import internal_auth_client, token_storage_adapter
 
+_STORE_CONFIG_SUB_NAME = "auth_user_data"
+
 
 def do_link_auth_flow(scopes, *, session_params=None):
     """
@@ -95,8 +97,7 @@ def exchange_code_and_store(auth_client, auth_code):
     adapter = token_storage_adapter()
     tkn = auth_client.oauth2_exchange_code_for_tokens(auth_code)
     sub_new = tkn.decode_id_token()["sub"]
-    config_name = "auth_user_data"
-    auth_user_data = adapter.read_config(config_name)
+    auth_user_data = adapter.read_config(_STORE_CONFIG_SUB_NAME)
     if auth_user_data and sub_new != auth_user_data.get("sub"):
         auth_client.oauth2_revoke_token(tkn["access_token"])
         auth_client.oauth2_revoke_token(tkn["refresh_token"])
@@ -108,5 +109,5 @@ def exchange_code_and_store(auth_client, auth_code):
         )
         click.get_current_context().exit(1)
     if not auth_user_data:
-        adapter.store_config(config_name, {"sub": sub_new})
+        adapter.store_config(_STORE_CONFIG_SUB_NAME, {"sub": sub_new})
     adapter.store(tkn)

--- a/tests/files/api_fixtures/user_info_logout.yaml
+++ b/tests/files/api_fixtures/user_info_logout.yaml
@@ -1,0 +1,61 @@
+metadata:
+  user_id: "25de0aed-aa83-4600-a1be-a62a910af116"
+  username: "foo@globusid.org"
+  name: "Foo McUser"
+  organization: "McUser Group"
+  email: "foo.mcuser@globus.org"
+  idp_id: "c8abac57-560c-46c8-b386-f116ed8793d5"
+  linked_ids:
+    - user_id: "ae332d86-d274-11e5-b885-b31714a110e9"
+      username: "foo2@globusid.org"
+      name: "Foo2 McUser"
+      email: "foo2.mcuser@globus.org"
+auth:
+  - path: /v2/api/clients/fakeClientIDString
+    method: delete
+    json: {}
+  - path: /v2/oauth2/userinfo
+    json:
+      {
+        "preferred_username": "foo@globusid.org",
+        "name": "Foo McUser",
+        "sub": "25de0aed-aa83-4600-a1be-a62a910af116",
+        "email": "foo.mcuser@globus.org",
+        "identity_set": [
+          {
+            "username": "foo2@globusid.org",
+            "name": "Foo2 McUser",
+            "sub": "ae332d86-d274-11e5-b885-b31714a110e9",
+            "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+            "identity_provider_display_name": "Globus ID",
+            "organization": "McUsers and Company",
+            "status": "used",
+            "email": "foo2.mcuser@globus.org"
+          },
+          {
+            "username": "foo@globusid.org",
+            "name": "Foo McUser",
+            "sub": "25de0aed-aa83-4600-a1be-a62a910af116",
+            "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+            "identity_provider_display_name": "Globus ID",
+            "organization": "McUser Group",
+            "status": "used",
+            "email": "foo.mcuser@globus.org"
+          }
+        ]
+      }
+  - path: /v2/api/identities
+    json:
+      {
+        "identities": [
+          {
+            "username": "foo@globusid.org",
+            "name": "Foo McUser",
+            "id": "25de0aed-aa83-4600-a1be-a62a910af116",
+            "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+            "organization": "McUser Group",
+            "status": "used",
+            "email": "foo.mcuser@globus.org"
+          }
+        ]
+      }

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def mock_link_flow():
+    with mock.patch("globus_cli.login_manager.manager.do_link_auth_flow") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_local_server_flow():
+    with mock.patch("globus_cli.login_manager.manager.do_local_server_auth_flow") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_remote_session():
+    with mock.patch("globus_cli.login_manager.manager.is_remote_session") as m:
+        yield m

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -7,7 +7,7 @@ from globus_sdk import NativeAppAuthClient
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.login_manager.auth_flows import (
-    _STORE_CONFIG_SUB_NAME,
+    _STORE_CONFIG_USERINFO,
     exchange_code_and_store,
 )
 from tests.conftest import _mock_token_response_data
@@ -67,7 +67,7 @@ def test_login_gcs_different_identity(
     """
     load_api_fixtures("user_info_logout.yaml")
     test_token_storage.store_config(
-        _STORE_CONFIG_SUB_NAME, {"sub": str(uuid.UUID(int=0))}
+        _STORE_CONFIG_USERINFO, {"sub": str(uuid.UUID(int=0))}
     )
     mock_auth_client = mock.MagicMock(spec=NativeAppAuthClient)
     mock_auth_client.oauth2_exchange_code_for_tokens = lambda _: MockToken()
@@ -89,4 +89,4 @@ def test_login_gcs_different_identity(
         "globus_cli.commands.logout.internal_native_client", lambda: mock_auth_client
     )
     result = run_line("globus logout --yes")
-    assert test_token_storage.read_config(_STORE_CONFIG_SUB_NAME) is None
+    assert test_token_storage.read_config(_STORE_CONFIG_USERINFO) is None

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -1,8 +1,16 @@
+import uuid
+from collections import UserDict
 from unittest import mock
 
 import globus_sdk
+from globus_sdk import NativeAppAuthClient
 
 from globus_cli.login_manager import LoginManager
+from globus_cli.login_manager.auth_flows import (
+    _STORE_CONFIG_SUB_NAME,
+    exchange_code_and_store,
+)
+from tests.conftest import _mock_token_response_data
 
 
 def test_login_validates_token(run_line, mock_login_token_response):
@@ -20,3 +28,65 @@ def test_login_validates_token(run_line, mock_login_token_response):
         t_rt = by_rs["transfer.api.globus.org"]["refresh_token"]
         ac.oauth2_validate_token.assert_any_call(a_rt)
         ac.oauth2_validate_token.assert_any_call(t_rt)
+
+
+class MockToken(UserDict):
+    access_token = "mock_access_token"
+    refresh_token = "mock_refresh_token"
+    by_resource_server = {
+        "auth.globus.org": _mock_token_response_data(
+            "auth.globus.org",
+            "openid profile email "
+            "urn:globus:auth:scope:auth.globus.org:view_identity_set",
+        )
+    }
+
+    def __init__(self):
+        self.data = {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+        }
+
+    def decode_id_token(self, uuid_value: int = 1):
+        return {"sub": str(uuid.UUID(int=uuid_value))}
+
+
+def test_login_gcs_different_identity(
+    monkeypatch,
+    run_line,
+    load_api_fixtures,
+    mock_remote_session,
+    mock_local_server_flow,
+    mock_login_token_response,
+    test_token_storage,
+):
+    """
+    Test the `exchange_code_and_store` behavior where logging in with a different
+    identity is prevented. The user is instructed to logout, which should correctly
+    remove the `sub` in config storage (which is what originally raises that error).
+    """
+    load_api_fixtures("user_info_logout.yaml")
+    test_token_storage.store_config(
+        _STORE_CONFIG_SUB_NAME, {"sub": str(uuid.UUID(int=0))}
+    )
+    mock_auth_client = mock.MagicMock(spec=NativeAppAuthClient)
+    mock_auth_client.oauth2_exchange_code_for_tokens = lambda _: MockToken()
+    mock_local_server_flow.side_effect = (
+        lambda *args, **kwargs: exchange_code_and_store(mock_auth_client, "bogus_code")
+    )
+    mock_remote_session.return_value = False
+    result = run_line(f"globus login --gcs {uuid.UUID(int=0)}", assert_exit_code=1)
+    assert "Authorization failed" in result.stderr
+    mock_auth_client.oauth2_revoke_token.assert_has_calls(
+        [
+            mock.call(MockToken.access_token),
+            mock.call(MockToken.refresh_token),
+        ],
+        any_order=True,
+    )
+
+    monkeypatch.setattr(
+        "globus_cli.commands.logout.internal_native_client", lambda: mock_auth_client
+    )
+    result = run_line("globus logout --yes")
+    assert test_token_storage.read_config(_STORE_CONFIG_SUB_NAME) is None

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -35,7 +35,11 @@ class MockToken:
             "auth.globus.org",
             "openid profile email "
             "urn:globus:auth:scope:auth.globus.org:view_identity_set",
-        )
+        ),
+        "transfer.api.globus.org": _mock_token_response_data(
+            "transfer.api.globus.org",
+            "urn:globus:auth:scope:transfer.api.globus.org:all",
+        ),
     }
 
     def decode_id_token(self, uuid_value: int = 1):

--- a/tests/functional/test_session_update.py
+++ b/tests/functional/test_session_update.py
@@ -1,24 +1,4 @@
-from unittest import mock
-
 import pytest
-
-
-@pytest.fixture
-def mock_remote_session():
-    with mock.patch("globus_cli.login_manager.manager.is_remote_session") as m:
-        yield m
-
-
-@pytest.fixture
-def mock_link_flow():
-    with mock.patch("globus_cli.login_manager.manager.do_link_auth_flow") as m:
-        yield m
-
-
-@pytest.fixture
-def mock_local_server_flow():
-    with mock.patch("globus_cli.login_manager.manager.do_local_server_auth_flow") as m:
-        yield m
 
 
 def test_username_not_in_idset(run_line, load_api_fixtures):


### PR DESCRIPTION
- Modify `exchange_code_and_store` to issue an error if the tokens fetched don't match what the user was previously authenticated as
- Shuffle around test fixtures to support adding a test for the above, running a login flow