### PR TITLE
Add tests for bookmark list command

### DIFF
--- a/tests/files/api_fixtures/bookmark_list.yaml
+++ b/tests/files/api_fixtures/bookmark_list.yaml
@@ -1,0 +1,91 @@
+metadata:
+  bookmarks:
+    '2f7ea128-14b3-11e7-bb75-22000b9a448b':
+      ep_name: myserver
+      name: bm1
+      path: /home/
+    '30ceab04-14b3-11e7-bb75-22000b9a448b':
+      ep_name: null
+      name: bm2
+      path: /scratch/projects/foo
+    '9406eab4-b3ae-11e9-9394-02ff96a5aa76':
+      ep_name: HTTPS Test - Guest
+      name: http-test guest collection
+      path: /
+
+transfer:
+  - path: /bookmark_list
+    json:
+      {
+        "DATA": [
+          {
+            "DATA_TYPE": "bookmark",
+            "endpoint_id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+            "id": "2f7ea128-14b3-11e7-bb75-22000b9a448b",
+            "name": "bm1",
+            "path": "/home/",
+            "pinned": false
+          },
+          {
+            "DATA_TYPE": "bookmark",
+            "endpoint_id": "7b123e08-6638-11eb-8282-0275e0cda761",
+            "id": "30ceab04-14b3-11e7-bb75-22000b9a448b",
+            "name": "bm2",
+            "path": "/scratch/projects/foo",
+            "pinned": false
+          },
+          {
+            "DATA_TYPE": "bookmark",
+            "endpoint_id": "4c5f4e22-4628-4ab7-b57d-3af25c1ed1e4",
+            "id": "9406eab4-b3ae-11e9-9394-02ff96a5aa76",
+            "name": "http-test guest collection",
+            "path": "/",
+            "pinned": false
+          }
+        ]
+      }
+  - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15
+    json:
+      {
+        "DATA_TYPE": "endpoint",
+        "canonical_name": "auser#myserver",
+        "description": "Example gridftp endpoint.",
+        "display_name": "myserver",
+        "host_endpoint_id": null,
+        "id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+        "username": "auser",
+        "DATA": [
+          {
+            "DATA_TYPE": "server",
+            "hostname": "example.org",
+            "uri": "gsiftp://example.org:2811",
+            "port": 2811,
+            "scheme": "gsiftp",
+            "id": 985,
+            "subject": "/O=Grid/OU=Example/CN=host/girdftp.example.org"
+          }
+        ]
+      }
+  - path: /endpoint/7b123e08-6638-11eb-8282-0275e0cda761
+    status: 404
+    json:
+      {
+        "code": "EndpointDeleted",
+        "message": "Endpoint '7b123e08-6638-11eb-8282-0275e0cda761' has been deleted",
+        "request_id": "TgFtEL2lG"
+      }
+  - path: /endpoint/4c5f4e22-4628-4ab7-b57d-3af25c1ed1e4
+    json:
+      {
+        "DATA": [],
+        "DATA_TYPE": "endpoint",
+        "canonical_name": "foouser#http-test",
+        "description": "Guest Collection on the testing HTTPS endpoint",
+        "display_name": "HTTPS Test - Guest",
+        "gcs_version": "5.4.10",
+        "host_endpoint_id": null,
+        "id": "4c5f4e22-4628-4ab7-b57d-3af25c1ed1e4",
+        "is_globus_connect": false,
+        "non_functional": false,
+        "owner_id": "cf37806c-572c-47ff-88e2-511c646ef1a4"
+      }

--- a/tests/files/api_fixtures/bookmark_list_failure.yaml
+++ b/tests/files/api_fixtures/bookmark_list_failure.yaml
@@ -1,0 +1,61 @@
+transfer:
+  - path: /bookmark_list
+    json:
+      {
+        "DATA": [
+          {
+            "DATA_TYPE": "bookmark",
+            "endpoint_id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+            "id": "2f7ea128-14b3-11e7-bb75-22000b9a448b",
+            "name": "bm1",
+            "path": "/home/",
+            "pinned": false
+          },
+          {
+            "DATA_TYPE": "bookmark",
+            "endpoint_id": "7b123e08-6638-11eb-8282-0275e0cda761",
+            "id": "30ceab04-14b3-11e7-bb75-22000b9a448b",
+            "name": "bm2",
+            "path": "/scratch/projects/foo",
+            "pinned": false
+          },
+          {
+            "DATA_TYPE": "bookmark",
+            "endpoint_id": "4c5f4e22-4628-4ab7-b57d-3af25c1ed1e4",
+            "id": "9406eab4-b3ae-11e9-9394-02ff96a5aa76",
+            "name": "http-test guest collection",
+            "path": "/",
+            "pinned": false
+          }
+        ]
+      }
+  - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15
+    status: 500
+    json:
+      {
+        "code": "InternalError",
+        "request_id": "GtSgRY2yT"
+      }
+  - path: /endpoint/7b123e08-6638-11eb-8282-0275e0cda761
+    status: 404
+    json:
+      {
+        "code": "EndpointDeleted",
+        "message": "Endpoint '7b123e08-6638-11eb-8282-0275e0cda761' has been deleted",
+        "request_id": "TgFtEL2lG"
+      }
+  - path: /endpoint/4c5f4e22-4628-4ab7-b57d-3af25c1ed1e4
+    json:
+      {
+        "DATA": [],
+        "DATA_TYPE": "endpoint",
+        "canonical_name": "foouser#http-test",
+        "description": "Guest Collection on the testing HTTPS endpoint",
+        "display_name": "HTTPS Test - Guest",
+        "gcs_version": "5.4.10",
+        "host_endpoint_id": null,
+        "id": "4c5f4e22-4628-4ab7-b57d-3af25c1ed1e4",
+        "is_globus_connect": false,
+        "non_functional": false,
+        "owner_id": "cf37806c-572c-47ff-88e2-511c646ef1a4"
+      }


### PR DESCRIPTION
Two cases are worth testing:
- working case in which endpoint name is pulled for each item
- failing case in which the endpoint lookup errors and we need to be sure that the error will propagate correctly