### PR TITLE
Add testing for 'endpoint permission create'

### DIFF
--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -62,9 +62,6 @@ def create_command(
     '--anonymous', '--group', or '--identity' is required to know to whom permissions
     are being granted.
     """
-    if not principal:
-        raise click.UsageError("A security principal is required for this command")
-
     endpoint_id, path = endpoint_plus_path
     principal_type, principal_val = principal
 

--- a/tests/files/api_fixtures/endpoint_acl_operations.yaml
+++ b/tests/files/api_fixtures/endpoint_acl_operations.yaml
@@ -1,0 +1,34 @@
+metadata:
+  user_id: "25de0aed-aa83-4600-a1be-a62a910af116"
+  username: "foo@globusid.org"
+  endpoint_id: "1405823f-0597-4a16-b296-46d4f0ae4b15"
+
+auth:
+  - path: /v2/api/identities
+    json:
+      {
+        "identities": [
+          {
+            "username": "foo@globusid.org",
+            "name": "Foo McUser",
+            "id": "25de0aed-aa83-4600-a1be-a62a910af116",
+            "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+            "organization": "McUser Group",
+            "status": "used",
+            "email": "foo.mcuser@globus.org"
+          }
+        ]
+      }
+
+transfer:
+  - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15/access
+    method: post
+    json:
+      {
+        "code": "Created",
+        "resource": "/endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15/access",
+        "DATA_TYPE": "access_create_result",
+        "request_id": "abc123",
+        "access_id": 12345,
+        "message": "Access rule created successfully."
+      }

--- a/tests/functional/test_permission_commands.py
+++ b/tests/functional/test_permission_commands.py
@@ -1,0 +1,149 @@
+import json
+import uuid
+
+import pytest
+import responses
+
+DUMMY_ID1 = str(uuid.UUID(int=1))
+DUMMY_ID2 = str(uuid.UUID(int=2))
+
+
+@pytest.mark.parametrize("provision", [True, False])
+def test_permission_create_identity_name(run_line, load_api_fixtures, provision):
+    data = load_api_fixtures("endpoint_acl_operations.yaml")
+    user_id = data["metadata"]["user_id"]
+    username = data["metadata"]["username"]
+    ep = data["metadata"]["endpoint_id"]
+
+    result = run_line(
+        [
+            "globus",
+            "endpoint",
+            "permission",
+            "create",
+            f"{ep}:/",
+            "--permissions",
+            "rw",
+            "--provision-identity" if provision else "--identity",
+            username,
+        ]
+    )
+    sent_data = json.loads(responses.calls[-1].request.body)
+    assert sent_data["principal_type"] == "identity"
+    assert sent_data["principal"] == user_id
+
+    assert "Access rule created successfully." in result.stdout
+
+
+def test_permission_create_identity_id(run_line, load_api_fixtures):
+    data = load_api_fixtures("endpoint_acl_operations.yaml")
+    user_id = data["metadata"]["user_id"]
+    ep = data["metadata"]["endpoint_id"]
+
+    result = run_line(
+        [
+            "globus",
+            "endpoint",
+            "permission",
+            "create",
+            f"{ep}:/",
+            "--permissions",
+            "rw",
+            "--identity",
+            user_id,
+        ]
+    )
+    sent_data = json.loads(responses.calls[-1].request.body)
+    assert sent_data["principal_type"] == "identity"
+    assert sent_data["principal"] == user_id
+
+    assert "Access rule created successfully." in result.stdout
+
+
+def test_permission_create_requires_principal(run_line):
+    dummy_ep = str(uuid.uuid1())
+    result = run_line(
+        [
+            "globus",
+            "endpoint",
+            "permission",
+            "create",
+            f"{dummy_ep}:/",
+            "--permissions",
+            "rw",
+        ],
+        assert_exit_code=2,
+    )
+    assert "You must provide at least one principal" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "addopts, expecterr",
+    [
+        (
+            ["--identity", DUMMY_ID1, "--provision-identity", DUMMY_ID2],
+            "Only one of --identity or --provision-identity allowed",
+        ),
+        (
+            ["--identity", DUMMY_ID1, "--group", DUMMY_ID2],
+            (
+                "You have passed both an identity and a group. "
+                "Please only pass one principal type"
+            ),
+        ),
+        (
+            ["--provision-identity", DUMMY_ID1, "--group", DUMMY_ID2],
+            (
+                "You have passed both an identity and a group. "
+                "Please only pass one principal type"
+            ),
+        ),
+        (
+            ["--identity", DUMMY_ID1, "--anonymous"],
+            "You may only pass one security principal",
+        ),
+        (
+            ["--identity", DUMMY_ID1, "--all-authenticated"],
+            "You may only pass one security principal",
+        ),
+    ],
+)
+def test_permission_create_incompatible_security_principal_opts(
+    run_line, addopts, expecterr
+):
+    dummy_ep = str(uuid.uuid1())
+    result = run_line(
+        [
+            "globus",
+            "endpoint",
+            "permission",
+            "create",
+            f"{dummy_ep}:/",
+            "--permissions",
+            "rw",
+        ]
+        + addopts,
+        assert_exit_code=2,
+    )
+    assert expecterr in result.stderr
+
+
+def test_permission_create_username_lookup_fails(run_line, register_api_route):
+    register_api_route("auth", "/v2/api/identities", json={"identities": []})
+    dummy_ep = str(uuid.uuid1())
+    result = run_line(
+        [
+            "globus",
+            "endpoint",
+            "permission",
+            "create",
+            f"{dummy_ep}:/",
+            "--permissions",
+            "rw",
+            "--identity",
+            "foo@globus.org",
+        ],
+        assert_exit_code=2,
+    )
+    assert "Identity does not exist" in result.stderr
+    assert "Use --provision-identity" in result.stderr


### PR DESCRIPTION
The ACL creation command was untested and features a variety of interesting codepaths.

The success cases are fairly simple, but also test the various failure modes for improper options. In one case, remove a check from the command itself because it is unreachable -- the checked condition is handled in the security_principal_opts decorator.

All tests focus on checking exit code and part of output.