### PR TITLE
Validate environment variables before running commands

### DIFF
--- a/src/globus_cli/termio/__init__.py
+++ b/src/globus_cli/termio/__init__.py
@@ -1,6 +1,7 @@
 import click
 
 from .context import (
+    env_interactive,
     err_is_terminal,
     get_jmespath_expression,
     is_verbose,
@@ -44,6 +45,7 @@ __all__ = [
     "FORMAT_TEXT_RECORD",
     "FORMAT_TEXT_RAW",
     "out_is_terminal",
+    "env_interactive",
     "err_is_terminal",
     "term_is_interactive",
     "outformat_is_json",

--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from distutils.util import strtobool
+from typing import Optional
 
 import click
 
@@ -69,11 +70,22 @@ def err_is_terminal():
     return sys.stderr.isatty()
 
 
-def term_is_interactive() -> bool:
+def env_interactive() -> Optional[bool]:
+    """
+    Check the `GLOBUS_CLI_INTERACTIVE` environment variable for a boolean, and *let*
+    `strtobool` raise a `ValueError` if it doesn't parse.
+    """
     explicit_val = os.getenv("GLOBUS_CLI_INTERACTIVE")
-    if explicit_val is not None:
-        try:
-            return strtobool(explicit_val.lower())
-        except ValueError:
-            pass
+    if explicit_val is None:
+        return None
+    return bool(strtobool(explicit_val.lower()))
+
+
+def term_is_interactive() -> bool:
+    try:
+        env = env_interactive()
+        if env is not None:
+            return env
+    except ValueError:
+        pass
     return os.getenv("PS1") is not None

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -1,3 +1,8 @@
+import os
+
+import pytest
+
+
 def test_parsing(run_line):
     """
     Runs --help and confirms the option is parsed
@@ -219,3 +224,15 @@ def test_delete_batchmode_dryrun(run_line, load_api_fixtures, go_ep1_id):
         )
         == result.output
     )
+
+
+@pytest.mark.parametrize("cmd", ["list-commands", "version", "whoami"])
+def test_env_checks(monkeypatch, run_line, cmd):
+    """
+    Test that passing garbage values for specific environment variables causes an error
+    with a specific message. (This test just parametrizes over a few example commands
+    that don't require extra input to run.)
+    """
+    monkeypatch.setitem(os.environ, "GLOBUS_CLI_INTERACTIVE", "Whoops")
+    result = run_line(f"globus {cmd}", assert_exit_code=1)
+    assert "GLOBUS_CLI_INTERACTIVE" in result.stderr


### PR DESCRIPTION
- Add a `GlobusCommandEnvChecks` command subclass to validate env vars
- Use the above to reject invalid `GLOBUS_CLI_INTERACTIVE` values