### PR TITLE
Add mypy to tox, fixup types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,5 @@ repos:
       additional_dependencies:
         - types-setuptools
         - types-requests
+        - click
         - 'globus-sdk==3.0.1'

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ localdev: .venv
 
 .PHONY: lint test reference
 lint:
-	tox -e lint
+	tox -e lint,mypy
 reference:
 	tox -e reference
 test:

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -1,5 +1,6 @@
 import logging.config
 import warnings
+from typing import Callable
 
 import click
 import jmespath
@@ -56,7 +57,7 @@ class CommandState:
         return self.verbosity > 0
 
 
-def format_option(f):
+def format_option(f: Callable) -> Callable:
     def callback(ctx, param, value):
         if not value:
             return
@@ -103,7 +104,7 @@ def format_option(f):
     return f
 
 
-def debug_option(f):
+def debug_option(f: Callable) -> Callable:
     def callback(ctx, param, value):
         if not value or ctx.resilient_parsing:
             # turn off warnings altogether
@@ -125,7 +126,7 @@ def debug_option(f):
     )(f)
 
 
-def verbose_option(f):
+def verbose_option(f: Callable) -> Callable:
     def callback(ctx, param, value):
         # set state verbosity value from option
         state = ctx.ensure_object(CommandState)
@@ -171,7 +172,7 @@ def verbose_option(f):
     )(f)
 
 
-def map_http_status_option(f):
+def map_http_status_option(f: Callable) -> Callable:
     exit_stat_set = [0, 1] + list(range(50, 100))
 
     def per_val_callback(ctx, value):

--- a/src/globus_cli/parsing/mutex_group.py
+++ b/src/globus_cli/parsing/mutex_group.py
@@ -1,9 +1,11 @@
 import functools
-import typing
+from typing import Callable, List, TypeVar, Union
 
 import click
 
 from ..utils import format_list_of_words
+
+C = TypeVar("C", bound=Callable)
 
 
 class MutexInfo:
@@ -27,7 +29,7 @@ class MutexInfo:
         return self.option_name
 
 
-def mutex_option_group(*options: typing.Union[str, MutexInfo]):
+def mutex_option_group(*options: Union[str, MutexInfo]) -> Callable[[C], C]:
     """
     Given a mapping of param name to option string, decorate a command function to check
     for the exclusivity of those options.
@@ -48,7 +50,7 @@ def mutex_option_group(*options: typing.Union[str, MutexInfo]):
     MutexInfo allows you to customize how an option is detected as present in a
     dict of parameters by setting `present=...`.
     """
-    opt_infos: typing.List[MutexInfo] = []
+    opt_infos: List[MutexInfo] = []
     for opt in options:
         if isinstance(opt, str):
             opt_infos.append(MutexInfo(opt))

--- a/src/globus_cli/parsing/shared_options.py
+++ b/src/globus_cli/parsing/shared_options.py
@@ -13,7 +13,7 @@ from globus_cli.parsing.command_state import (
 
 def common_options(
     f: Optional[Callable] = None, *, disable_options: Optional[List[str]] = None
-):
+) -> Callable:
     """
     This is a multi-purpose decorator for applying a "base" set of options
     shared by all commands.

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,14 @@ deps = pre-commit~=2.9.2
 skip_install = true
 commands = pre-commit run --all-files
 
+[testenv:mypy]
+deps =
+    mypy
+    types-jwt
+    types-requests
+    typing-extensions
+commands = mypy src/
+
 [testenv:reference]
 whitelist_externals = find
 commands_pre = find reference/ -name "*.adoc" -type f -delete


### PR DESCRIPTION
Add mypy to tox as an environment. This lets us run `mypy` easily in CI without relying on pre-commit file-passing logic. It also changes the behavior of mypy to run in this way, so it's a good safety check. `make lint` runs this in addition to pre-commit linting.

The resulting `mypy` invocation fails, mostly because we have un-annotated functions within the CLI. These are treated as producing `Any`, so they mess up type-narrowing logic on Optional values. To solve this, many functions simply need to be annotated as `Callable -> Callable`.

Add `click` to the requirements for mypy linting in pre-commit. This lets mypy get types for click objects and methods, rather than converting everything to Any.