### PR TITLE
Add 'collection show' command

### DIFF
--- a/src/globus_cli/commands/collection/__init__.py
+++ b/src/globus_cli/commands/collection/__init__.py
@@ -1,6 +1,7 @@
 from globus_cli.parsing import group
 
 from .delete import collection_delete
+from .show import collection_show
 
 
 @group("collection")
@@ -10,3 +11,4 @@ def collection_command():
 
 # commands
 collection_command.add_command(collection_delete)
+collection_command.add_command(collection_show)

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -32,7 +32,6 @@ STANDARD_FIELDS = [
     ("Contact E-mail", "contact_email"),
     ("Contact Info", "contact_info"),
     ("Collection Info Link", "info_link"),
-    ("Google Cloud Storage Project", "policies.project"),
 ]
 
 PRIVATE_FIELDS = [

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -1,0 +1,87 @@
+import click
+
+from globus_cli.endpointish import Endpointish
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import collection_id_arg, command
+from globus_cli.principal_resolver import default_identity_id_resolver
+from globus_cli.services.gcs import connector_id_to_display_name, get_gcs_client
+from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+from globus_cli.utils import filter_fields, sorted_json_field
+
+STANDARD_FIELDS = [
+    ("Display Name", "display_name"),
+    ("Owner", default_identity_id_resolver.field),
+    ("ID", "id"),
+    ("Collection Type", "collection_type"),
+    ("Storage Gateway ID", "storage_gateway_id"),
+    ("Connector", lambda x: connector_id_to_display_name(x["connector_id"])),
+    ("Allow Guest Collections", "allow_guest_collections"),
+    ("Disable Anonymous Writes", "disable_anonymous_writes"),
+    ("High Assurance", "high_assurance"),
+    ("Authentication Timeout", "authentication_timeout_mins"),
+    ("Multi-factor Authentication", "require_mfa"),
+    ("Manager URL", "manager_url"),
+    ("HTTPS URL", "https_url"),
+    ("TLSFTP URL", "tlsftp_url"),
+    ("Force Encryption", "force_encryption"),
+    ("Public", "public"),
+    ("Organization", "organization"),
+    ("Department", "department"),
+    ("Keywords", "keywords"),
+    ("Description", "description"),
+    ("Contact E-mail", "contact_email"),
+    ("Contact Info", "contact_info"),
+    ("Collection Info Link", "info_link"),
+    ("Google Cloud Storage Project", "policies.project"),
+]
+
+PRIVATE_FIELDS = [
+    ("Root Path", "root_path"),
+    ("Default Directory", "default_directory"),
+    ("Sharing Path Restrictions", sorted_json_field("sharing_restrict_paths")),
+    ("Sharing Allowed Users", "sharing_users_allow"),
+    ("Sharing Denied Users", "sharing_users_deny"),
+    ("Sharing Allowed POSIX Groups", "policies.sharing_groups_allow"),
+    ("Sharing Denied POSIX Groups", "policies.sharing_groups_deny"),
+]
+
+
+@command("show", short_help="Show a Collection definition")
+@collection_id_arg
+@click.option(
+    "--include-private-policies",
+    is_flag=True,
+    help=(
+        "Include private policies. Requires administrator role on the endpoint. "
+        "Some policy data may only be visible in `--format JSON` output"
+    ),
+)
+@LoginManager.requires_login(
+    LoginManager.TRANSFER_RS, LoginManager.AUTH_RS, pass_manager=True
+)
+def collection_show(login_manager, *, include_private_policies, collection_id):
+    """
+    Show a Collection on the current Endpoint
+    """
+    endpoint_id = Endpointish(collection_id).get_collection_endpoint_id()
+    login_manager.assert_logins(endpoint_id, assume_gcs=True)
+    client = get_gcs_client(endpoint_id)
+
+    query_params = {}
+    fields = STANDARD_FIELDS
+
+    if include_private_policies:
+        query_params["include"] = "private_policies"
+        fields += PRIVATE_FIELDS
+
+    res = client.get_collection(collection_id, query_params=query_params)
+
+    # walk the list of all known fields and reduce the rendering to only look
+    # for fields which are actually present
+    real_fields = filter_fields(fields, res)
+
+    formatted_print(
+        res,
+        text_format=FORMAT_TEXT_RECORD,
+        fields=real_fields,
+    )

--- a/src/globus_cli/commands/endpoint/show.py
+++ b/src/globus_cli/commands/endpoint/show.py
@@ -1,3 +1,4 @@
+from globus_cli.endpointish import Endpointish
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.services.transfer import get_client
@@ -10,6 +11,7 @@ from globus_cli.termio import FORMAT_TEXT_RECORD, FormatField, formatted_print
 def endpoint_show(endpoint_id):
     """Display a detailed endpoint definition"""
     client = get_client()
+    Endpointish(endpoint_id, transfer_client=client).assert_is_not_collection()
 
     res = client.get_endpoint(endpoint_id)
 

--- a/src/globus_cli/endpointish/endpoint_type.py
+++ b/src/globus_cli/endpointish/endpoint_type.py
@@ -20,6 +20,10 @@ class EndpointType(Enum):
         return (cls.GCP, cls.SHARE, cls.NON_GCSV5_ENDPOINT)
 
     @classmethod
+    def non_collection_types(cls) -> Tuple["EndpointType", ...]:
+        return tuple(x for x in cls if x not in cls.collections())
+
+    @classmethod
     def nice_name(cls, eptype: "EndpointType") -> str:
         return {
             cls.GCP: "Globus Connect Personal",

--- a/src/globus_cli/endpointish/endpointish.py
+++ b/src/globus_cli/endpointish/endpointish.py
@@ -41,6 +41,11 @@ class Endpointish:
             EndpointType.collections(), error_class=ExpectedCollectionError
         )
 
+    def assert_is_not_collection(self):
+        self.assert_ep_type(
+            EndpointType.non_collection_types(), error_class=ExpectedEndpointError
+        )
+
     def assert_is_traditional_endpoint(self):
         self.assert_ep_type(
             EndpointType.traditional_endpoints(), error_class=ExpectedEndpointError

--- a/src/globus_cli/endpointish/errors.py
+++ b/src/globus_cli/endpointish/errors.py
@@ -9,6 +9,12 @@ SHOULD_USE_MAP = {
     "globus endpoint delete": [
         ("globus collection delete", EndpointType.collections()),
     ],
+    "globus collection show": [
+        ("globus endpoint show", EndpointType.non_collection_types()),
+    ],
+    "globus endpoint show": [
+        ("globus collection show", EndpointType.collections()),
+    ],
 }
 
 

--- a/src/globus_cli/principal_resolver.py
+++ b/src/globus_cli/principal_resolver.py
@@ -1,0 +1,98 @@
+"""
+A wrapper which nicely integrates SDK IdentityMaps into the CLI.
+
+This was originally implemented in gcs-cli and ported into here.
+
+A "resolver" is defined with a field it uses in each item from the response data as the
+full principal value. This is the "key".
+Typical usage should be to define a resolver in each command which needs resolution, to
+provide the key to use. Definition may have to happen outside of a command to
+accommodate field lists which are defined as constants, and this is supported.
+
+A resolver provides a field handler for principal URNs + a pagination callback to get
+all principals from each page of results added to the ID map.
+It can also be initialized to take identity IDs (not in Principal URN format).
+
+This lets us get some of the benefit of the IdentityMap bulk calls without forcing the
+whole paginated call to be walked at once.
+
+This also lets us keep the resolution work only in the text-mode printed output (and not
+applied on JSON output).
+"""
+from globus_sdk import IdentityMap
+
+from globus_cli.services.auth import get_auth_client
+
+IDENTITY_URN_PREFIX = "urn:globus:auth:identity:"
+
+
+class PrincipalResolver:
+    """
+    Everything is done lazily via properties so that nothing happens during
+    start up.
+
+    Pass ``PrincipalResolver.field`` as a field key for output printing
+
+    Pass ``PrincipalResolver.page_callback`` as a page callback for output printing.
+
+    Usage:
+
+    >>> PrincipalResolver("urnfield")
+
+    creates a resolver which pulls principal URNs from the field named "urnfield"
+
+    >>> PrincipalResolver("idfield", use_urns=False)
+
+    creates a resolver which pulls Identity IDs from the field named "idfield"
+    """
+
+    def __init__(self, key, use_urns=True):
+        self.key = key
+        self.use_urns = use_urns
+        self._idmap = None
+
+    @property
+    def idmap(self):
+        if not self._idmap:
+            self._idmap = IdentityMap(get_auth_client())
+        return self._idmap
+
+    def _raw_id_from_object(self, obj):
+        """
+        returns a 3-tuple, (resolved?, original, value)
+        so that callers know if this helper thinks it got a good result or not
+        """
+        value = obj[self.key]
+        # if not using URNs, the "raw ID" is just the value and it "always works"
+        if not self.use_urns:
+            return (True, value, value)
+
+        # otherwise, check
+        # if it doesn't have the URN prefix, it is not a valid URN, so this lookup
+        # failed -- the result is (False, ...) to indicate failure
+        if not value.startswith(IDENTITY_URN_PREFIX):
+            return (False, value, value)
+        # if it has the right prefix, left-strip the prefix as the new value, return the
+        # original and the success indicator
+        return (True, value, value[len(IDENTITY_URN_PREFIX) :])
+
+    def field(self, data):
+        resolved, original, value = self._raw_id_from_object(data)
+        if not resolved:
+            return value
+        # try to do the lookup and get the "username" property
+        # but default to the original value if this doesn't resolve
+        return self.idmap.get(value, {}).get("username", original)
+
+    # TODO: In gcs-cli, page_callback is suported by the pretty printer. In globus-cli,
+    # we should attach this to the PagingWrapper. The purpose is to get the map
+    # populated on a per-page basis.
+    def page_callback(self, data_page):
+        for item in data_page:
+            resolved, _original, value = self._raw_id_from_object(item)
+            if resolved:
+                self.idmap.add(value)
+
+
+default_principal_resolver = PrincipalResolver("principal")
+default_identity_id_resolver = PrincipalResolver("identity_id", use_urns=False)

--- a/src/globus_cli/services/gcs.py
+++ b/src/globus_cli/services/gcs.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Optional
+
 from globus_sdk import GCSClient, RefreshTokenAuthorizer
 
 from globus_cli import version
@@ -30,3 +32,73 @@ def get_gcs_client(gcs_id: str, *, require_auth=True) -> GCSClient:
     gcs_address = tc.get_endpoint(gcs_id)["DATA"][0]["hostname"]
 
     return GCSClient(gcs_address, authorizer=authorizer, app_name=version.app_name)
+
+
+CONNECTOR_INFO: List[Dict[str, str]] = [
+    {
+        "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+        "name": "POSIX",
+    },
+    {
+        "connector_id": "7e3f3f5e-350c-4717-891a-2f451c24b0d4",
+        "name": "BlackPearl",
+    },
+    {
+        "connector_id": "7c100eae-40fe-11e9-95a3-9cb6d0d9fd63",
+        "name": "Box",
+    },
+    {
+        "connector_id": "1b6374b0-f6a4-4cf7-a26f-f262d9c6ca72",
+        "name": "Ceph",
+    },
+    {
+        "connector_id": "28ef55da-1f97-11eb-bdfd-12704e0d6a4d",
+        "name": "OneDrive",
+    },
+    {
+        "connector_id": "976cf0cf-78c3-4aab-82d2-7c16adbcc281",
+        "name": "Google Drive",
+    },
+    {
+        "connector_id": "56366b96-ac98-11e9-abac-9cb6d0d9fd63",
+        "name": "Google Cloud Storage",
+    },
+    {
+        "connector_id": "7251f6c8-93c9-11eb-95ba-12704e0d6a4d",
+        "name": "ActiveScale",
+    },
+    {
+        "connector_id": "7643e831-5f6c-4b47-a07f-8ee90f401d23",
+        "name": "S3",
+    },
+    {
+        "connector_id": "052be037-7dda-4d20-b163-3077314dc3e6",
+        "name": "POSIX Staging",
+    },
+    {
+        "connector_id": "e47b6920-ff57-11ea-8aaa-000c297ab3c2",
+        "name": "iRODS",
+    },
+]
+
+
+def connector_display_name_to_id(connector_name: str) -> Optional[str]:
+    conn_id = None
+    for data in CONNECTOR_INFO:
+        if data["name"] == connector_name:
+            conn_id = data["connector_id"]
+            break
+    return conn_id
+
+
+def connector_id_to_display_name(connector_id: str) -> str:
+    display_name = None
+    for data in CONNECTOR_INFO:
+        if data["connector_id"] == connector_id:
+            display_name = data["name"]
+            break
+
+    if not display_name:
+        display_name = f"UNKNOWN ({connector_id})"
+
+    return display_name

--- a/src/globus_cli/termio/output_formatter.py
+++ b/src/globus_cli/termio/output_formatter.py
@@ -63,9 +63,13 @@ def _key_to_keyfunc(k):
     # if the key is a string, then the "keyfunc" is just a basic lookup
     # operation -- return that
     if isinstance(k, str):
+        subkeys = k.split(".")
 
         def lookup(x):
-            return x[k]
+            current = x
+            for sub in subkeys:
+                current = x[sub]
+            return current
 
         return lookup
     # otherwise, the key must be a function which is executed on the item

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -1,3 +1,4 @@
+import json
 from typing import Dict, Iterator, Optional
 
 
@@ -32,6 +33,50 @@ def format_plural_str(formatstr: str, pluralizable: Dict[str, str], use_plural: 
         for singular, plural in pluralizable.items()
     }
     return formatstr.format(**argdict)
+
+
+def sorted_json_field(key):
+    """Define sorted JSON output for text output containing complex types."""
+
+    def field_func(data):
+        return json.dumps(data[key], sort_keys=True)
+
+    field_func._filter_key = key
+    return field_func
+
+
+def filter_fields(check_fields, container):
+    """
+    Given a set of fields, this is a list of fields actually found in some containing
+    object.
+
+    Always includes keyfunc fields unless they set the magic _filter_key attribute
+    sorted_json_field above is a good example of doing this
+    """
+    fields = []
+    for name, key in check_fields:
+        check_key = key
+        if callable(key) and hasattr(key, "_filter_key"):
+            check_key = key._filter_key
+
+        # if it's a string lookup, check if it's contained (and skip if not)
+        if isinstance(check_key, str):
+            subkeys = check_key.split(".")
+            skip_subkey = False
+
+            check_container = container
+            for check_subkey in subkeys[:-1]:
+                if check_subkey not in check_container:
+                    skip_subkey = True
+                    break
+                check_container = check_container[check_subkey]
+            if skip_subkey or subkeys[-1] not in check_container:
+                continue
+
+        # anything else falls through to success
+        # includes keyfuncs which don't set _filter_key
+        fields.append((name, key))
+    return fields
 
 
 class CLIStubResponse:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import shlex
 import time
 import urllib.parse
@@ -119,6 +120,39 @@ def cli_runner():
     return CliRunner(mix_stderr=False)
 
 
+class OutputMatcher:
+    r"""
+    A helper for running regex matches and optionally doing literal checking of match
+    groups against expected strings. This can be attached to run_line by passing
+    "matcher=True".
+
+    Runs regex matches on a per-line basis until a match is found. On the first regex
+    match, it will test expected values and fail if they do not match.
+    If no match is found for the regex, it will raise an error.
+
+    Usage:
+
+    >>> res, matcher = run_line(..., matcher=True)
+    >>> matcher.check(r"^Foo:\s+(\w+)$", groups=["FooValue"])
+    """
+
+    def __init__(self, result):
+        self._result = result
+
+    def check(self, regex, groups=None, err=False) -> None:
+        pattern = re.compile(regex)
+        groups = groups or []
+        data = self._result.stderr if err else self._result.output
+        for line in data.split("\n"):
+            m = pattern.match(line)
+            if not m:
+                continue
+            for i, x in enumerate(groups, 1):
+                assert m.group(i) == x
+            return
+        raise ValueError(f"Did not find a match for '{regex}' in {data}")
+
+
 @pytest.fixture
 def run_line(cli_runner, request, patch_tokenstorage):
     """
@@ -129,7 +163,7 @@ def run_line(cli_runner, request, patch_tokenstorage):
     for easier debugging.
     """
 
-    def func(line, assert_exit_code=0, stdin=None):
+    def func(line, assert_exit_code=0, stdin=None, matcher=False):
         from globus_cli import main
 
         # split line into args and confirm line starts with "globus"
@@ -165,6 +199,8 @@ def run_line(cli_runner, request, patch_tokenstorage):
                     )
                 )
             )
+        if matcher:
+            return result, OutputMatcher(result)
         return result
 
     return func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,9 +126,8 @@ class OutputMatcher:
     groups against expected strings. This can be attached to run_line by passing
     "matcher=True".
 
-    Runs regex matches on a per-line basis until a match is found. On the first regex
-    match, it will test expected values and fail if they do not match.
-    If no match is found for the regex, it will raise an error.
+    Runs regex matches in multiline mode, operating on the first match.
+    If no match is found, it will raise an error.
 
     Usage:
 
@@ -140,17 +139,15 @@ class OutputMatcher:
         self._result = result
 
     def check(self, regex, groups=None, err=False) -> None:
-        pattern = re.compile(regex)
+        pattern = re.compile(regex, flags=re.MULTILINE)
         groups = groups or []
         data = self._result.stderr if err else self._result.output
-        for line in data.split("\n"):
-            m = pattern.match(line)
-            if not m:
-                continue
-            for i, x in enumerate(groups, 1):
-                assert m.group(i) == x
-            return
-        raise ValueError(f"Did not find a match for '{regex}' in {data}")
+
+        m = pattern.search(data)
+        if not m:
+            raise ValueError(f"Did not find a match for '{regex}' in {data}")
+        for i, x in enumerate(groups, 1):
+            assert m.group(i) == x
 
 
 @pytest.fixture

--- a/tests/files/api_fixtures/collection_operations.yaml
+++ b/tests/files/api_fixtures/collection_operations.yaml
@@ -3,6 +3,7 @@ metadata:
   guest_collection_id: "0e4a77f8-b778-4d5c-abaa-e1254e71427f"
   endpoint_id: "cf37806c-572c-47ff-88e2-511c646ef1a4"
   gcp_endpoint_id: "06e2c959-d311-4bab-b2ea-25ad77d9fc12"
+  username: "sirosen@globusid.org"
 
 transfer:
   - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15
@@ -10,6 +11,7 @@ transfer:
       {
         "DATA": [],
         "DATA_TYPE": "endpoint",
+        "display_name": "Happy Fun Collection Name",
         "gcs_version": "5.4.10",
         "host_endpoint_id": null,
         "id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
@@ -39,12 +41,29 @@ transfer:
           }
         ],
         "DATA_TYPE": "endpoint",
+        "activated": false,
+        "canonical_name": "cf37806c-572c-47ff-88e2-511c646ef1a4#myserver",
+        "contact_email": null,
+        "contact_info": null,
+        "default_directory": null,
+        "description": "example gcsv5 endpoint",
+        "department": null,
+        "display_name": "myserver",
+        "force_encryption": false,
         "gcs_version": "5.4.10",
         "host_endpoint_id": null,
         "id": "cf37806c-572c-47ff-88e2-511c646ef1a4",
         "is_globus_connect": false,
+        "info_link": null,
+        "keywords": null,
+        "local_user_info_available": false,
         "non_functional": true,
-        "owner_id": "cf37806c-572c-47ff-88e2-511c646ef1a4"
+        "organization": "My Org",
+        "owner_string": "cf37806c-572c-47ff-88e2-511c646ef1a4@clients.auth.globus.org",
+        "owner_id": "cf37806c-572c-47ff-88e2-511c646ef1a4",
+        "public": false,
+        "shareable": false,
+        "subscription_id": null,
       }
   - path: /endpoint/cf37806c-572c-47ff-88e2-511c646ef1a4/server_list
     json:
@@ -76,6 +95,23 @@ transfer:
         "owner_id": "c699d42e-d274-11e5-bf75-1fc5bf53bb24"
       }
 
+auth:
+  - path: /v2/api/identities
+    json:
+      {
+        "identities": [
+          {
+            "email": "sirosen@uchicago.edu",
+            "id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+            "identity_provider": "41143743-f3c8-4d60-bbdb-eeecaba85bd9",
+            "name": "Stephen Rosen",
+            "organization": "University of Chicago",
+            "status": "used",
+            "username": "sirosen@globusid.org"
+          }
+        ]
+      }
+
 gcs:
   - path: /collections/0e4a77f8-b778-4d5c-abaa-e1254e71427f
     method: delete
@@ -96,4 +132,24 @@ gcs:
         "data": [],
         "detail": "success",
         "http_response_code": 200
+      }
+  - path: /collections/1405823f-0597-4a16-b296-46d4f0ae4b15
+    json:
+      {
+        "DATA_TYPE": "result#1.0.0",
+        "code": "success",
+        "detail": "success",
+        "http_response_code": 200,
+        "data": [
+          {
+            "DATA_TYPE": "collection#1.0.0",
+            "public": true,
+            "id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+            "display_name": "Happy Fun Collection Name",
+            "identity_id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+            "collection_type": "mapped",
+            "storage_gateway_id": "6ebdbaa3-9c60-4637-9d26-1bcfa3921f6b",
+            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b"
+          }
+        ]
       }

--- a/tests/files/api_fixtures/collection_show_private_policies.yaml
+++ b/tests/files/api_fixtures/collection_show_private_policies.yaml
@@ -1,0 +1,94 @@
+metadata:
+  collection_id: "1405823f-0597-4a16-b296-46d4f0ae4b15"
+  endpoint_id: "cf37806c-572c-47ff-88e2-511c646ef1a4"
+  username: "sirosen@globusid.org"
+
+transfer:
+  - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15
+    json:
+      {
+        "DATA": [],
+        "DATA_TYPE": "endpoint",
+        "display_name": "Happy Fun Collection Name",
+        "gcs_version": "5.4.10",
+        "host_endpoint_id": null,
+        "id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+        "is_globus_connect": false,
+        "non_functional": false,
+        "owner_id": "cf37806c-572c-47ff-88e2-511c646ef1a4"
+      }
+  - path: /endpoint/cf37806c-572c-47ff-88e2-511c646ef1a4
+    json:
+     {
+        "DATA": [
+          {
+            "DATA_TYPE": "server",
+            "hostname": "abc.xyz.data.globus.org"
+          }
+        ],
+        "DATA_TYPE": "endpoint",
+        "gcs_version": "5.4.10",
+        "host_endpoint_id": null,
+        "id": "cf37806c-572c-47ff-88e2-511c646ef1a4",
+        "is_globus_connect": false,
+        "non_functional": true,
+        "owner_id": "cf37806c-572c-47ff-88e2-511c646ef1a4"
+      }
+  - path: /endpoint/cf37806c-572c-47ff-88e2-511c646ef1a4/server_list
+    json:
+     {
+        "DATA": [
+          {
+            "DATA_TYPE": "server",
+            "hostname": "abc.xyz.data.globus.org"
+          }
+        ],
+        "DATA_TYPE": "endpoint_server_list"
+      }
+
+auth:
+  - path: /v2/api/identities
+    json:
+      {
+        "identities": [
+          {
+            "email": "sirosen@uchicago.edu",
+            "id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+            "identity_provider": "41143743-f3c8-4d60-bbdb-eeecaba85bd9",
+            "name": "Stephen Rosen",
+            "organization": "University of Chicago",
+            "status": "used",
+            "username": "sirosen@globusid.org"
+          }
+        ]
+      }
+
+gcs:
+  - path: /collections/1405823f-0597-4a16-b296-46d4f0ae4b15
+    json:
+      {
+        "DATA_TYPE": "result#1.0.0",
+        "code": "success",
+        "detail": "success",
+        "http_response_code": 200,
+        "data": [
+          {
+            "DATA_TYPE": "collection#1.0.0",
+            "public": true,
+            "id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+            "display_name": "Happy Fun Collection Name",
+            "identity_id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+            "collection_type": "mapped",
+            "root_path": "/",
+            "collection_base_path": "/",
+            "storage_gateway_id": "6ebdbaa3-9c60-4637-9d26-1bcfa3921f6b",
+            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+            "sharing_restrict_paths": {
+                "DATA_TYPE": "path_restrictions#1.0.0",
+                "read": ["/projects"],
+                "read_write": ["$HOME"],
+                "none": ["/"]
+            }
+          }
+        ]
+      }

--- a/tests/functional/endpoint/test_endpoint_show.py
+++ b/tests/functional/endpoint/test_endpoint_show.py
@@ -30,3 +30,29 @@ def test_show_long_description(run_line, load_api_fixtures):
     assert "== 1.14.0\n" in result.output
     # much later lines should have been truncated out
     assert "== 1.13.0\n" not in result.output
+
+
+# confirm that this *does not* error:
+# showing a GCSv5 host needs to be supported for show (unlike update, delete, etc)
+def test_show_on_gcsv5_endpoint(run_line, load_api_fixtures):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"]["endpoint_id"]
+
+    result = run_line(f"globus endpoint show {epid}")
+    assert "Display Name:" in result.output
+    assert epid in result.output
+
+
+def test_show_on_gcsv5_collection(run_line, load_api_fixtures):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"]["mapped_collection_id"]
+
+    result = run_line(f"globus endpoint show {epid}", assert_exit_code=2)
+    assert (
+        f"Expected {epid} to be an endpoint ID.\n"
+        "Instead, found it was of type 'Mapped Collection'."
+    ) in result.stderr
+    assert (
+        "Please run the following command instead:\n\n"
+        f"    globus collection show {epid}"
+    ) in result.stderr

--- a/tests/functional/test_collection_commands.py
+++ b/tests/functional/test_collection_commands.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_guest_collection_delete(run_line, load_api_fixtures, add_gcs_login):
     data = load_api_fixtures("collection_operations.yaml")
     epid = data["metadata"]["endpoint_id"]
@@ -55,4 +58,70 @@ def test_collection_delete_on_gcp(run_line, load_api_fixtures):
     assert (
         "Please run the following command instead:\n\n"
         f"    globus endpoint delete {epid}"
+    ) in result.stderr
+
+
+def test_collection_show(run_line, load_api_fixtures, add_gcs_login):
+    data = load_api_fixtures("collection_operations.yaml")
+    cid = data["metadata"]["mapped_collection_id"]
+    username = data["metadata"]["username"]
+    epid = data["metadata"]["endpoint_id"]
+    add_gcs_login(epid)
+
+    _result, matcher = run_line(f"globus collection show {cid}", matcher=True)
+
+    matcher.check(r"^Display Name:\s+(.*)$", groups=["Happy Fun Collection Name"])
+    matcher.check(r"^Owner:\s+(.*)$", groups=[username])
+    matcher.check(r"^ID:\s+(.*)$", groups=[cid])
+    matcher.check(r"^Collection Type:\s+(.*)$", groups=["mapped"])
+    matcher.check(r"^Connector:\s+(.*)$", groups=["POSIX"])
+
+
+def test_collection_show_private_policies(run_line, load_api_fixtures, add_gcs_login):
+    data = load_api_fixtures("collection_show_private_policies.yaml")
+    cid = data["metadata"]["collection_id"]
+    username = data["metadata"]["username"]
+    epid = data["metadata"]["endpoint_id"]
+    add_gcs_login(epid)
+
+    _result, matcher = run_line(
+        f"globus collection show --include-private-policies {cid}", matcher=True
+    )
+
+    matcher.check(r"^Display Name:\s+(.*)$", groups=["Happy Fun Collection Name"])
+    matcher.check(r"^Owner:\s+(.*)$", groups=[username])
+    matcher.check(r"^ID:\s+(.*)$", groups=[cid])
+    matcher.check(r"^Collection Type:\s+(.*)$", groups=["mapped"])
+    matcher.check(r"^Connector:\s+(.*)$", groups=["POSIX"])
+
+    matcher.check(r"Root Path:\s+(.*)$", groups=["/"])
+    matcher.check(
+        r"^Sharing Path Restrictions:\s+(.*)$",
+        groups=[
+            '{"DATA_TYPE": "path_restrictions#1.0.0", "none": ["/"], "read": ["/projects"], "read_write": ["$HOME"]}',  # noqa: E501
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "epid_key, ep_type",
+    [
+        ("gcp_endpoint_id", "Globus Connect Personal"),
+        ("endpoint_id", "Globus Connect Server v5 Endpoint"),
+    ],
+)
+def test_collection_show_on_non_collection(
+    run_line, load_api_fixtures, epid_key, ep_type
+):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"][epid_key]
+
+    result = run_line(f"globus collection show {epid}", assert_exit_code=2)
+    assert (
+        f"Expected {epid} to be a collection ID.\n"
+        f"Instead, found it was of type '{ep_type}'."
+    ) in result.stderr
+    assert (
+        "Please run the following command instead:\n\n"
+        f"    globus endpoint show {epid}"
     ) in result.stderr

--- a/tests/unit/test_connector_name_helpers.py
+++ b/tests/unit/test_connector_name_helpers.py
@@ -1,0 +1,39 @@
+import uuid
+
+import pytest
+
+from globus_cli.services.gcs import (
+    connector_display_name_to_id,
+    connector_id_to_display_name,
+)
+
+
+@pytest.mark.parametrize(
+    "connector_id, connector_name",
+    [
+        ("145812c8-decc-41f1-83cf-bb2a85a2a70b", "POSIX"),
+        ("7e3f3f5e-350c-4717-891a-2f451c24b0d4", "BlackPearl"),
+        ("7c100eae-40fe-11e9-95a3-9cb6d0d9fd63", "Box"),
+        ("1b6374b0-f6a4-4cf7-a26f-f262d9c6ca72", "Ceph"),
+        ("28ef55da-1f97-11eb-bdfd-12704e0d6a4d", "OneDrive"),
+        ("976cf0cf-78c3-4aab-82d2-7c16adbcc281", "Google Drive"),
+        ("56366b96-ac98-11e9-abac-9cb6d0d9fd63", "Google Cloud Storage"),
+        ("7251f6c8-93c9-11eb-95ba-12704e0d6a4d", "ActiveScale"),
+        ("7643e831-5f6c-4b47-a07f-8ee90f401d23", "S3"),
+        ("052be037-7dda-4d20-b163-3077314dc3e6", "POSIX Staging"),
+        ("e47b6920-ff57-11ea-8aaa-000c297ab3c2", "iRODS"),
+    ],
+)
+def test_connector_id_name_methods_are_inverses(connector_id, connector_name):
+    assert connector_display_name_to_id(connector_name) == connector_id
+    assert connector_id_to_display_name(connector_id) == connector_name
+
+
+def test_name_of_unknown_connector_id():
+    fake_id = str(uuid.UUID(int=0))
+    assert connector_id_to_display_name(fake_id) == f"UNKNOWN ({fake_id})"
+
+
+def test_id_of_unknown_connector_name():
+    fake_name = "foo-invalid"
+    assert connector_display_name_to_id(fake_name) is None


### PR DESCRIPTION
This pulls in a few significant pieces from gcs-cli without significant modifications. In particular, the connector name<->id mapping information is pulled from there (and reformatted a bit), and the PrincipalResolver (which we will need for other GCS commands) is pulled in without changes.

The idea of the PrincipalResolver is that it handles rewriting an ID to a username, or rewriting a URN to a username. We may want to make this into one of our field objects in the future, but for now it is left unchanged.

`--include-private-policies` and the test data for it are copied pretty much verbatim from gcs-cli.

One odd nuance is that if we remap `collection show` and `endpoint show` the same way we did `delete`, we won't be able to handle a GCSv5 Host Endpoint. That doesn't make a ton of sense, so this is tweaked a bit to allow `globus endpoint show` on any non-collection endpoint(ish).

Tests exercise most of the new functionality, but a bit of `PrincipalResolver` is not being used yet.