### PR TITLE
Add 'collection update' command

### DIFF
--- a/src/globus_cli/commands/collection/__init__.py
+++ b/src/globus_cli/commands/collection/__init__.py
@@ -2,6 +2,7 @@ from globus_cli.parsing import group
 
 from .delete import collection_delete
 from .show import collection_show
+from .update import collection_update
 
 
 @group("collection")
@@ -12,3 +13,4 @@ def collection_command():
 # commands
 collection_command.add_command(collection_delete)
 collection_command.add_command(collection_show)
+collection_command.add_command(collection_update)

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -60,7 +60,7 @@ PRIVATE_FIELDS = [
 )
 def collection_show(login_manager, *, include_private_policies, collection_id):
     """
-    Show a Collection on the current Endpoint
+    Display a Mapped or Guest Collection
     """
     endpoint_id = Endpointish(collection_id).get_collection_endpoint_id()
     login_manager.assert_logins(endpoint_id, assume_gcs=True)

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -1,0 +1,266 @@
+import click
+from globus_sdk import GuestCollectionDocument, MappedCollectionDocument
+
+from globus_cli.constants import EXPLICIT_NULL
+from globus_cli.endpointish import Endpointish, EndpointType
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import (
+    CommaDelimitedList,
+    JSONStringOrFile,
+    StringOrNull,
+    UrlOrNull,
+    collection_id_arg,
+    command,
+    mutex_option_group,
+    nullable_multi_callback,
+)
+from globus_cli.services.gcs import get_gcs_client
+from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+
+
+def _mkhelp(txt):
+    return f"New {txt} the collection"
+
+
+def collection_update_params(f):
+    """
+    Collection of options consumed by GCS Collection update
+
+    Usage:
+
+    >>> @collection_create_and_update_params(create=False)
+    >>> def command_func(**kwargs):
+    >>>     ...
+    """
+    multi_use_option_str = "Give this option multiple times in a single command"
+
+    f = click.option(
+        "--public/--private",
+        "public",
+        default=None,
+        help="Set the collection to be public or private",
+    )(f)
+    f = click.option(
+        "--description", type=StringOrNull(), help=_mkhelp("description for")
+    )(f)
+    f = click.option(
+        "--info-link", type=StringOrNull(), help=_mkhelp("link for info about")
+    )(f)
+    f = click.option(
+        "--contact-info", type=StringOrNull(), help=_mkhelp("contact Info for")
+    )(f)
+    f = click.option(
+        "--contact-email",
+        type=StringOrNull(),
+        help=_mkhelp("contact email for"),
+    )(f)
+    f = click.option(
+        "--organization", type=StringOrNull(), help=_mkhelp("organization for")
+    )(f)
+    f = click.option(
+        "--department", type=StringOrNull(), help=_mkhelp("department which operates")
+    )(f)
+    f = click.option(
+        "--keywords",
+        type=CommaDelimitedList(),
+        help=_mkhelp("comma separated list of keywords to help searches for"),
+    )(f)
+    f = click.option("--display-name", help=_mkhelp("name for"))(f)
+    f = click.option(
+        "--force-encryption/--no-force-encryption",
+        "force_encryption",
+        default=None,
+        help=(
+            "When set, all transfers to and from this collection are "
+            "always encrypted"
+        ),
+    )(f)
+    f = click.option(
+        "--sharing-restrict-paths",
+        type=JSONStringOrFile(null="null"),
+        help="Path restrictions for sharing data on guest collections "
+        "based on this collection. This option is only usable on Mapped "
+        "Collections",
+    )(f)
+    f = click.option(
+        "--allow-guest-collections/--no-allow-guest-collections",
+        "allow_guest_collections",
+        default=None,
+        help=(
+            "Allow Guest Collections to be created on this Collection. This option "
+            "is only usable on Mapped Collections. If this option is disabled on a "
+            "Mapped Collection which already has associated Guest Collections, "
+            "those collections will no longer be accessible"
+        ),
+    )(f)
+    f = click.option(
+        "--disable-anonymous-writes/--enable-anonymous-writes",
+        default=None,
+        help=(
+            "Allow anonymous write ACLs on Guest Collections attached to this "
+            "Mapped Collection. This option is only usable on non high assurance "
+            "Mapped Collections and the setting is inherited by the hosted Guest "
+            "Collections. Anonymous write ACLs are enabled by default "
+            "(requires an endpoint with API v1.8.0)"
+        ),
+    )(f)
+    f = click.option(
+        "--domain-name",
+        "domain_name",
+        default=None,
+        help=(
+            "DNS host name for the collection (mapped "
+            "collections only). This may be either a host name "
+            "or a fully-qualified domain name, but if it is the latter "
+            "it must be a subdomain of the endpoint's domain"
+        ),
+    )(f)
+    f = click.option(
+        "--default-directory",
+        default=None,
+        help="Default directory when browsing the collection",
+    )(f)
+    f = click.option(
+        "--enable-https",
+        is_flag=True,
+        help=(
+            "Explicitly enable HTTPS supprt (requires a managed endpoint "
+            "with API v1.1.0)"
+        ),
+    )(f)
+
+    f = click.option(
+        "--disable-https",
+        is_flag=True,
+        help=(
+            "Explicitly disable HTTPS supprt (requires a managed endpoint "
+            "with API v1.1.0)"
+        ),
+    )(f)
+    f = click.option(
+        "--user-message",
+        help=(
+            "A message for clients to display to users when interacting "
+            "with this collection"
+        ),
+        type=StringOrNull(),
+    )(f)
+    f = click.option(
+        "--user-message-link",
+        help=(
+            "Link to additional messaging for clients to display to users "
+            "when interacting with this endpoint, linked to an http or https URL "
+            "with this collection"
+        ),
+        type=UrlOrNull(),
+    )(f)
+    f = click.option(
+        "--sharing-user-allow",
+        "sharing_users_allow",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "Connector-specific username allowed to create guest collections."
+            f"{multi_use_option_str} to allow multiple users. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--sharing-user-deny",
+        "sharing_users_deny",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "Connector-specific username denied permission to create guest "
+            f"collections. {multi_use_option_str} to deny multiple users. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+
+    f = click.option(
+        "--verify",
+        type=click.Choice(["force", "disable", "default"], case_sensitive=False),
+        help=(
+            "Set the policy for this collection for file integrity verification "
+            "after transfer. 'force' requires all transfers to perform "
+            "verfication. 'disable' disables all verification checks. 'default' "
+            "allows the user to decide on verification at Transfer task submit  "
+            "time. When set on mapped collections, this policy is inherited by any "
+            "guest collections"
+        ),
+    )(f)
+    return f
+
+
+@command("update", short_help="Update a Collection definition")
+@collection_id_arg
+@collection_update_params
+@mutex_option_group("--enable-https", "--disable-https")
+@LoginManager.requires_login(
+    LoginManager.TRANSFER_RS, LoginManager.AUTH_RS, pass_manager=True
+)
+def collection_update(
+    login_manager,
+    *,
+    collection_id,
+    verify,
+    **kwargs,
+):
+    """
+    Update a Mapped or Guest Collection
+    """
+    epish = Endpointish(collection_id)
+    endpoint_id = epish.get_collection_endpoint_id()
+    login_manager.assert_logins(endpoint_id, assume_gcs=True)
+    client = get_gcs_client(endpoint_id)
+
+    if epish.ep_type == EndpointType.GUEST_COLLECTION:
+        doc_class = GuestCollectionDocument
+
+        if any(
+            kwargs.get(k) is not None
+            for k in (
+                "sharing_restrict_paths",
+                "sharing_users_allow",
+                "sharing_users_deny",
+                "allow_guest_collections",
+                "disable_anonymous_writes",
+                "domain_name",
+            )
+        ):
+            raise click.UsageError("Use of incompatible options with Guest Collection.")
+    else:
+        doc_class = MappedCollectionDocument
+
+    # convert keyword args as follows:
+    # - filter out Nones
+    # - pass through EXPLICIT_NULL as None
+    converted_kwargs = {
+        k: (v if v != EXPLICIT_NULL else None)
+        for k, v in kwargs.items()
+        if v is not None
+    }
+
+    if converted_kwargs.get("enable_https") is False:
+        converted_kwargs.pop("enable_https")
+    if converted_kwargs.pop("disable_https", None):
+        converted_kwargs["enable_https"] = False
+
+    if verify is not None:
+        if verify.lower() == "force":
+            converted_kwargs["force_verify"] = True
+            converted_kwargs["disable_verify"] = False
+        elif verify.lower() == "disable":
+            converted_kwargs["force_verify"] = False
+            converted_kwargs["disable_verify"] = True
+        else:
+            converted_kwargs["force_verify"] = False
+            converted_kwargs["disable_verify"] = False
+
+    doc = doc_class(**converted_kwargs)
+    res = client.update_collection(collection_id, doc)
+    formatted_print(
+        res,
+        fields=[("code", lambda x: x.full_data["code"])],
+        text_format=FORMAT_TEXT_RECORD,
+    )

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -1,3 +1,4 @@
+from globus_cli.endpointish import Endpointish
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.services.transfer import assemble_generic_doc, get_client
@@ -18,18 +19,20 @@ def endpoint_update(**kwargs):
     # validate params. Requires a get call to check the endpoint type
     client = get_client()
     endpoint_id = kwargs.pop("endpoint_id")
-    get_res = client.get_endpoint(endpoint_id)
 
-    if get_res["host_endpoint_id"]:
+    epish = Endpointish(endpoint_id, transfer_client=client)
+    epish.assert_is_traditional_endpoint()
+
+    if epish.data["host_endpoint_id"]:
         endpoint_type = "shared"
-    elif get_res["is_globus_connect"]:
+    elif epish.data["is_globus_connect"]:
         endpoint_type = "personal"
-    elif get_res["s3_url"]:
+    elif epish.data["s3_url"]:
         endpoint_type = "s3"
     else:
         endpoint_type = "server"
     validate_endpoint_create_and_update_params(
-        endpoint_type, get_res["subscription_id"], kwargs
+        endpoint_type, epish.data["subscription_id"], kwargs
     )
 
     # make the update

--- a/src/globus_cli/constants.py
+++ b/src/globus_cli/constants.py
@@ -8,7 +8,18 @@ It should not depend on any other part of the globus-cli codebase.
 __all__ = ["EXPLICIT_NULL"]
 
 
-# this object is a sentinel value used to disambiguate values which are being
-# intentionally nulled from values which are incidentally `None` because no
-# argument was provided
-EXPLICIT_NULL = object()
+class _ExplicitNullClass:
+    """
+    Magic sentinel value used to disambiguate values which are being
+    intentionally nulled from values which are `None` because no argument was
+    provided
+    """
+
+    def __bool__(self):
+        return False
+
+    def __repr__(self):
+        return "null"
+
+
+EXPLICIT_NULL = _ExplicitNullClass()

--- a/src/globus_cli/endpointish/endpointish.py
+++ b/src/globus_cli/endpointish/endpointish.py
@@ -23,6 +23,10 @@ class Endpointish:
 
         self.ep_type = EndpointType.determine_endpoint_type(self.data)
 
+    @property
+    def nice_type_name(self) -> str:
+        return EndpointType.nice_name(self.ep_type)
+
     def assert_ep_type(
         self,
         expect_types: Tuple[EndpointType, ...],

--- a/src/globus_cli/endpointish/errors.py
+++ b/src/globus_cli/endpointish/errors.py
@@ -15,6 +15,12 @@ SHOULD_USE_MAP = {
     "globus endpoint show": [
         ("globus collection show", EndpointType.collections()),
     ],
+    "globus collection update": [
+        ("globus endpoint update", EndpointType.traditional_endpoints()),
+    ],
+    "globus endpoint update": [
+        ("globus collection update", EndpointType.collections()),
+    ],
 }
 
 

--- a/src/globus_cli/parsing/__init__.py
+++ b/src/globus_cli/parsing/__init__.py
@@ -15,9 +15,14 @@ from globus_cli.parsing.shared_options import (
 from .param_types import (
     ENDPOINT_PLUS_OPTPATH,
     ENDPOINT_PLUS_REQPATH,
+    CommaDelimitedList,
     IdentityType,
+    JSONStringOrFile,
     LocationType,
+    StringOrNull,
     TaskPath,
+    UrlOrNull,
+    nullable_multi_callback,
 )
 
 __all__ = [
@@ -29,12 +34,17 @@ __all__ = [
     # param types
     "ENDPOINT_PLUS_OPTPATH",
     "ENDPOINT_PLUS_REQPATH",
-    "TaskPath",
-    "one_use_option",
-    "MutexInfo",
-    "mutex_option_group",
+    "CommaDelimitedList",
     "IdentityType",
+    "JSONStringOrFile",
     "LocationType",
+    "MutexInfo",
+    "StringOrNull",
+    "TaskPath",
+    "UrlOrNull",
+    "mutex_option_group",
+    "nullable_multi_callback",
+    "one_use_option",
     # Transfer options
     "collection_id_arg",
     "endpoint_id_arg",

--- a/src/globus_cli/parsing/param_types/__init__.py
+++ b/src/globus_cli/parsing/param_types/__init__.py
@@ -1,3 +1,4 @@
+from .comma_delimited import CommaDelimitedList
 from .endpoint_plus_path import (
     ENDPOINT_PLUS_OPTPATH,
     ENDPOINT_PLUS_REQPATH,
@@ -5,13 +6,20 @@ from .endpoint_plus_path import (
 )
 from .identity_type import IdentityType
 from .location import LocationType
+from .nullable import StringOrNull, UrlOrNull, nullable_multi_callback
+from .prefix_mapper import JSONStringOrFile
 from .task_path import TaskPath
 
 __all__ = (
+    "CommaDelimitedList",
     "ENDPOINT_PLUS_OPTPATH",
     "ENDPOINT_PLUS_REQPATH",
     "EndpointPlusPath",
     "IdentityType",
     "LocationType",
+    "StringOrNull",
+    "UrlOrNull",
+    "nullable_multi_callback",
+    "JSONStringOrFile",
     "TaskPath",
 )

--- a/src/globus_cli/parsing/param_types/comma_delimited.py
+++ b/src/globus_cli/parsing/param_types/comma_delimited.py
@@ -1,0 +1,24 @@
+import click
+
+
+class CommaDelimitedList(click.ParamType):
+    def get_metavar(self, param):
+        return "TEXT,TEXT,..."
+
+    def convert(self, value, param, ctx):
+        value = super().convert(value, param, ctx)
+        if value is None:
+            return None
+        # if `--foo` is a comma delimited list and someone passes
+        # `--foo ""`, take that as `foo=[]` rather than foo=[""]
+        #
+        # the alternative is fine, but we have to choose one and this is
+        # probably "closer to what the caller meant"
+        #
+        # it means that if you take
+        # `--foo={",".join(original)}`, you will get a value equal to
+        # `original` back if `original=[]` (but not if `original=[""]`)
+        elif value == "":
+            return []
+        else:
+            return value.split(",")

--- a/src/globus_cli/parsing/param_types/nullable.py
+++ b/src/globus_cli/parsing/param_types/nullable.py
@@ -70,6 +70,6 @@ class UrlOrNull(StringOrNull):
                 assert url[0] in ["http", "https"]
             except Exception:
                 raise click.UsageError(
-                    f"{value} did not contain a well-formed http or https URL"
+                    f"'{value}' is not a well-formed http or https URL"
                 )
             return value

--- a/src/globus_cli/parsing/param_types/nullable.py
+++ b/src/globus_cli/parsing/param_types/nullable.py
@@ -1,0 +1,75 @@
+from urllib.parse import urlparse
+
+import click
+
+from globus_cli.constants import EXPLICIT_NULL
+
+
+def nullable_multi_callback(null="null"):
+    """
+    A callback which converts multiple=True options as follows:
+    - empty results, [] => None
+    - [<null>,] => []
+    - anything else => passthrough
+
+    This makes the null value explicit, and not setting it results in omission, not
+    clearing.
+
+    The null value used here is tunable. If set to a non-string value when using a
+    string type, like `None`, it means that "there is no null value" because
+    there is no way to pass `[]`
+
+    Note that this will see values after the type conversion has happened.
+    """
+
+    def callback(ctx, param, value):
+        if value is None or len(value) == 0:
+            return None
+        if len(value) == 1 and value[0] == null:
+            return []
+        return value
+
+    return callback
+
+
+class StringOrNull(click.ParamType):
+    """
+    Very similar to a basic string type, but one in which the empty string will
+    be converted into an EXPLICIT_NULL
+    """
+
+    def get_metavar(self, param):
+        return "TEXT"
+
+    def convert(self, value, param, ctx):
+        if value is None:
+            return None
+        elif value == "":
+            return EXPLICIT_NULL
+        else:
+            return value
+
+
+class UrlOrNull(StringOrNull):
+    """
+    Very similar to StringOrNull, but validates that the string is parsable as an
+    http or https URL.
+    """
+
+    def get_metavar(self, param):
+        return "TEXT"
+
+    def convert(self, value, param, ctx):
+        if value is None:
+            return None
+        elif value == "":
+            return EXPLICIT_NULL
+        else:
+            try:
+                url = urlparse(value)
+                assert url[0] in ["http", "https"]
+            except Exception:
+                raise click.UsageError(
+                    f"{value} did not contain a well-formed http or https URL"
+                )
+            return value

--- a/src/globus_cli/parsing/param_types/prefix_mapper.py
+++ b/src/globus_cli/parsing/param_types/prefix_mapper.py
@@ -1,0 +1,86 @@
+import json
+from typing import Dict, List
+
+import click
+
+from globus_cli.constants import EXPLICIT_NULL
+
+
+class StringPrefixMapper(click.ParamType):
+    """
+    This is the base class for mapping types which try to split up inputs and parse them
+    based on identifying prefixes
+
+    It can be used to define a nice system for dispatch on prefixes
+    """
+
+    __prefix_mapping__: Dict[str, str] = {}
+    __prefix_metavars__: List[str] = []
+
+    def __init__(self, *args, null=None, **kwargs):
+        self.null = null
+        super().__init__(*args, **kwargs)
+
+    def get_metavar(self, param):
+        return "[" + "|".join(self.__prefix_metavars__) + "]"
+
+    def convert(self, value, param, ctx):
+        if value is None:
+            return None
+        if self.null is not None and value == self.null:
+            return EXPLICIT_NULL
+
+        return self.prefix_mapper_parse_input(value)
+
+    def _prefix_mapper_get_parser(self, parsername):
+        return getattr(self, parsername)
+
+    def prefix_mapper_default_parser(self, value):
+        """override-able default (no-op)"""
+        return value
+
+    def prefix_mapper_parse_input(self, value):
+        """
+        Given an input, try to map it to a parsing func by prefix
+        """
+        for prefix, parser in self.__prefix_mapping__.items():
+            if value.startswith(prefix):
+                value = value[len(prefix) :]
+                return self._prefix_mapper_get_parser(parser)(value)
+        return self.prefix_mapper_default_parser(value)
+
+
+class JSONStringOrFile(StringPrefixMapper):
+    """
+    This type parses a JSON string or falls back to loading JSON data from a
+    path, specified by `file:PATH`
+
+    Implements file: -> json
+    Default is parse-as-JSON
+    """
+
+    __prefix_mapping__ = {"file:": "prefix_mapper_parse_json_file"}
+    __prefix_metavars__ = ["JSON", "file:JSON_FILE"]
+
+    def prefix_mapper_parse_json_file(self, value):
+        try:
+            with open(value) as fp:
+                return json.load(fp)
+        except json.JSONDecodeError:
+            raise click.UsageError(f"{value} did not contain valid JSON")
+        except FileNotFoundError:
+            raise click.UsageError(f"FileNotFound: {value} does not exist")
+
+    def prefix_mapper_default_parser(self, value):
+        """
+        The mapper also provides a shared JSON string parser which produces nice errors
+        """
+        # try to handle by parsing as JSON data
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            addendum = (
+                ". Did you mean to use 'file:'?" if value.startswith("file") else ""
+            )
+            # did not match as a URI or parse as JSON, error
+            raise click.UsageError(f"the string '{value}' is not valid JSON{addendum}")

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -1,5 +1,24 @@
+import inspect
 import json
-from typing import Dict, Iterator, Optional
+from typing import Callable, Dict, Iterable, Iterator, List, Optional
+
+import click
+
+
+def get_current_option_help(
+    *, filter_names: Optional[Iterable[str]] = None
+) -> List[str]:
+    ctx = click.get_current_context()
+    cmd = ctx.command
+    opts = [x for x in cmd.params if isinstance(x, click.Option)]
+    if filter_names is not None:
+        opts = [o for o in opts if o.name is not None and o.name in filter_names]
+    return [o.get_error_hint(ctx) for o in opts]
+
+
+def supported_parameters(c: Callable) -> List[str]:
+    sig = inspect.signature(c)
+    return list(sig.parameters.keys())
 
 
 def format_list_of_words(first: str, *rest: str):

--- a/tests/files/api_fixtures/collection_operations.yaml
+++ b/tests/files/api_fixtures/collection_operations.yaml
@@ -26,7 +26,7 @@ transfer:
         "DATA_TYPE": "endpoint",
         "gcs_version": "5.4.10",
         "host_endpoint_id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
-        "id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+        "id": "0e4a77f8-b778-4d5c-abaa-e1254e71427f",
         "is_globus_connect": false,
         "non_functional": false,
         "owner_id": "cf37806c-572c-47ff-88e2-511c646ef1a4"
@@ -150,6 +150,82 @@ gcs:
             "collection_type": "mapped",
             "storage_gateway_id": "6ebdbaa3-9c60-4637-9d26-1bcfa3921f6b",
             "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b"
+          }
+        ]
+      }
+  - path: /collections/1405823f-0597-4a16-b296-46d4f0ae4b15
+    method: patch
+    json:
+      {
+        "DATA_TYPE": "result#1.0.0",
+        "code": "success",
+        "detail": "success",
+        "http_response_code": 200,
+        "data": [
+          {
+            "DATA_TYPE": "collection#1.0.0",
+            "authentication_assurance_timeout": 30,
+            "authentication_timeout_mins": 30,
+            "collection_type": "mapped",
+            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+            "contact_email": "user@example.com",
+            "contact_info": "string",
+            "default_directory": "/",
+            "department": "globus",
+            "description": "example collection",
+            "display_name": "Happy Fun Collection Name",
+            "force_encryption": true,
+            "https_url": "http://example.com",
+            "id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+            "identity_id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+            "info_link": "http://example.com",
+            "keywords": "example",
+            "manager_url": "https://gcs.data.globus.org/",
+            "organization": "uchicago",
+            "policies": {},
+            "public": true,
+            "root_path": "/",
+            "storage_gateway_id": "6ebdbaa3-9c60-4637-9d26-1bcfa3921f6b",
+            "tlsftp_url": "http://example.com"
+          }
+        ]
+      }
+  - path: /collections/0e4a77f8-b778-4d5c-abaa-e1254e71427f
+    method: patch
+    json:
+      {
+        "DATA_TYPE": "result#1.0.0",
+        "code": "success",
+        "detail": "success",
+        "http_response_code": 200,
+        "data": [
+          {
+            "DATA_TYPE": "collection#1.0.0",
+            "authentication_assurance_timeout": 30,
+            "authentication_timeout_mins": 30,
+            "collection_type": "guest",
+            "contact_email": "user@example.com",
+            "default_directory": "/",
+            "department": "globus",
+            "description": "example collection",
+            "display_name": "Happy Fun Guest Collection Name",
+            "force_encryption": true,
+            "gcs_version": "5.4.10",
+            "host_endpoint_id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+            "https_url": "http://example.com",
+            "id": "0e4a77f8-b778-4d5c-abaa-e1254e71427f",
+            "identity_id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+            "info_link": "http://example.com",
+            "is_globus_connect": false,
+            "keywords": "example",
+            "manager_url": "https://gcs.data.globus.org/",
+            "non_functional": false,
+            "organization": "uchicago",
+            "owner_id": "cf37806c-572c-47ff-88e2-511c646ef1a4",
+            "policies": {},
+            "public": true,
+            "root_path": "/",
+            "tlsftp_url": "http://example.com"
           }
         ]
       }

--- a/tests/functional/collection/test_collection_delete.py
+++ b/tests/functional/collection/test_collection_delete.py
@@ -1,0 +1,58 @@
+def test_guest_collection_delete(run_line, load_api_fixtures, add_gcs_login):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"]["endpoint_id"]
+    cid = data["metadata"]["guest_collection_id"]
+    add_gcs_login(epid)
+
+    result = run_line(f"globus collection delete {cid}")
+    assert "success" in result.output
+
+
+def test_mapped_collection_delete(run_line, load_api_fixtures, add_gcs_login):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"]["endpoint_id"]
+    cid = data["metadata"]["mapped_collection_id"]
+    add_gcs_login(epid)
+
+    result = run_line(f"globus collection delete {cid}")
+    assert "success" in result.output
+
+
+def test_collection_delete_missing_login(run_line, load_api_fixtures):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"]["endpoint_id"]
+    cid = data["metadata"]["guest_collection_id"]
+
+    result = run_line(f"globus collection delete {cid}", assert_exit_code=1)
+    assert "success" not in result.output
+    assert f"Missing login for {epid}" in result.stderr
+    assert f"  globus login --gcs {epid}" in result.stderr
+
+
+def test_collection_delete_on_gcsv5_host(run_line, load_api_fixtures):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"]["endpoint_id"]
+
+    result = run_line(f"globus collection delete {epid}", assert_exit_code=2)
+    assert "success" not in result.output
+    assert (
+        f"Expected {epid} to be a collection ID.\n"
+        "Instead, found it was of type 'Globus Connect Server v5 Endpoint'."
+    ) in result.stderr
+    assert "This operation is not supported on objects of this type." in result.stderr
+
+
+def test_collection_delete_on_gcp(run_line, load_api_fixtures):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"]["gcp_endpoint_id"]
+
+    result = run_line(f"globus collection delete {epid}", assert_exit_code=2)
+    assert "success" not in result.output
+    assert (
+        f"Expected {epid} to be a collection ID.\n"
+        "Instead, found it was of type 'Globus Connect Personal'."
+    ) in result.stderr
+    assert (
+        "Please run the following command instead:\n\n"
+        f"    globus endpoint delete {epid}"
+    ) in result.stderr

--- a/tests/functional/collection/test_collection_show.py
+++ b/tests/functional/collection/test_collection_show.py
@@ -1,66 +1,6 @@
 import pytest
 
 
-def test_guest_collection_delete(run_line, load_api_fixtures, add_gcs_login):
-    data = load_api_fixtures("collection_operations.yaml")
-    epid = data["metadata"]["endpoint_id"]
-    cid = data["metadata"]["guest_collection_id"]
-    add_gcs_login(epid)
-
-    result = run_line(f"globus collection delete {cid}")
-    assert "success" in result.output
-
-
-def test_mapped_collection_delete(run_line, load_api_fixtures, add_gcs_login):
-    data = load_api_fixtures("collection_operations.yaml")
-    epid = data["metadata"]["endpoint_id"]
-    cid = data["metadata"]["mapped_collection_id"]
-    add_gcs_login(epid)
-
-    result = run_line(f"globus collection delete {cid}")
-    assert "success" in result.output
-
-
-def test_collection_delete_missing_login(run_line, load_api_fixtures):
-    data = load_api_fixtures("collection_operations.yaml")
-    epid = data["metadata"]["endpoint_id"]
-    cid = data["metadata"]["guest_collection_id"]
-
-    result = run_line(f"globus collection delete {cid}", assert_exit_code=1)
-    assert "success" not in result.output
-    assert f"Missing login for {epid}" in result.stderr
-    assert f"  globus login --gcs {epid}" in result.stderr
-
-
-def test_collection_delete_on_gcsv5_host(run_line, load_api_fixtures):
-    data = load_api_fixtures("collection_operations.yaml")
-    epid = data["metadata"]["endpoint_id"]
-
-    result = run_line(f"globus collection delete {epid}", assert_exit_code=2)
-    assert "success" not in result.output
-    assert (
-        f"Expected {epid} to be a collection ID.\n"
-        "Instead, found it was of type 'Globus Connect Server v5 Endpoint'."
-    ) in result.stderr
-    assert "This operation is not supported on objects of this type." in result.stderr
-
-
-def test_collection_delete_on_gcp(run_line, load_api_fixtures):
-    data = load_api_fixtures("collection_operations.yaml")
-    epid = data["metadata"]["gcp_endpoint_id"]
-
-    result = run_line(f"globus collection delete {epid}", assert_exit_code=2)
-    assert "success" not in result.output
-    assert (
-        f"Expected {epid} to be a collection ID.\n"
-        "Instead, found it was of type 'Globus Connect Personal'."
-    ) in result.stderr
-    assert (
-        "Please run the following command instead:\n\n"
-        f"    globus endpoint delete {epid}"
-    ) in result.stderr
-
-
 def test_collection_show(run_line, load_api_fixtures, add_gcs_login):
     data = load_api_fixtures("collection_operations.yaml")
     cid = data["metadata"]["mapped_collection_id"]

--- a/tests/functional/collection/test_collection_update.py
+++ b/tests/functional/collection/test_collection_update.py
@@ -1,0 +1,116 @@
+import json
+
+import pytest
+import responses
+
+
+@pytest.mark.parametrize("cid_key", ["mapped_collection_id", "guest_collection_id"])
+def test_collection_update(run_line, load_api_fixtures, add_gcs_login, cid_key):
+    is_mapped = cid_key.startswith("mapped")
+
+    data = load_api_fixtures("collection_operations.yaml")
+    cid = data["metadata"][cid_key]
+    epid = data["metadata"]["endpoint_id"]
+    add_gcs_login(epid)
+
+    ep_type_specific_opts = []
+    if is_mapped:
+        ep_type_specific_opts = ["--sharing-user-allow", ""]
+
+    result = run_line(
+        [
+            "globus",
+            "collection",
+            "update",
+            cid,
+            "--description",
+            "FooBar",
+            "--keywords",
+            "foo,bar",
+        ]
+        + ep_type_specific_opts
+    )
+    assert "success" in result.output
+
+    sent = json.loads(responses.calls[-1].request.body)
+    assert "description" in sent
+    assert sent["description"] == "FooBar"
+    assert "keywords" in sent
+    assert sent["keywords"] == ["foo", "bar"]
+    if is_mapped:
+        assert "sharing_users_allow" in sent
+        assert sent["sharing_users_allow"] == []
+
+
+@pytest.mark.parametrize(
+    "verify_str, verify_settings",
+    [
+        ("force", {"force_verify": True, "disable_verify": False}),
+        ("disable", {"force_verify": False, "disable_verify": True}),
+        ("default", {"force_verify": False, "disable_verify": False}),
+    ],
+)
+@pytest.mark.parametrize("cid_key", ["mapped_collection_id", "guest_collection_id"])
+def test_collection_update_verify_opts(
+    run_line, load_api_fixtures, add_gcs_login, verify_str, verify_settings, cid_key
+):
+    data = load_api_fixtures("collection_operations.yaml")
+    cid = data["metadata"][cid_key]
+    epid = data["metadata"]["endpoint_id"]
+    add_gcs_login(epid)
+
+    result = run_line(["globus", "collection", "update", cid, "--verify", verify_str])
+    assert "success" in result.output
+
+    sent = json.loads(responses.calls[-1].request.body)
+    for k, v in verify_settings.items():
+        assert k in sent
+        assert sent[k] == v
+
+
+def test_collection_update_on_gcp(run_line, load_api_fixtures):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"]["gcp_endpoint_id"]
+
+    result = run_line(
+        f"globus collection update {epid} --description foo", assert_exit_code=2
+    )
+    assert (
+        f"Expected {epid} to be a collection ID.\n"
+        "Instead, found it was of type 'Globus Connect Personal'."
+    ) in result.stderr
+    assert (
+        "Please run the following command instead:\n\n"
+        f"    globus endpoint update {epid}"
+    ) in result.stderr
+
+
+def test_collection_update_on_gcsv5_host(run_line, load_api_fixtures):
+    data = load_api_fixtures("collection_operations.yaml")
+    epid = data["metadata"]["endpoint_id"]
+
+    result = run_line(
+        f"globus collection update {epid} --description foo", assert_exit_code=2
+    )
+    assert "success" not in result.output
+    assert (
+        f"Expected {epid} to be a collection ID.\n"
+        "Instead, found it was of type 'Globus Connect Server v5 Endpoint'."
+    ) in result.stderr
+    assert "This operation is not supported on objects of this type." in result.stderr
+
+
+def test_gust_collection_update_rejects_invalid_opts(
+    run_line, load_api_fixtures, add_gcs_login
+):
+    data = load_api_fixtures("collection_operations.yaml")
+    cid = data["metadata"]["guest_collection_id"]
+    epid = data["metadata"]["endpoint_id"]
+    add_gcs_login(epid)
+
+    result = run_line(
+        ["globus", "collection", "update", cid, "--sharing-user-allow", ""],
+        assert_exit_code=2,
+    )
+    assert "success" not in result.output
+    assert "Use of incompatible options with Guest Collection" in result.stderr

--- a/tests/unit/test_param_types.py
+++ b/tests/unit/test_param_types.py
@@ -1,0 +1,164 @@
+import json
+
+import click
+
+from globus_cli.constants import EXPLICIT_NULL
+from globus_cli.parsing import CommaDelimitedList, JSONStringOrFile, StringOrNull
+from globus_cli.parsing.param_types.prefix_mapper import StringPrefixMapper
+
+
+def test_string_or_null(runner):
+    @click.command()
+    @click.option(
+        "--bar", type=StringOrNull(), default=None, help="a string or null value"
+    )
+    def foo(bar):
+        if bar is None:
+            click.echo("none")
+        elif bar is EXPLICIT_NULL:
+            click.echo("null")
+        else:
+            click.echo(bar)
+
+    # in helptext, it shows up with "string" as the metavar
+    result = runner.invoke(foo, ["--help"])
+    assert "--bar TEXT  a string or null value" in result.output
+
+    # absent, it returns None
+    result = runner.invoke(foo, [])
+    assert result.output == "none\n"
+
+    # given empty string returns explicit null value
+    result = runner.invoke(foo, ["--bar", ""])
+    assert result.output == "null\n"
+
+    # given a string, it returns that string
+    result = runner.invoke(foo, ["--bar", "alpha"])
+    assert result.output == "alpha\n"
+
+
+def test_comma_delimited_list(runner):
+    @click.command()
+    @click.option(
+        "--bar", type=CommaDelimitedList(), default=None, help="a comma delimited list"
+    )
+    def foo(bar):
+        if bar is None:
+            click.echo("nil")
+        else:
+            click.echo(len(bar))
+            for x in bar:
+                click.echo(x)
+
+    # in helptext, it shows up with "string,string,..." as the metavar
+    result = runner.invoke(foo, ["--help"])
+    assert "--bar TEXT,TEXT,...  a comma delimited list" in result.output
+
+    # absent, it returns None
+    result = runner.invoke(foo, [])
+    assert result.output == "nil\n"
+
+    # given empty string (this is ambiguous!) returns empty array
+    result = runner.invoke(foo, ["--bar", ""])
+    assert result.output == "0\n"
+
+    # given "alpha" it returns "['alpha']"
+    result = runner.invoke(foo, ["--bar", "alpha"])
+    assert result.output == "1\nalpha\n"
+
+    # given a UUID it returns that UUID
+    result = runner.invoke(foo, ["--bar", "alpha,beta"])
+    assert result.output == "2\nalpha\nbeta\n"
+
+
+def test_string_prefix_mapper(runner, tmpdir):
+    class MyType(StringPrefixMapper):
+        __prefix_mapping__ = {"bar:": "prefix_mapper_parse_bar"}
+        __prefix_metavars__ = ["bar:BAR", "BAZ"]
+
+        def prefix_mapper_parse_bar(self, value):
+            if not value.startswith("BARBAR"):
+                raise click.UsageError("malformed BarObject")
+            return value[len("BARBAR") :]
+
+    @click.command()
+    @click.option("--bar", type=MyType(null="NIL"), default=None, help="a BarObject")
+    def foo(bar):
+        if bar is None:
+            click.echo("nil")
+        else:
+            click.echo(bar)
+
+    # in helptext, it shows up with the correct metavar
+    result = runner.invoke(foo, ["--help"])
+    assert "--bar [bar:BAR|BAZ]" in result.output
+
+    # absent, it leaves the default
+    result = runner.invoke(foo, [])
+    assert result.output == "nil\n"
+
+    # supports explicit null value as well
+    result = runner.invoke(foo, ["--bar", "NIL"])
+    assert result.output == "null\n"
+
+    # does nothing when the value is neither the null value nor has the prefix
+    result = runner.invoke(foo, ["--bar", "foo:bar"])
+    assert result.output == "foo:bar\n"
+
+    # but with the prefix, behaves as expected
+    result = runner.invoke(foo, ["--bar", "bar:BARBARbaz"])
+    assert result.output == "baz\n"
+
+
+def test_json_string_or_file(runner, tmpdir):
+    @click.command()
+    @click.option("--bar", type=JSONStringOrFile(), default=None, help="a JSON blob")
+    def foo(bar):
+        click.echo(json.dumps(bar, sort_keys=True))
+
+    # in helptext, it shows up with the correct metavar
+    result = runner.invoke(foo, ["--help"])
+    assert "--bar [JSON|file:JSON_FILE]" in result.output
+
+    # absent, it leaves the default
+    result = runner.invoke(foo, [])
+    assert result.output == "null\n"
+
+    # can be given raw json objects and parses them faithfully
+    result = runner.invoke(foo, ["--bar", "null"])
+    assert result.output == "null\n"
+    result = runner.invoke(foo, ["--bar", '"baz"'])
+    assert result.output == '"baz"\n'
+    result = runner.invoke(foo, ["--bar", '{"foo": 1}'])
+    assert result.output == '{"foo": 1}\n'
+
+    # invalid JSON data causes errors
+    result = runner.invoke(foo, ["--bar", '{"foo": 1,}'])
+    assert result.exit_code == 2
+    assert "the string '{\"foo\": 1,}' is not valid JSON" in result.output
+
+    # something which looks like a file path but is malformed gives a specific error
+    result = runner.invoke(foo, ["--bar", "file//1"])
+    assert result.exit_code == 2
+    assert (
+        "the string 'file//1' is not valid JSON. Did you mean to use 'file:'?"
+        in result.output
+    )
+
+    # given the path to a file with valid JSON, it parses the result
+    valid_file = tmpdir.mkdir("valid").join("file1.json")
+    valid_file.write('{"foo": 1}\n')
+    result = runner.invoke(foo, ["--bar", "file:" + str(valid_file)])
+    assert result.output == '{"foo": 1}\n'
+
+    # given the path to a file with invalid JSON, it raises an error
+    invalid_file = tmpdir.mkdir("invalid").join("file1.json")
+    invalid_file.write('{"foo": 1,}\n')
+    result = runner.invoke(foo, ["--bar", "file:" + str(invalid_file)])
+    assert "did not contain valid JSON" in result.output
+
+    # given a path to a file which does not exist, it raises an error
+    missing_file = tmpdir.join("missing.json")
+    result = runner.invoke(foo, ["--bar", "file:" + str(missing_file)])
+    assert "FileNotFound" in result.output
+    assert "does not exist" in result.output


### PR DESCRIPTION
The work is split into two commits.

First is a copy of parsing utilities in gcs-cli which will be needed for this.
These include a few nullable types, CommaDelimitedList, and the StringPrefixMapper class + the JSON-related subclass thereof.
It also gives `EXPLICIT_NULL` a repr, which is nice when unit testing things.

The second commit implements `collection update` + makes `endpoint update` redirect to it as appropriate.
Not all of the options from gcs-cli are supported yet, as some will be problematic without doing more work in the SDK to support this.
There's also some messy logic around options that cannot be used with Guest Collections. See the code surrounding `UsageError("Use of incompatible options with Guest Collection.")` in the `collection update` body. Ideally, this would be better coordinated somehow. I'm considering swapping it out for `inspect` usage on the collection class signatures, but I'm not decided on anything yet, so this is left as-is for now.

All of the new code in `src/globus_cli/parsing/param_types/` has been fairly thoroughly tested in gcs-cli at this point. Review should focus on the `collection update` implementation itself for the most part.