### PR TITLE
Begin the journey towards type-checking coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ ignore = W503,W504,E203
 
 
 [mypy]
+# disallow_untyped_defs = true
 ignore_missing_imports = true
 warn_unreachable = true
 warn_unused_ignores = true

--- a/src/globus_cli/commands/__init__.py
+++ b/src/globus_cli/commands/__init__.py
@@ -21,7 +21,7 @@ from globus_cli.parsing import main_group
 
 
 @main_group
-def main():
+def main() -> None:
     """
     Interact with Globus from the command line
 

--- a/src/globus_cli/commands/bookmark/__init__.py
+++ b/src/globus_cli/commands/bookmark/__init__.py
@@ -7,7 +7,7 @@ from globus_cli.parsing import group
 
 
 @group("bookmark")
-def bookmark_command():
+def bookmark_command() -> None:
     """Manage endpoint bookmarks"""
 
 

--- a/src/globus_cli/commands/bookmark/_common.py
+++ b/src/globus_cli/commands/bookmark/_common.py
@@ -1,10 +1,13 @@
+from typing import Any, Dict, Union, cast
 from uuid import UUID
 
 import click
-from globus_sdk import TransferAPIError
+import globus_sdk
 
 
-def resolve_id_or_name(client, bookmark_id_or_name):
+def resolve_id_or_name(
+    client: globus_sdk.TransferClient, bookmark_id_or_name: str
+) -> Union[globus_sdk.GlobusHTTPResponse, Dict[str, Any]]:
     # leading/trailing whitespace doesn't make sense for UUIDs and the Transfer
     # service outright forbids it for bookmark names, so we can strip it off
     bookmark_id_or_name = bookmark_id_or_name.strip()
@@ -17,22 +20,25 @@ def resolve_id_or_name(client, bookmark_id_or_name):
     else:
         try:
             res = client.get_bookmark(bookmark_id_or_name.lower())
-        except TransferAPIError as exception:
-            if exception.code != "BookmarkNotFound":
+        except globus_sdk.TransferAPIError as err:
+            if err.code != "BookmarkNotFound":
                 raise
+    if res:
+        return res
 
-    if not res:  # non-UUID input or UUID not found; fallback to match by name
-        try:
-            # n.b. case matters to the Transfer service for bookmark names, so
-            # two bookmarks can exist whose names vary only by their case
-            res = next(
+    # non-UUID input or UUID not found; fallback to match by name
+    try:
+        # n.b. case matters to the Transfer service for bookmark names, so
+        # two bookmarks can exist whose names vary only by their case
+        return cast(
+            Dict[str, Any],
+            next(
                 bookmark_row
                 for bookmark_row in client.bookmark_list()
                 if bookmark_row["name"] == bookmark_id_or_name
-            )
+            ),
+        )
 
-        except StopIteration:
-            click.echo(f'No bookmark found for "{bookmark_id_or_name}"', err=True)
-            click.get_current_context().exit(1)
-
-    return res
+    except StopIteration:
+        click.echo(f'No bookmark found for "{bookmark_id_or_name}"', err=True)
+        click.get_current_context().exit(1)

--- a/src/globus_cli/commands/bookmark/create.py
+++ b/src/globus_cli/commands/bookmark/create.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import click
 
 from globus_cli.login_manager import LoginManager
@@ -34,7 +36,7 @@ $ globus bookmark create \
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
 @click.argument("bookmark_name")
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
-def bookmark_create(endpoint_plus_path, bookmark_name):
+def bookmark_create(endpoint_plus_path: Tuple[str, str], bookmark_name: str) -> None:
     """
     Create a new bookmark. Given an endpoint plus a path, and a name for the bookmark,
     the service will generate the bookmark's ID.

--- a/src/globus_cli/commands/collection/__init__.py
+++ b/src/globus_cli/commands/collection/__init__.py
@@ -6,7 +6,7 @@ from .update import collection_update
 
 
 @group("collection")
-def collection_command():
+def collection_command() -> None:
     """Manage your Collections"""
 
 

--- a/src/globus_cli/commands/endpoint/__init__.py
+++ b/src/globus_cli/commands/endpoint/__init__.py
@@ -18,7 +18,7 @@ from globus_cli.parsing import group
 
 
 @group("endpoint")
-def endpoint_command():
+def endpoint_command() -> None:
     """Manage Globus endpoint definitions"""
 
 

--- a/src/globus_cli/commands/endpoint/_common.py
+++ b/src/globus_cli/commands/endpoint/_common.py
@@ -7,7 +7,9 @@ from globus_cli.constants import EXPLICIT_NULL
 from globus_cli.parsing import LocationType, MutexInfo, mutex_option_group
 
 
-def endpoint_create_and_update_params(f: Optional[Callable] = None, *, create=False):
+def endpoint_create_and_update_params(
+    f: Optional[Callable] = None, *, create: bool = False
+) -> Callable:
     """
     Collection of options consumed by Transfer endpoint create and update
     operations -- accepts toggle regarding create vs. update that makes
@@ -189,7 +191,9 @@ def endpoint_create_and_update_params(f: Optional[Callable] = None, *, create=Fa
     return f
 
 
-def validate_endpoint_create_and_update_params(endpoint_type, managed, params):
+def validate_endpoint_create_and_update_params(
+    endpoint_type: str, managed: bool, params: dict
+) -> None:
     """
     Given an endpoint type of "shared" "server" or "personal" and option values
     Confirms the option values are valid for the given endpoint

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -1,4 +1,5 @@
 import webbrowser
+from typing import Optional
 
 import click
 
@@ -115,18 +116,18 @@ $ globus endpoint activate $ep_id --myproxy -U username
 @mutex_option_group("--web", "--myproxy", "--delegate-proxy")
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_activate(
-    endpoint_id,
-    myproxy,
-    myproxy_username,
-    myproxy_password,
-    myproxy_lifetime,
-    web,
-    no_browser,
-    delegate_proxy,
-    proxy_lifetime,
-    no_autoactivate,
-    force,
-):
+    endpoint_id: str,
+    myproxy: bool,
+    myproxy_username: Optional[str],
+    myproxy_password: Optional[str],
+    myproxy_lifetime: Optional[int],
+    web: bool,
+    no_browser: bool,
+    delegate_proxy: bool,
+    proxy_lifetime: Optional[int],
+    no_autoactivate: bool,
+    force: bool,
+) -> None:
     """
     Activate an endpoint using Autoactivation, Myproxy, Delegate Proxy,
     or Web activation.

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import click
 
 from globus_cli.login_manager import LoginManager
@@ -69,7 +71,7 @@ $ globus endpoint create --shared host_ep:~/ my_shared_endpoint
     ),
 )
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
-def endpoint_create(**kwargs):
+def endpoint_create(**kwargs: Any) -> None:
     """
     Create a new endpoint.
 

--- a/src/globus_cli/commands/endpoint/deactivate.py
+++ b/src/globus_cli/commands/endpoint/deactivate.py
@@ -18,7 +18,7 @@ $ globus endpoint deactivate $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
-def endpoint_deactivate(endpoint_id):
+def endpoint_deactivate(endpoint_id: str) -> None:
     """
     Remove the credential previously assigned to an endpoint via
     'globus endpoint activate' or any other form of endpoint activation

--- a/src/globus_cli/commands/endpoint/delete.py
+++ b/src/globus_cli/commands/endpoint/delete.py
@@ -17,7 +17,7 @@ $ globus endpoint delete $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
-def endpoint_delete(endpoint_id):
+def endpoint_delete(endpoint_id: str) -> None:
     """Delete a given endpoint.
 
     WARNING: Deleting an endpoint will permanently disable any existing shared

--- a/src/globus_cli/commands/endpoint/is_activated.py
+++ b/src/globus_cli/commands/endpoint/is_activated.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 from globus_cli.login_manager import LoginManager
@@ -79,7 +81,9 @@ fi
     ),
 )
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
-def endpoint_is_activated(endpoint_id, until, absolute_time):
+def endpoint_is_activated(
+    endpoint_id: str, until: Optional[int], absolute_time: bool
+) -> None:
     """
     Check if an endpoint is activated or requires activation.
 

--- a/src/globus_cli/commands/endpoint/local_id.py
+++ b/src/globus_cli/commands/endpoint/local_id.py
@@ -43,7 +43,7 @@ globus ls "${ep_id}:/${dir_to_ls}"
     default=True,
     help="Use local Globus Connect Personal endpoint (default)",
 )
-def local_id(personal):
+def local_id(personal: bool) -> None:
 
     """
     Look for data referring to a local installation of Globus Connect Personal software

--- a/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
+++ b/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
@@ -16,7 +16,7 @@ $ globus endpoint my-shared-endpoint-list $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
-def my_shared_endpoint_list(endpoint_id):
+def my_shared_endpoint_list(endpoint_id: str) -> None:
     """
     Show a list of all shared endpoints hosted on the target endpoint for which the user
     has the "administrator" or "access_manager" effective roles.

--- a/src/globus_cli/commands/endpoint/permission/__init__.py
+++ b/src/globus_cli/commands/endpoint/permission/__init__.py
@@ -7,7 +7,7 @@ from globus_cli.parsing import group
 
 
 @group("permission")
-def permission_command():
+def permission_command() -> None:
     """Manage endpoint permissions (Access Control Lists)"""
 
 

--- a/src/globus_cli/commands/endpoint/role/__init__.py
+++ b/src/globus_cli/commands/endpoint/role/__init__.py
@@ -6,7 +6,7 @@ from globus_cli.parsing import group
 
 
 @group("role")
-def role_command():
+def role_command() -> None:
     """Manage endpoint roles"""
 
 

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 from globus_cli.login_manager import LoginManager
@@ -71,7 +73,12 @@ $ globus endpoint search --filter-scope my-endpoints
 )
 @click.argument("filter_fulltext", required=False)
 @LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
-def endpoint_search(filter_fulltext, limit, filter_owner_id, filter_scope):
+def endpoint_search(
+    filter_fulltext: Optional[str],
+    limit: int,
+    filter_owner_id: Optional[str],
+    filter_scope: Optional[str],
+) -> None:
     """
     Search for Globus endpoints with search filters. If --filter-scope is set to the
     default of 'all', then FILTER_FULLTEXT is required.

--- a/src/globus_cli/commands/endpoint/server/__init__.py
+++ b/src/globus_cli/commands/endpoint/server/__init__.py
@@ -7,7 +7,7 @@ from globus_cli.parsing import group
 
 
 @group("server", short_help="Manage servers for a Globus endpoint")
-def server_command():
+def server_command() -> None:
     """
     Manage the servers which back a Globus endpoint
 

--- a/src/globus_cli/commands/endpoint/show.py
+++ b/src/globus_cli/commands/endpoint/show.py
@@ -11,7 +11,7 @@ from globus_cli.termio import FORMAT_TEXT_RECORD, FormatField, formatted_print
 @endpoint_id_arg
 @click.option("--skip-endpoint-type-check", is_flag=True, hidden=True)
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
-def endpoint_show(endpoint_id, skip_endpoint_type_check):
+def endpoint_show(endpoint_id: str, skip_endpoint_type_check: bool) -> None:
     """Display a detailed endpoint definition"""
     client = get_client()
     if not skip_endpoint_type_check:

--- a/src/globus_cli/commands/group/__init__.py
+++ b/src/globus_cli/commands/group/__init__.py
@@ -3,7 +3,7 @@ from globus_cli.parsing import group
 
 
 @group("group")
-def group_command():
+def group_command() -> None:
     """Manage Globus Groups"""
 
 

--- a/src/globus_cli/commands/session/__init__.py
+++ b/src/globus_cli/commands/session/__init__.py
@@ -5,7 +5,7 @@ from globus_cli.parsing import group
 
 
 @group("session")
-def session_command():
+def session_command() -> None:
     """Manage your CLI auth session"""
 
 

--- a/src/globus_cli/commands/task/__init__.py
+++ b/src/globus_cli/commands/task/__init__.py
@@ -10,7 +10,7 @@ from globus_cli.parsing import group
 
 
 @group("task")
-def task_command():
+def task_command() -> None:
     """Manage asynchronous tasks"""
 
 


### PR DESCRIPTION
This is not necessary for v3.0 . But I had the branch in progress, so I'm cleaning it up and putting it in a PR.

Temporarily enable disallow_untyped_defs, fix many of the errors, then turn the flag off (comment it out) so that builds will pass. The commented-out directive could be read as a "statement of intent".
(You can also do this with the mypy `--disallow-untyped-defs` flag.)

We can start working on getting mypy to check the whole CLI, but turning on this strict flag would make our builds fail today. Rather than make *all* of the desirable changes -- many of which are very simple -- for now, take a sample and get the ball rolling.