### PR TITLE
Update minimum dependency versions & test mindeps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,3 +42,7 @@ jobs:
         run: python -m tox -e twine-check
       - name: Run Tests
         run: python -m tox -e py
+      - name: Mindeps Test
+        # mindeps runs on py36, as "the oldest everything"
+        if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest' }}
+        run: python -m tox -e py-mindeps

--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,14 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.6",
     install_requires=[
-        "globus-sdk==3.0.1",
+        # the SDK version bounds versions of `cryptography` and `requests`
+        "globus-sdk==3.0.2",
         "click>=8.0.0,<9",
         "jmespath==0.10.0",
-        "requests>=2.0.0,<3.0.0",
-        # cryptography versioning info:
-        # https://cryptography.io/en/latest/api-stability/
-        "cryptography>=1.8.1,<35.0.0",
+        # these are dependencies of the SDK, but they are used directly in the CLI
+        # declare them here in case the underlying lib ever changes
+        "requests>=2.19.1,<3.0.0",
+        "cryptography>=2.0,<37",
     ],
     extras_require={"development": DEV_REQUIREMENTS},
     entry_points={"console_scripts": ["globus = globus_cli:main"]},

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,20 @@
 [tox]
-envlist = cov-clean,py{39,38,37,36},cov-report
+envlist =
+    cov-clean
+    cov-report
+    py{39,38,37,36}
+    py36-mindeps
 skip_missing_interpreters = true
 minversion = 3.0.0
 
 [testenv]
 usedevelop = true
 extras = development
+deps =
+    mindeps: click==8.0.0
+    mindeps: requests==2.19.1
+    mindeps: pyjwt==2.0.0
+    mindeps: cryptography==2.0
 commands = pytest --cov-append --cov-report= {posargs}
 depends =
     {py36,py37,py38,py39}: cov-clean


### PR DESCRIPTION
Add a tox env for testing minimum dependency versions. Pull in the version bounds from the SDK 3.0.2, and update the SDK version to 3.0.2 . Add py36-mindeps to the steps tested in CI as well.

resolves #562

---

I plan to merge and release this as v3.0.1 as soon as CI testing passes.