### PR TITLE
Add `globus search query` command with GET & POST

### DIFF
--- a/src/globus_cli/commands/__init__.py
+++ b/src/globus_cli/commands/__init__.py
@@ -11,6 +11,7 @@ from globus_cli.commands.ls import ls_command
 from globus_cli.commands.mkdir import mkdir_command
 from globus_cli.commands.rename import rename_command
 from globus_cli.commands.rm import rm_command
+from globus_cli.commands.search import search_command
 from globus_cli.commands.session import session_command
 from globus_cli.commands.task import task_command
 from globus_cli.commands.transfer import transfer_command
@@ -56,3 +57,5 @@ main.add_command(task_command)
 main.add_command(session_command)
 
 main.add_command(group_command)
+
+main.add_command(search_command)

--- a/src/globus_cli/commands/search/__init__.py
+++ b/src/globus_cli/commands/search/__init__.py
@@ -1,0 +1,10 @@
+from globus_cli.commands.search.query import query_command
+from globus_cli.parsing import group
+
+
+@group("search")
+def search_command():
+    """Use Globus Search to store and query for data"""
+
+
+search_command.add_command(query_command)

--- a/src/globus_cli/commands/search/query.py
+++ b/src/globus_cli/commands/search/query.py
@@ -1,0 +1,90 @@
+import json
+from io import TextIOWrapper
+from typing import Any, Dict, List, Optional
+
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import CommaDelimitedList, command, mutex_option_group
+from globus_cli.services.search import get_search_client
+from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
+
+
+@command("query", short_help="Perform a search")
+@click.option("-q", help="The query-string to use to search the index.")
+@click.option(
+    "--query-document",
+    type=click.File("r"),
+    help="A complete query document to use to search the index.",
+)
+@click.option("--limit", type=int, help="Limit the number of results to return")
+@click.option(
+    "--advanced",
+    is_flag=True,
+    help="Perform the search using the advanced query syntax",
+)
+@click.option(
+    "--bypass-visible-to",
+    is_flag=True,
+    help="Bypass the visible_to restriction on searches. "
+    "This option is only available to the admins of an index",
+)
+@click.option(
+    "--filter-principal-sets",
+    type=CommaDelimitedList(),
+    help=(
+        "A principal-sets filter to apply to the results, allowing filtering by "
+        "predefined sets of identities or groups. Supplied as a comma-delimited list."
+    ),
+)
+@click.argument("INDEX_ID")
+@mutex_option_group("-q", "--query-document")
+@LoginManager.requires_login(LoginManager.SEARCH_RS)
+def query_command(
+    index_id: str,
+    q: Optional[str],
+    query_document: Optional[TextIOWrapper],
+    limit: Optional[int],
+    advanced: bool,
+    bypass_visible_to: bool,
+    filter_principal_sets: Optional[List[str]],
+):
+    """
+    Query a Globus Search Index by ID using either a simple query string, or a complex
+    query document. At least one of `-q` or `--query-document` must be provided.
+
+    If a query document and command-line options are provided, the options used will
+    override any options which were present on the query document.
+    """
+    search_client = get_search_client()
+
+    if q:
+        query_params: Dict[str, Any] = {}
+        if filter_principal_sets:
+            query_params["filter_principal_sets"] = ",".join(filter_principal_sets)
+        if bypass_visible_to:
+            query_params["bypass_visible_to"] = bypass_visible_to
+
+        data = search_client.search(
+            index_id, q, advanced=advanced, limit=limit, query_params=query_params
+        )
+    elif query_document:
+        doc = json.load(query_document)
+
+        if limit:
+            doc["limit"] = limit
+        if advanced:
+            doc["advanced"] = advanced
+        if bypass_visible_to:
+            doc["bypass_visible_to"] = bypass_visible_to
+        if filter_principal_sets:
+            doc["filter_principal_sets"] = filter_principal_sets
+
+        data = search_client.post_search(index_id, doc)
+    else:
+        raise click.UsageError("Either '-q' or '--query-document' must be provided")
+
+    # format such that TEXT mode is JSON output
+    # because Globus Search data is user-supplied JSON, there is no other sensible way
+    # to format the data
+    formatted_print(data, text_format=FORMAT_TEXT_RAW)

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -3,7 +3,7 @@ from typing import Dict, Generator, List, Optional, Tuple
 
 import click
 import globus_sdk
-from globus_sdk.scopes import AuthScopes, GroupsScopes, TransferScopes
+from globus_sdk.scopes import AuthScopes, GroupsScopes, SearchScopes, TransferScopes
 
 from .auth_flows import do_link_auth_flow, do_local_server_auth_flow
 from .errors import MissingLoginError
@@ -15,9 +15,10 @@ class LoginManager:
     # TEST_MODE skips token validation
     _TEST_MODE: bool = False
 
-    AUTH_RS = "auth.globus.org"
-    TRANSFER_RS = "transfer.api.globus.org"
-    GROUPS_RS = "groups.api.globus.org"
+    AUTH_RS = AuthScopes.resource_server
+    TRANSFER_RS = TransferScopes.resource_server
+    GROUPS_RS = GroupsScopes.resource_server
+    SEARCH_RS = SearchScopes.resource_server
 
     STATIC_SCOPES: Dict[str, List[str]] = {
         AUTH_RS: [
@@ -31,6 +32,9 @@ class LoginManager:
         ],
         GROUPS_RS: [
             GroupsScopes.all,
+        ],
+        SEARCH_RS: [
+            SearchScopes.all,
         ],
     }
 

--- a/src/globus_cli/services/search.py
+++ b/src/globus_cli/services/search.py
@@ -1,0 +1,19 @@
+from globus_sdk import RefreshTokenAuthorizer, SearchClient
+
+from globus_cli import version
+from globus_cli.login_manager import internal_auth_client, token_storage_adapter
+
+
+def get_search_client() -> SearchClient:
+    adapter = token_storage_adapter()
+    tokens = adapter.get_token_data("search.api.globus.org")
+
+    authorizer = RefreshTokenAuthorizer(
+        tokens["refresh_token"],
+        internal_auth_client(),
+        access_token=tokens["access_token"],
+        expires_at=tokens["expires_at_seconds"],
+        on_refresh=adapter.on_refresh,
+    )
+
+    return SearchClient(authorizer=authorizer, app_name=version.app_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,9 @@ def mock_login_token_response():
         "groups.api.globus.org": _mock_token_response_data(
             "groups.api.globus.org", "urn:globus:auth:scope:groups.api.globus.org:all"
         ),
+        "search.api.globus.org": _mock_token_response_data(
+            "search.api.globus.org", "urn:globus:auth:scope:search.api.globus.org:all"
+        ),
     }
     return mock_token_res
 

--- a/tests/files/api_fixtures/search.yaml
+++ b/tests/files/api_fixtures/search.yaml
@@ -1,0 +1,200 @@
+metadata:
+  index_id: 6f831ac8-4c41-4812-b383-6fb04f8b9f9f
+
+search:
+  - path: /v1/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f/search
+    method: get
+    json:
+      {
+        "@datatype": "GSearchResult",
+        "@version": "2017-09-01",
+        "count": 1,
+        "gmeta": [
+          {
+            "@datatype": "GMetaResult",
+            "@version": "2019-08-27",
+            "entries": [
+              {
+                "content": {
+                  "cuisine": [
+                    "mexican"
+                  ],
+                  "handle": "salsa-verde",
+                  "ingredients": [
+                    {
+                      "amount": {
+                        "number": 10
+                      },
+                      "default": "tomatillo",
+                      "preparation": "simmer 20 minutes",
+                      "type": "fruit"
+                    },
+                    {
+                      "amount": {
+                        "number": 2
+                      },
+                      "default": "serrano pepper",
+                      "preparation": "seeded",
+                      "substitutes": [
+                        "jalapeno",
+                        "thai bird chili"
+                      ],
+                      "type": "fruit"
+                    },
+                    {
+                      "amount": {
+                        "number": 2,
+                        "unit": "clove"
+                      },
+                      "default": "garlic",
+                      "type": "vegetable"
+                    },
+                    {
+                      "amount": {
+                        "number": 0.5
+                      },
+                      "default": "yellow onion",
+                      "type": "vegetable"
+                    },
+                    {
+                      "amount": {
+                        "number": 2,
+                        "unit": "tsp"
+                      },
+                      "default": "salt",
+                      "type": "spice"
+                    },
+                    {
+                      "amount": {
+                        "number": 2,
+                        "unit": "tbsp"
+                      },
+                      "default": "coriander",
+                      "preparation": "ground",
+                      "subsitutes": [
+                        "cumin"
+                      ],
+                      "type": "spice"
+                    }
+                  ],
+                  "keywords": [
+                    "salsa",
+                    "tomatillo",
+                    "coriander",
+                    "serrano pepper"
+                  ],
+                  "origin": {
+                    "author": "Diana Kennedy",
+                    "title": "Regional Mexican Cooking",
+                    "type": "book"
+                  }
+                },
+                "entry_id": null,
+                "matched_principal_sets": []
+              }
+            ],
+            "subject": "https://en.wikipedia.org/wiki/Salsa_verde"
+          }
+        ],
+        "has_next_page": false,
+        "offset": 0,
+        "total": 1
+      }
+  - path: /v1/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f/search
+    method: post
+    json:
+      {
+        "@datatype": "GSearchResult",
+        "@version": "2017-09-01",
+        "count": 1,
+        "gmeta": [
+          {
+            "@datatype": "GMetaResult",
+            "@version": "2019-08-27",
+            "entries": [
+              {
+                "content": {
+                  "cuisine": [
+                    "mexican"
+                  ],
+                  "handle": "salsa-verde",
+                  "ingredients": [
+                    {
+                      "amount": {
+                        "number": 10
+                      },
+                      "default": "tomatillo",
+                      "preparation": "simmer 20 minutes",
+                      "type": "fruit"
+                    },
+                    {
+                      "amount": {
+                        "number": 2
+                      },
+                      "default": "serrano pepper",
+                      "preparation": "seeded",
+                      "substitutes": [
+                        "jalapeno",
+                        "thai bird chili"
+                      ],
+                      "type": "fruit"
+                    },
+                    {
+                      "amount": {
+                        "number": 2,
+                        "unit": "clove"
+                      },
+                      "default": "garlic",
+                      "type": "vegetable"
+                    },
+                    {
+                      "amount": {
+                        "number": 0.5
+                      },
+                      "default": "yellow onion",
+                      "type": "vegetable"
+                    },
+                    {
+                      "amount": {
+                        "number": 2,
+                        "unit": "tsp"
+                      },
+                      "default": "salt",
+                      "type": "spice"
+                    },
+                    {
+                      "amount": {
+                        "number": 2,
+                        "unit": "tbsp"
+                      },
+                      "default": "coriander",
+                      "preparation": "ground",
+                      "subsitutes": [
+                        "cumin"
+                      ],
+                      "type": "spice"
+                    }
+                  ],
+                  "keywords": [
+                    "salsa",
+                    "tomatillo",
+                    "coriander",
+                    "serrano pepper"
+                  ],
+                  "origin": {
+                    "author": "Diana Kennedy",
+                    "title": "Regional Mexican Cooking",
+                    "type": "book"
+                  }
+                },
+                "entry_id": null,
+                "matched_principal_sets": []
+              }
+            ],
+            "subject": "https://en.wikipedia.org/wiki/Salsa_verde"
+          }
+        ],
+        "has_next_page": false,
+        "offset": 0,
+        "total": 1
+      }

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -1,0 +1,131 @@
+import json
+
+import pytest
+import responses
+
+
+@pytest.mark.parametrize(
+    "addargs, expect_params",
+    [
+        ([], {}),
+        (["--limit", 10], {"limit": "10"}),
+        (["--advanced", "--limit", 10], {"limit": "10", "advanced": "True"}),
+        (["--bypass-visible-to"], {"bypass_visible_to": "True"}),
+        (
+            ["--filter-principal-sets", "admin,manager"],
+            {"filter_principal_sets": "admin,manager"},
+        ),
+    ],
+)
+def test_query_string(run_line, load_api_fixtures, addargs, expect_params):
+    """
+    Runs 'globus search query -q ...' and validates results
+    """
+    data = load_api_fixtures("search.yaml")
+    index_id = data["metadata"]["index_id"]
+
+    result = run_line(
+        ["globus", "search", "query", index_id, "-q", "tomatillo"] + addargs
+    )
+
+    assert "simmer 20 minutes" in result.output
+    data = json.loads(result.output)
+    assert data["count"] == 1
+    assert [x["subject"] for x in data["gmeta"]] == [
+        "https://en.wikipedia.org/wiki/Salsa_verde"
+    ]
+
+    sent = responses.calls[-1].request
+    assert sent.method == "GET"
+    assert sent.params["q"] == "tomatillo"
+    for k, v in expect_params.items():
+        assert k in sent.params
+        assert sent.params[k] == v
+
+
+@pytest.mark.parametrize(
+    "addargs, expect_params",
+    [
+        ([], {}),
+        (["--limit", 10], {"limit": 10}),
+        (["--advanced", "--limit", 10], {"limit": 10, "advanced": True}),
+        (["--bypass-visible-to"], {"bypass_visible_to": True}),
+        (
+            ["--filter-principal-sets", "admin,manager"],
+            {"filter_principal_sets": ["admin", "manager"]},
+        ),
+    ],
+)
+def test_query_document(run_line, load_api_fixtures, tmp_path, addargs, expect_params):
+    """
+    Runs 'globus search query --query-document ...' and validates results
+    """
+    data = load_api_fixtures("search.yaml")
+    index_id = data["metadata"]["index_id"]
+    doc = tmp_path / "doc.json"
+    doc.write_text(json.dumps({"q": "tomatillo"}))
+
+    result = run_line(
+        ["globus", "search", "query", index_id, "--query-document", str(doc)] + addargs
+    )
+
+    assert "simmer 20 minutes" in result.output
+    data = json.loads(result.output)
+    assert data["count"] == 1
+    assert [x["subject"] for x in data["gmeta"]] == [
+        "https://en.wikipedia.org/wiki/Salsa_verde"
+    ]
+
+    sent = responses.calls[-1].request
+    assert sent.method == "POST"
+    assert "q" not in sent.params
+    sent_body = json.loads(sent.body)
+    assert "q" in sent_body
+    assert sent_body["q"] == "tomatillo"
+    for k, v in expect_params.items():
+        assert k in sent_body
+        assert sent_body[k] == v
+
+
+def test_query_string_and_document_mutex(run_line, load_api_fixtures, tmp_path):
+    """
+    Check that `-q` and `--query-document` cannot be used together
+    """
+    data = load_api_fixtures("search.yaml")
+    index_id = data["metadata"]["index_id"]
+    doc = tmp_path / "doc.json"
+    doc.write_text(json.dumps({"q": "tomatillo"}))
+
+    result = run_line(
+        [
+            "globus",
+            "search",
+            "query",
+            index_id,
+            "-q",
+            "tomatillo",
+            "--query-document",
+            str(doc),
+        ],
+        assert_exit_code=2,
+    )
+    assert "mutually exclusive" in result.stderr
+
+
+def test_query_required(run_line, load_api_fixtures):
+    """
+    Check that at least one of `-q` or `--query-document` must be provided
+    """
+    data = load_api_fixtures("search.yaml")
+    index_id = data["metadata"]["index_id"]
+
+    result = run_line(
+        [
+            "globus",
+            "search",
+            "query",
+            index_id,
+        ],
+        assert_exit_code=2,
+    )
+    assert "Either '-q' or '--query-document' must be provided" in result.stderr


### PR DESCRIPTION
This is part of CLI v3.1 . It is the first bit of Globus Search support in the CLI, building on what is now possible in terms of added requirements with LoginManager.

I'll be adding other commands in the future and possibly refining this one if it seems like there are obvious improvements in advance of v3.1.

Because Globus Search returns user-defined JSON (with Globus-defined wrappers), it's not clear what non-JSON printing would be. So, for now at least, this command does not have non-JSON text output.

---

The command supports two usage modes for `GET` and `POST` query submission. Unlike the globus-search-cli version of this command, `--offset` is not supported, in anticipation of eventual use of built-in pagination.

The other major difference from the globus-search-cli commands is the fact that `query` is supplied as one command, with `-q` or `--query-document` as options which switch between GET and POST query forms.