### PR TITLE
Fix to use data kwarg in .put()

### DIFF
--- a/changelog.d/20211008_142903_rudyardrichter_fix_subscription_id_error.md
+++ b/changelog.d/20211008_142903_rudyardrichter_fix_subscription_id_error.md
@@ -1,0 +1,14 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section or sections which match your change. Use "Other" for all
+changes which do not match a different section.
+
+Fill in one or more bullet points with details of your change.
+
+Make sure you add the new file in `changelog.d/` to your pull request!
+-->
+
+### Bugfixes
+
+* Fix `TypeError` from running `globus endpoint set-subscription-id`

--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -46,6 +46,6 @@ def set_endpoint_subscription_id(
     # make the update
     res = client.put(
         f"/endpoint/{endpoint_id}/subscription",
-        {"subscription_id": subscription_id},
+        data={"subscription_id": subscription_id},
     )
     formatted_print(res, text_format=FORMAT_TEXT_RAW, response_key="message")

--- a/tests/files/api_fixtures/endpoint_operations.yaml
+++ b/tests/files/api_fixtures/endpoint_operations.yaml
@@ -25,6 +25,16 @@ transfer:
         "request_id": "SlzMEdxjp",
         "resource": "/endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15"
       }
+  - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15/subscription
+    method: put
+    json:
+      {
+        "DATA_TYPE": "result",
+        "code": "Updated",
+        "message": "Endpoint updated successfully",
+        "request_id": "ABCdef789",
+        "resource": "/endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15"
+      }
   - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15
     json:
       {
@@ -98,6 +108,16 @@ transfer:
         "request_id": "SlzMEdxjp",
         "resource": "/endpoint/b379e973-f5c5-4501-8377-5a0ecf37a99b"
       }
+  - path: /endpoint/b379e973-f5c5-4501-8377-5a0ecf37a99b/subscription
+    method: put
+    json:
+      {
+        "DATA_TYPE": "result",
+        "code": "Updated",
+        "message": "Endpoint updated successfully",
+        "request_id": "ABCdef789",
+        "resource": "/endpoint/b379e973-f5c5-4501-8377-5a0ecf37a99b"
+      }
   - path: /endpoint/b379e973-f5c5-4501-8377-5a0ecf37a99b
     json:
       {
@@ -150,6 +170,16 @@ transfer:
         "code": "Updated",
         "message": "Endpoint updated successfully",
         "request_id": "SlzMEdxjp",
+        "resource": "/endpoint/06e2c959-d311-4bab-b2ea-25ad77d9fc12"
+      }
+  - path: /endpoint/06e2c959-d311-4bab-b2ea-25ad77d9fc12/subscription
+    method: put
+    json:
+      {
+        "DATA_TYPE": "result",
+        "code": "Updated",
+        "message": "Endpoint updated successfully",
+        "request_id": "ABCdef789",
         "resource": "/endpoint/06e2c959-d311-4bab-b2ea-25ad77d9fc12"
       }
   - path: /endpoint/06e2c959-d311-4bab-b2ea-25ad77d9fc12

--- a/tests/functional/endpoint/test_endpoint_set_subscription_id.py
+++ b/tests/functional/endpoint/test_endpoint_set_subscription_id.py
@@ -1,0 +1,25 @@
+import json
+import uuid
+
+import pytest
+import responses
+
+
+@pytest.mark.parametrize(
+    "ep_type",
+    ["personal", "share", "server"],
+)
+def test_endpoint_set_subscription_id(run_line, load_api_fixtures, ep_type):
+    data = load_api_fixtures("endpoint_operations.yaml")
+    if ep_type == "personal":
+        epid = data["metadata"]["gcp_endpoint_id"]
+    elif ep_type == "share":
+        epid = data["metadata"]["share_id"]
+    else:
+        epid = data["metadata"]["endpoint_id"]
+    subscription_id = str(uuid.UUID(int=0))
+    run_line(f"globus endpoint set-subscription-id {epid} {subscription_id}")
+    assert (
+        json.loads(responses.calls[-1].request.body)["subscription_id"]
+        == subscription_id
+    )


### PR DESCRIPTION
Fixes a `TransferClient.put` call in `set_endpoint_subscription_id` which was causing a `TypeError`.

Resolves #569.