### PR TITLE
Fix `endpoint activate` calls for SDKv3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         - types-setuptools
         - types-requests
         - click
-        - 'globus-sdk==3.0.1'
+        - 'globus-sdk==3.0.3'
 - repo: local
   hooks:
     - id: fix-changelog

--- a/changelog.d/20211011_222558_sirosen_fix_ep_activate.md
+++ b/changelog.d/20211011_222558_sirosen_fix_ep_activate.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section or sections which match your change. Use "Other" for all
+changes which do not match a different section.
+
+Fill in one or more bullet points with details of your change.
+
+Make sure you add the new file in `changelog.d/` to your pull request!
+-->
+
+### Bugfixes
+
+* Fix `TypeError` in `globus endpoint activate` resulting from the v3 upgrade
+
+<!--
+### Enhancements
+
+* A bullet item for the Enhancements category.
+
+-->
+<!--
+### Other
+
+* A bullet item for the Other category.
+
+-->

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         # the SDK version bounds versions of `cryptography` and `requests`
-        "globus-sdk==3.0.2",
+        "globus-sdk==3.0.3",
         "click>=8.0.0,<9",
         "jmespath==0.10.0",
         # these are dependencies of the SDK, but they are used directly in the CLI

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -1,7 +1,8 @@
 import webbrowser
-from typing import Optional
+from typing import Dict, Optional, Union
 
 import click
+from globus_sdk import GlobusHTTPResponse
 
 from globus_cli.login_manager import LoginManager, is_remote_session
 from globus_cli.parsing import command, endpoint_id_arg, mutex_option_group
@@ -194,7 +195,9 @@ def endpoint_activate(
 
     # check if endpoint is already activated unless --force
     if not force:
-        res = client.endpoint_autoactivate(endpoint_id, if_expires_in=60)
+        res: Union[Dict[str, str], GlobusHTTPResponse] = client.endpoint_autoactivate(
+            endpoint_id, if_expires_in=60
+        )
 
         if "AlreadyActivated" == res["code"]:
             formatted_print(
@@ -266,7 +269,7 @@ def endpoint_activate(
             if data["name"] == "lifetime_in_hours" and myproxy_lifetime is not None:
                 data["value"] = str(myproxy_lifetime)
 
-        res = client.endpoint_activate(endpoint_id, requirements_data)
+        res = client.endpoint_activate(endpoint_id, requirements_data=requirements_data)
 
     # web activation
     elif web:
@@ -285,7 +288,9 @@ def endpoint_activate(
         filled_requirements_data = fill_delegate_proxy_activation_requirements(
             requirements_data, delegate_proxy, lifetime_hours=proxy_lifetime or 12
         )
-        res = client.endpoint_activate(endpoint_id, filled_requirements_data)
+        res = client.endpoint_activate(
+            endpoint_id, requirements_data=filled_requirements_data
+        )
 
     # output
     formatted_print(res, text_format=FORMAT_TEXT_RAW, response_key="message")

--- a/src/globus_cli/commands/endpoint/is_activated.py
+++ b/src/globus_cli/commands/endpoint/is_activated.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import NoReturn, Optional
 
 import click
 
@@ -95,7 +95,7 @@ def endpoint_is_activated(
     client = get_client()
     res = client.endpoint_get_activation_requirements(endpoint_id)
 
-    def fail(deadline=None):
+    def fail(deadline=None) -> NoReturn:
         exp_string = ""
         if deadline is not None:
             exp_string = f" or will expire within {deadline} seconds"

--- a/src/globus_cli/services/transfer/client.py
+++ b/src/globus_cli/services/transfer/client.py
@@ -1,9 +1,10 @@
 import logging
 import sys
 import textwrap
+from typing import Tuple, Union
 
 import click
-from globus_sdk import RefreshTokenAuthorizer, TransferClient
+from globus_sdk import GlobusHTTPResponse, RefreshTokenAuthorizer, TransferClient
 
 from globus_cli import login_manager, version
 from globus_cli.termio import FORMAT_SILENT, formatted_print
@@ -18,7 +19,7 @@ class CustomTransferClient(TransferClient):
     # TDOD: Remove this function when endpoints natively support recursive ls
     def recursive_operation_ls(
         self, endpoint_id, depth=3, filter_after_first=True, **params
-    ):
+    ) -> RecursiveLsResponse:
         """
         Makes recursive calls to ``GET /operation/endpoint/<endpoint_id>/ls``
         Does not preserve access to top level operation_ls fields, but
@@ -57,7 +58,9 @@ class CustomTransferClient(TransferClient):
         )
         return RecursiveLsResponse(self, endpoint_id, depth, filter_after_first, params)
 
-    def get_endpoint_w_server_list(self, endpoint_id):
+    def get_endpoint_w_server_list(
+        self, endpoint_id
+    ) -> Tuple[GlobusHTTPResponse, Union[str, GlobusHTTPResponse]]:
         """
         A helper for handling endpoint server list lookups correctly accounting
         for various endpoint types.
@@ -92,7 +95,7 @@ class CustomTransferClient(TransferClient):
 
     def task_wait_with_io(
         self, meow, heartbeat, polling_interval, timeout, task_id, timeout_exit_code
-    ):
+    ) -> None:
         """
         Options are the core "task wait" options, including the `--meow` easter
         egg.
@@ -176,7 +179,7 @@ class CustomTransferClient(TransferClient):
         click.get_current_context().exit(exit_code)
 
 
-def get_client():
+def get_client() -> CustomTransferClient:
     adapter = login_manager.token_storage_adapter()
     tokens = adapter.get_token_data("transfer.api.globus.org")
     authorizer = None

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,8 @@ deps =
     types-jwt
     types-requests
     typing-extensions
+    click
+    globus-sdk==3.0.3
 commands = mypy src/
 
 [testenv:reference]


### PR DESCRIPTION
This updates to SDK v3.0.3 to pick up a bugfix to the type annotations. With this in place, and a few additions to annotations in the CustomTransferClient, type checking is more complete. This lets mypy pick up on the incorrect arguments to `endpoint_activate()`, which requires that `requirements_data=...` is a named parameter.

Linting under mypy now includes SDK v3.