### PR TITLE
Test the legacy-line of virtualenv

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,3 +46,19 @@ jobs:
         # mindeps runs on py36, as "the oldest everything"
         if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest' }}
         run: python -m tox -e py-mindeps
+
+  # use the oldest python version we support for this build
+  test-ancient-virtualenv:
+    name: "Python 3.6, Using Old virtualenv"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install Requirements
+        run: python -m pip install -U pip setuptools tox
+      - name: Downgrade Virtualenv
+        run: python -m pip install 'virtualenv==16.7.12'
+      - name: Run Tests
+        run: python -m tox -e py

--- a/changelog.d/20211013_204529_sirosen_test_ancient_virtualenv.md
+++ b/changelog.d/20211013_204529_sirosen_test_ancient_virtualenv.md
@@ -1,0 +1,6 @@
+### Bugfixes
+
+* Fix the handling of the legacy-line of `virtualenv`, versions below `20.0.0`.
+  When the `globus-cli` was installed under these versions of `virtualenv`, all
+  commands would fail at import-time due to an API difference between stdlib
+  `site` module and the `virtualenv`-generated `site`


### PR DESCRIPTION
`virtualenv<20` creates its own `site` module and puts it in the path. Because it's not API-compatible with python3.2+ , the CLI code for checking `USER_BASE` fails.

To fix:
- Add a build for `test-ancient-virtualenv` which makes sure that tox running with the old virtualenv version installed will fail without a fix (confirmed)
- Defer testing of `site` (and `PIPX_HOME` for good measure) until runtime to avoid blowing up at import-time, as a safety measure
- Fix the handling to always mark an install "not a user install" if `site.getuserbase()` is not available (the "ancient virtualenv" case)