### PR TITLE
Update `endpoint create` help and opt handling

### DIFF
--- a/changelog.d/20211020_173613_sirosen_update_personal_setup_helptext.md
+++ b/changelog.d/20211020_173613_sirosen_update_personal_setup_helptext.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* The `--help` text for `globus endpoint create` now clarifies the meaning of `--personal`.
+* Errors for use of mutually exclusive options to `globus endpoint create` have been improved.


### PR DESCRIPTION
1. Use `mutex_option_group` to handle `--shared`, `--server`, `--personal`
2. Add a note to the helptext (per support request) to note that `--personal` returns a setup key and shouldn't be confused with full GCP setup

This also drove a change into the mutex option handling code to have better type annotations.