### PR TITLE
Fix 'globus session consent' crashfail after login

### DIFF
--- a/changelog.d/20211103_221444_sirosen_fix_session_consent.md
+++ b/changelog.d/20211103_221444_sirosen_fix_session_consent.md
@@ -1,0 +1,5 @@
+### Bugfixes
+
+* Fix a bug in `globus session consent` in which an `id_token` was expected as
+  part of the token data, but the `openid` scope was not provided to the login
+  flow

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import click
 
 from globus_cli.login_manager import LoginManager
@@ -11,7 +13,7 @@ from globus_cli.parsing import command, no_local_server_option
 )
 @no_local_server_option
 @click.argument("SCOPES", nargs=-1, required=True)
-def session_consent(scopes, no_local_server):
+def session_consent(scopes: Tuple[str], no_local_server: bool) -> None:
     """
     Update your current CLI auth session by authenticating with a specific scope or set
     of scopes.
@@ -19,8 +21,6 @@ def session_consent(scopes, no_local_server):
     This command is necessary when the CLI needs access to resources which require the
     user to explicitly consent to access.
     """
-    session_params = {"scope": " ".join(scopes)}
-
     manager = LoginManager()
     manager.run_login_flow(
         no_local_server=no_local_server,
@@ -33,5 +33,5 @@ def session_consent(scopes, no_local_server):
             "\n---"
         ),
         epilog="\nYou have successfully updated your CLI session.\n",
-        session_params=session_params,
+        scopes=list(scopes),
     )


### PR DESCRIPTION
At the end of the login flow, `globus session consent` would expect `id_token` in the response data in order to do the no-account-switching validation step we added in v3.0. However, the `id_token` is only present on login flows which include the `openid` scope.

To rectify:
- add `LoginManager.always_required_scopes`, an iterator which yields the openid scope string, "openid"
- `LoginManager.run_login_flow` adds `always_required_scopes` to any scope list (implicit or provided)
- `globus session consent` now passes scopes as a keyword argument, not under `session_params`
- annotate and type-check `globus session consent`

This was tested manually, and it is not clear how effective a mocked test with synthetic response data would be in preventing errors of this kind in the future.

Aside: I've converted one method typed as `Generator` to `Iterator`, as it is a simpler type to annotate. I used Iterator for the new iterator method, and it made sense to harmonize the existing method with it.