### PR TITLE
Fix a crash due to incorrect function parameter names

### DIFF
--- a/changelog.d/20211105_084824_kurtmckee_task_event_list_crash.md
+++ b/changelog.d/20211105_084824_kurtmckee_task_event_list_crash.md
@@ -1,0 +1,3 @@
+### Bugfixes
+
+* Fix a crash that occurs when running `globus task event-list {task-id}`.

--- a/src/globus_cli/commands/task/event_list.py
+++ b/src/globus_cli/commands/task/event_list.py
@@ -71,7 +71,10 @@ def task_event_list(task_id, limit, filter_errors, filter_non_errors):
         filter_string = ""
 
     event_iterator = PagingWrapper(
-        client.paginated.task_event_list(task_id, filter=filter_string).items(),
+        client.paginated.task_event_list(
+            task_id,
+            query_params={"filter": filter_string},
+        ).items(),
         limit=limit,
     )
 


### PR DESCRIPTION
This appears to resolve the crash and match the query parameter signature expected by the API:

https://docs.globus.org/api/transfer/task/#get_event_list

[sc-11551]