### PR TITLE
Add basic `globus search index` commands

### DIFF
--- a/changelog.d/20211109_210431_sirosen_add_search_index_commands.md
+++ b/changelog.d/20211109_210431_sirosen_add_search_index_commands.md
@@ -1,0 +1,8 @@
+### Enhancements
+
+* Add a new `globus search index show` command which displays an index by ID
+* Add a new `globus search index list` command which lists indices for which
+  the current user has permissions
+* Add a new `globus search index create` command which creates a new Globus
+  Search index. Note that because the index creation API is in public beta, the
+  command is also labeled as "beta"

--- a/src/globus_cli/commands/search/__init__.py
+++ b/src/globus_cli/commands/search/__init__.py
@@ -1,5 +1,6 @@
 from globus_cli.parsing import group
 
+from .index import index_command
 from .ingest import ingest_command
 from .query import query_command
 from .task import task_command
@@ -11,5 +12,6 @@ def search_command():
 
 
 search_command.add_command(ingest_command)
+search_command.add_command(index_command)
 search_command.add_command(query_command)
 search_command.add_command(task_command)

--- a/src/globus_cli/commands/search/_common.py
+++ b/src/globus_cli/commands/search/_common.py
@@ -2,6 +2,8 @@ from typing import Callable
 
 import click
 
+from globus_cli.types import FIELD_LIST_T
+
 
 def index_id_arg(f: Callable) -> Callable:
     return click.argument("index_id", metavar="INDEX_ID", type=click.UUID)(f)
@@ -9,3 +11,10 @@ def index_id_arg(f: Callable) -> Callable:
 
 def task_id_arg(f: Callable) -> Callable:
     return click.argument("task_id", metavar="TASK_ID", type=click.UUID)(f)
+
+
+INDEX_FIELDS: FIELD_LIST_T = [
+    ("Index ID", "id"),
+    ("Display Name", "display_name"),
+    ("Status", "status"),
+]

--- a/src/globus_cli/commands/search/index/__init__.py
+++ b/src/globus_cli/commands/search/index/__init__.py
@@ -1,0 +1,15 @@
+from globus_cli.parsing import group
+
+from .create import create_command
+from .list import list_command
+from .show import show_command
+
+
+@group("index")
+def index_command():
+    """View and manage indices"""
+
+
+index_command.add_command(create_command)
+index_command.add_command(list_command)
+index_command.add_command(show_command)

--- a/src/globus_cli/commands/search/index/create.py
+++ b/src/globus_cli/commands/search/index/create.py
@@ -1,0 +1,22 @@
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+
+from .._common import INDEX_FIELDS
+
+
+@command("create")
+@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@click.argument("DISPLAY_NAME")
+@click.argument("DESCRIPTION")
+def create_command(*, login_manager: LoginManager, display_name: str, description: str):
+    """(BETA) Create a new Index"""
+    index_doc = {"display_name": display_name, "description": description}
+    search_client = login_manager.get_search_client()
+    formatted_print(
+        search_client.post("/beta/index", data=index_doc),
+        text_format=FORMAT_TEXT_RECORD,
+        fields=INDEX_FIELDS,
+    )

--- a/src/globus_cli/commands/search/index/list.py
+++ b/src/globus_cli/commands/search/index/list.py
@@ -1,0 +1,22 @@
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import FORMAT_TEXT_TABLE, formatted_print
+
+from .._common import INDEX_FIELDS
+
+INDEX_LIST_FIELDS = INDEX_FIELDS + [
+    ("Permissions", lambda x: ",".join(x["permissions"])),
+]
+
+
+@command("list")
+@LoginManager.requires_login(LoginManager.SEARCH_RS)
+def list_command(*, login_manager: LoginManager):
+    """List indices where you have some permissions"""
+    search_client = login_manager.get_search_client()
+    formatted_print(
+        search_client.get("/v1/index_list"),
+        fields=INDEX_LIST_FIELDS,
+        text_format=FORMAT_TEXT_TABLE,
+        response_key="index_list",
+    )

--- a/src/globus_cli/commands/search/index/show.py
+++ b/src/globus_cli/commands/search/index/show.py
@@ -1,0 +1,20 @@
+import uuid
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+
+from .._common import INDEX_FIELDS, index_id_arg
+
+
+@command("show")
+@index_id_arg
+@LoginManager.requires_login(LoginManager.SEARCH_RS)
+def show_command(*, login_manager: LoginManager, index_id: uuid.UUID):
+    """Display information about an index"""
+    search_client = login_manager.get_search_client()
+    formatted_print(
+        search_client.get_index(index_id),
+        text_format=FORMAT_TEXT_RECORD,
+        fields=INDEX_FIELDS,
+    )

--- a/tests/files/api_fixtures/search.yaml
+++ b/tests/files/api_fixtures/search.yaml
@@ -3,6 +3,19 @@ metadata:
   error_index_id: 2ac1f660-298b-432f-89ae-c1299ad4233e
   task_id: 49869cb5-4fca-4f19-bbb6-8b0a18bd1f95
   pending_task_id: cfdedea7-9c52-42cb-84a6-6daa8217f772
+  index_list_data:
+    "6f831ac8-4c41-4812-b383-6fb04f8b9f9f":
+      display_name: "example_cookery"
+      status: "open"
+      permissions: owner
+    "c1b60556-b9d3-4c2a-a2e1-e297c079abbf":
+      display_name: "Globus Tutorials"
+      status: "open"
+      permissions: writer
+    "75df9506-4e85-4ce5-9f2c-8dcf25ae172e":
+      display_name: "Searchable Files Demo Index"
+      status: "open"
+      permissions: owner,writer
 
 search:
   - path: /v1/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f/search
@@ -289,6 +302,102 @@ search:
             "state": "PENDING",
             "state_description": "Task is waiting to start",
             "task_id": "cfdedea7-9c52-42cb-84a6-6daa8217f772"
+          }
+        ]
+      }
+  - path: /v1/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f
+    json:
+      {
+        "@datatype": "GSearchIndex",
+        "@version": "2017-09-01",
+        "creation_date": "2018-04-20 19:23:46",
+        "description": "Example index of Cookery",
+        "display_name": "example_cookery",
+        "id": "6f831ac8-4c41-4812-b383-6fb04f8b9f9f",
+        "is_trial": false,
+        "max_size_in_mb": 5000,
+        "num_entries": 5,
+        "num_subjects": 3,
+        "size_in_mb": 0,
+        "status": "open",
+        "subscription_id": null
+      }
+  - path: /beta/index
+    method: POST
+    json:
+      {
+        "@datatype": "GSearchIndex",
+        "@version": "2017-09-01",
+        "creation_date": "2018-04-20 19:23:46",
+        "description": "Example index of Cookery",
+        "display_name": "example_cookery",
+        "id": "6f831ac8-4c41-4812-b383-6fb04f8b9f9f",
+        "is_trial": false,
+        "max_size_in_mb": 1,
+        "num_entries": 0,
+        "num_subjects": 0,
+        "size_in_mb": 0,
+        "status": "open",
+        "subscription_id": null
+      }
+  - path: /v1/index_list
+    json:
+      {
+        "index_list": [
+          {
+            "@datatype": "GSearchIndex",
+            "@version": "2017-09-01",
+            "creation_date": "2018-04-20 19:23:46",
+            "description": "Example index of Cookery",
+            "display_name": "example_cookery",
+            "id": "6f831ac8-4c41-4812-b383-6fb04f8b9f9f",
+            "is_trial": false,
+            "max_size_in_mb": 5000,
+            "num_entries": 5,
+            "num_subjects": 3,
+            "permissions": [
+              "owner"
+            ],
+            "size_in_mb": 0,
+            "status": "open",
+            "subscription_id": null
+          },
+          {
+            "@datatype": "GSearchIndex",
+            "@version": "2017-09-01",
+            "creation_date": "2021-01-26 15:23:25",
+            "description": "A place for new users to learn about Globus Search",
+            "display_name": "Globus Tutorials",
+            "id": "c1b60556-b9d3-4c2a-a2e1-e297c079abbf",
+            "is_trial": false,
+            "max_size_in_mb": 5000,
+            "num_entries": 0,
+            "num_subjects": 0,
+            "permissions": [
+              "writer"
+            ],
+            "size_in_mb": 0,
+            "status": "open",
+            "subscription_id": null
+          },
+          {
+            "@datatype": "GSearchIndex",
+            "@version": "2017-09-01",
+            "creation_date": "2021-05-04 21:53:04",
+            "description": "An index created for use with the Searchable Files Demo App",
+            "display_name": "Searchable Files Demo Index",
+            "id": "75df9506-4e85-4ce5-9f2c-8dcf25ae172e",
+            "is_trial": true,
+            "max_size_in_mb": 1,
+            "num_entries": 22,
+            "num_subjects": 11,
+            "permissions": [
+              "owner",
+              "writer"
+            ],
+            "size_in_mb": 0,
+            "status": "open",
+            "subscription_id": null
           }
         ]
       }

--- a/tests/functional/search/test_index.py
+++ b/tests/functional/search/test_index.py
@@ -1,0 +1,42 @@
+def test_index_list(run_line, load_api_fixtures):
+    data = load_api_fixtures("search.yaml")
+    list_data = data["metadata"]["index_list_data"]
+
+    result = run_line(["globus", "search", "index", "list"])
+
+    found = set()
+    for index_id, attrs in list_data.items():
+        for line in result.output.split("\n"):
+            if index_id in line:
+                found.add(index_id)
+                for v in attrs.values():
+                    assert v in line
+    assert len(found) == len(list_data)
+
+
+def test_index_show(run_line, load_api_fixtures):
+    data = load_api_fixtures("search.yaml")
+    index_id = data["metadata"]["index_id"]
+
+    result, matcher = run_line(
+        ["globus", "search", "index", "show", index_id], matcher=True
+    )
+    matcher.check(r"^Index ID:\s+([\w-]+)$", groups=[index_id])
+
+
+def test_index_create(run_line, load_api_fixtures):
+    data = load_api_fixtures("search.yaml")
+    index_id = data["metadata"]["index_id"]
+
+    result, matcher = run_line(
+        [
+            "globus",
+            "search",
+            "index",
+            "create",
+            "example_cookery",
+            "Example index of Cookery",
+        ],
+        matcher=True,
+    )
+    matcher.check(r"^Index ID:\s+([\w-]+)$", groups=[index_id])


### PR DESCRIPTION
create, list, and show are all added, with a helptext note that the create command is beta (because the underlying API is beta).

Tests are included for these commands, and they've been tested against the production API.

One nuance is that this is the first command to have a combination of field types in a list in a type-checked function, such that the fields need to be type annotated to pass mypy. Therefore, this PR also introduces `globus_cli.types` to contain types for annotations, and defines `FIELD_LIST_T` therein.