### PR TITLE
Update gitignore to remove src/*.egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build
 /dist
 /*.egg-info
+/src/*.egg-info
 *.pyc
 /docs-source/_build/
 /.coverage


### PR DESCRIPTION
With the new(ish) src-layout for this project, building to publish puts an egg-info into the src/ dir. The project gitignore is not ignoring this as it should.