### PR TITLE
client identities

### DIFF
--- a/changelog.d/20211213_135655_aaschaer_client_login.md
+++ b/changelog.d/20211213_135655_aaschaer_client_login.md
@@ -1,5 +1,10 @@
 ### Enhancements
 
-* Add support for client identities to use the Globus CLI
+* Add support for client credentials for authentication in the Globus CLI
   by setting GLOBUS_CLI_CLIENT_ID and GLOBUS_CLI_CLIENT_SECRET
   environment variables (:pr:`NUMBER`)
+** Both variables must be set to enable this behavior
+** Tokens generated with client credentials are cached in the current user's home
+   directory, but isolated from any user credentials
+** With client credentials, `globus login` is invalid, but `globus logout` can be used
+   to revoke any cached tokens

--- a/changelog.d/20211213_135655_aaschaer_client_login.md
+++ b/changelog.d/20211213_135655_aaschaer_client_login.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* Add support for client identities to use the Globus CLI
+  by setting GLOBUS_CLI_CLIENT_ID and GLOBUS_CLI_CLIENT_SECRET
+  environment variables (:pr:`NUMBER`)

--- a/src/globus_cli/commands/logout.py
+++ b/src/globus_cli/commands/logout.py
@@ -94,20 +94,22 @@ def logout_command(*, login_manager: LoginManager, ignore_errors):
 
     # first, try to delete the templated credentialed client
     # ignore failure (maybe creds are already invalidated or the client was deleted)
-    try:
-        delete_templated_client()
-    except AuthAPIError:
-        if not ignore_errors:
-            warnecho(
-                "Failure while deleting internal client. "
-                "Please try logging out again",
-            )
-            click.get_current_context().exit(1)
-        else:
-            warnecho(
-                "Warning: Failed to delete internal client. "
-                "Continuing... (--ignore-errors)",
-            )
+    # client logins don't do this as they don't use a templated client
+    if not is_client_login():
+        try:
+            delete_templated_client()
+        except AuthAPIError:
+            if not ignore_errors:
+                warnecho(
+                    "Failure while deleting internal client. "
+                    "Please try logging out again",
+                )
+                click.get_current_context().exit(1)
+            else:
+                warnecho(
+                    "Warning: Failed to delete internal client. "
+                    "Continuing... (--ignore-errors)",
+                )
 
     # because the client was deleted above, the tokens should all be revoked
     # but it could have been the `--ignore-errors` case, so take a shot at revoking

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import click
 
-from globus_cli.login_manager import LoginManager
+from globus_cli.login_manager import LoginManager, get_client_login, is_client_login
 from globus_cli.parsing import command, no_local_server_option
 
 
@@ -21,17 +21,22 @@ def session_consent(scopes: Tuple[str], no_local_server: bool) -> None:
     This command is necessary when the CLI needs access to resources which require the
     user to explicitly consent to access.
     """
-    manager = LoginManager()
-    manager.run_login_flow(
-        no_local_server=no_local_server,
-        local_server_message=(
-            "You are running 'globus session consent', "
-            "which should automatically open a browser window for you to "
-            "authenticate with specific identities.\n"
-            "If this fails or you experience difficulty, try "
-            "'globus session consent --no-local-server'"
-            "\n---"
-        ),
-        epilog="\nYou have successfully updated your CLI session.\n",
-        scopes=list(scopes),
-    )
+    if is_client_login():
+        client = get_client_login()
+        client.oauth2_client_credentials_tokens(requested_scopes=scopes)
+
+    else:
+        manager = LoginManager()
+        manager.run_login_flow(
+            no_local_server=no_local_server,
+            local_server_message=(
+                "You are running 'globus session consent', "
+                "which should automatically open a browser window for you to "
+                "authenticate with specific identities.\n"
+                "If this fails or you experience difficulty, try "
+                "'globus session consent --no-local-server'"
+                "\n---"
+            ),
+            epilog="\nYou have successfully updated your CLI session.\n",
+            scopes=list(scopes),
+        )

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import click
 
-from globus_cli.login_manager import LoginManager, get_client_login, is_client_login
+from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, no_local_server_option
 
 
@@ -21,22 +21,17 @@ def session_consent(scopes: Tuple[str], no_local_server: bool) -> None:
     This command is necessary when the CLI needs access to resources which require the
     user to explicitly consent to access.
     """
-    if is_client_login():
-        client = get_client_login()
-        client.oauth2_client_credentials_tokens(requested_scopes=scopes)
-
-    else:
-        manager = LoginManager()
-        manager.run_login_flow(
-            no_local_server=no_local_server,
-            local_server_message=(
-                "You are running 'globus session consent', "
-                "which should automatically open a browser window for you to "
-                "authenticate with specific identities.\n"
-                "If this fails or you experience difficulty, try "
-                "'globus session consent --no-local-server'"
-                "\n---"
-            ),
-            epilog="\nYou have successfully updated your CLI session.\n",
-            scopes=list(scopes),
-        )
+    manager = LoginManager()
+    manager.run_login_flow(
+        no_local_server=no_local_server,
+        local_server_message=(
+            "You are running 'globus session consent', "
+            "which should automatically open a browser window for you to "
+            "authenticate with specific identities.\n"
+            "If this fails or you experience difficulty, try "
+            "'globus session consent --no-local-server'"
+            "\n---"
+        ),
+        epilog="\nYou have successfully updated your CLI session.\n",
+        scopes=list(scopes),
+    )

--- a/src/globus_cli/commands/session/show.py
+++ b/src/globus_cli/commands/session/show.py
@@ -4,7 +4,9 @@ import globus_sdk
 
 from globus_cli.login_manager import (
     LoginManager,
+    get_client_login,
     internal_auth_client,
+    is_client_login,
     token_storage_adapter,
 )
 from globus_cli.parsing import command
@@ -58,10 +60,13 @@ def session_show(*, login_manager):
         session_info = {}
         authentications = {}
     else:
-        internal_client = internal_auth_client()
+        if is_client_login():
+            introspect_client = get_client_login()
+        else:
+            introspect_client = internal_auth_client()
 
         access_token = tokendata["access_token"]
-        res = internal_client.oauth2_token_introspect(
+        res = introspect_client.oauth2_token_introspect(
             access_token, include="session_info"
         )
 

--- a/src/globus_cli/login_manager/__init__.py
+++ b/src/globus_cli/login_manager/__init__.py
@@ -1,3 +1,4 @@
+from .client_login import get_client_login, is_client_login
 from .errors import MissingLoginError
 from .local_server import is_remote_session
 from .manager import LoginManager
@@ -16,4 +17,6 @@ __all__ = [
     "internal_auth_client",
     "internal_native_client",
     "token_storage_adapter",
+    "is_client_login",
+    "get_client_login",
 ]

--- a/src/globus_cli/login_manager/client_login.py
+++ b/src/globus_cli/login_manager/client_login.py
@@ -1,0 +1,42 @@
+"""
+Logic for using client identities with the Globus CLI
+"""
+import os
+
+import globus_sdk
+
+CLIENT_ID = os.getenv("GLOBUS_CLI_CLIENT_ID")
+CLIENT_SECRET = os.getenv("GLOBUS_CLI_CLIENT_SECRET")
+
+
+def is_client_login() -> bool:
+    """
+    Return True if the correct env variables have been set to use a
+    client identity with the Globus CLI
+    """
+    if CLIENT_ID is None and CLIENT_SECRET is None:
+        return False
+
+    elif isinstance(CLIENT_ID, str) and isinstance(CLIENT_SECRET, str):
+        return True
+
+    else:
+        raise ValueError(
+            "Both GLOBUS_CLI_CLIENT_ID and GLOBUS_CLI_CLIENT_SECRET must "
+            "be set to use a client identity. Either set both environment "
+            "variables, or unset them to use a normal login."
+        )
+
+
+def get_client_login() -> globus_sdk.ConfidentialAppAuthClient:
+    """
+    Return the ConfidentialAppAuthClient for the client identity
+    logged into the CLI
+    """
+    if CLIENT_ID is None or CLIENT_SECRET is None:
+        raise ValueError("No client identity is logged in")
+
+    return globus_sdk.ConfidentialAppAuthClient(
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+    )

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -293,6 +293,8 @@ class LoginManager:
             collection_id=collection_id, endpoint_id=endpoint_id
         )
 
+        # client identities need to have this scope added as a requirement
+        # so that they correctly request it when building authorizers
         self.add_requirement(
             gcs_id, scopes=[GCSEndpointScopeBuilder(gcs_id).manage_collections]
         )

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -4,7 +4,13 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 import click
 import globus_sdk
-from globus_sdk.scopes import AuthScopes, GroupsScopes, SearchScopes, TransferScopes
+from globus_sdk.scopes import (
+    AuthScopes,
+    GCSEndpointScopeBuilder,
+    GroupsScopes,
+    SearchScopes,
+    TransferScopes,
+)
 
 from globus_cli.endpointish import Endpointish, EndpointType
 
@@ -286,6 +292,9 @@ class LoginManager:
             collection_id=collection_id, endpoint_id=endpoint_id
         )
 
+        self.add_requirement(
+            gcs_id, scopes=[GCSEndpointScopeBuilder(gcs_id).manage_collections]
+        )
         self.assert_logins(gcs_id, assume_gcs=True)
 
         authorizer = self._get_client_authorizer(

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -13,6 +13,7 @@ from ..services.auth import CustomAuthClient
 from ..services.gcs import CustomGCSClient
 from ..services.transfer import CustomTransferClient
 from .auth_flows import do_link_auth_flow, do_local_server_auth_flow
+from .client_login import get_client_login, is_client_login
 from .errors import MissingLoginError
 from .local_server import is_remote_session
 from .tokenstore import internal_auth_client, token_storage_adapter
@@ -93,6 +94,10 @@ class LoginManager:
         Determines if the user has a valid refresh token for the given
         resource server
         """
+        # client identities are always logged in
+        if is_client_login():
+            return True
+
         tokens = self._token_storage.get_token_data(resource_server)
         if tokens is None or "refresh_token" not in tokens:
             return False
@@ -108,6 +113,13 @@ class LoginManager:
         session_params: Optional[dict] = None,
         scopes: Optional[List[str]] = None,
     ):
+        if is_client_login():
+            raise ValueError(
+                "Client identities do not need to log in. If you are trying "
+                "to do a user log in, please unset the GLOBUS_CLI_CLIENT_ID "
+                "and GLOBUS_CLI_CLIENT_SECRET environment variables."
+            )
+
         if scopes is None:  # flatten scopes to list of strings if none provided
             scopes = [
                 s for _rs_name, rs_scopes in self.login_requirements for s in rs_scopes
@@ -178,25 +190,53 @@ class LoginManager:
 
     def _get_client_authorizer(
         self, resource_server: str, *, no_tokens_msg: Optional[str] = None
-    ) -> globus_sdk.RefreshTokenAuthorizer:
+    ) -> globus_sdk.authorizers.RenewingAuthorizer:
         tokens = self._token_storage.get_token_data(resource_server)
 
-        # if there are no tokens, raise an error
-        # this *should* never be reached, but it's a safety check to ensure we never go
-        # into a bad state
-        if tokens is None:
-            raise ValueError(
-                no_tokens_msg
-                or f"Could not get login data for {resource_server}. Try login to fix."
+        if is_client_login():
+            # construct scopes for the specified resource server.
+            # this is not guaranteed to contain always required scopes,
+            # additional logic may be needed to handle client identities that
+            # may be missing those.
+            scopes = []
+            for rs_name, rs_scopes in self.login_requirements:
+                if rs_name == resource_server:
+                    scopes.extend(rs_scopes)
+
+            # if we already have a token use it. This token could be invalid
+            # or for another client, but automatic retries will handle that
+            access_token = None
+            expires_at = None
+            if tokens:
+                access_token = tokens["access_token"]
+                expires_at = tokens["expires_at_seconds"]
+
+            return globus_sdk.ClientCredentialsAuthorizer(
+                confidential_client=get_client_login(),
+                scopes=scopes,
+                access_token=access_token,
+                expires_at=expires_at,
+                on_refresh=self._token_storage.on_refresh,
             )
 
-        return globus_sdk.RefreshTokenAuthorizer(
-            tokens["refresh_token"],
-            internal_auth_client(),
-            access_token=tokens["access_token"],
-            expires_at=tokens["expires_at_seconds"],
-            on_refresh=self._token_storage.on_refresh,
-        )
+        else:
+            # tokens are required for user logins
+            if tokens is None:
+                raise ValueError(
+                    no_tokens_msg
+                    or (
+                        f"Could not get login data for {resource_server}."
+                        " Try login to fix."
+                    )
+                )
+
+            return globus_sdk.RefreshTokenAuthorizer(
+                tokens["refresh_token"],
+                internal_auth_client(),
+                access_token=tokens["access_token"],
+                expires_at=tokens["expires_at_seconds"],
+                on_refresh=self._token_storage.on_refresh,
+            )
 
     def get_transfer_client(self) -> CustomTransferClient:
         authorizer = self._get_client_authorizer(TransferScopes.resource_server)

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -120,11 +120,12 @@ class LoginManager:
         scopes: Optional[List[str]] = None,
     ):
         if is_client_login():
-            raise ValueError(
+            click.echo(
                 "Client identities do not need to log in. If you are trying "
                 "to do a user log in, please unset the GLOBUS_CLI_CLIENT_ID "
                 "and GLOBUS_CLI_CLIENT_SECRET environment variables."
             )
+            click.get_current_context().exit(1)
 
         if scopes is None:  # flatten scopes to list of strings if none provided
             scopes = [

--- a/src/globus_cli/login_manager/tokenstore.py
+++ b/src/globus_cli/login_manager/tokenstore.py
@@ -5,6 +5,7 @@ import globus_sdk
 from globus_sdk.tokenstorage import SQLiteAdapter
 
 from ._old_config import invalidate_old_config
+from .client_login import is_client_login
 
 # internal constants
 _CLIENT_DATA_CONFIG_KEY = "auth_client_data"
@@ -75,16 +76,21 @@ def _get_storage_filename():
 
 
 def _resolve_namespace():
+    """
+    expected namespaces are:
+
+    userprofile/production        (default)
+    userprofile/sandbox           (env is set to sandbox)
+    userprofile/test/myprofile    (env is set to test, profile is set to myprofile)
+    clientprofile/production      (client login)
+    clientprofile/sandbox         (client login, env is set to sandbox)
+    clientprofile/test/myprofile  (client login, env is set to test,
+                                   profile is set to myprofile)
+    """
+    prefix = "clientprofile/" if is_client_login() else "userprofile/"
     env = GLOBUS_ENV if GLOBUS_ENV else "production"
-    # namespace any user profile so that non-user namespaces may be used in the future
-    # e.g. for client-credentials authenticated use of the CLI
-    #
-    # expected namespaces are
-    #
-    #     userprofile/production     (default)
-    #     userprofile/sandbox        (env is set to sandbox, profile is unset)
-    #     userprofile/test/myprofile (env is set to test, profile is set to myprofile)
-    return "userprofile/" + (f"{env}/{GLOBUS_PROFILE}" if GLOBUS_PROFILE else env)
+
+    return prefix + (f"{env}/{GLOBUS_PROFILE}" if GLOBUS_PROFILE else env)
 
 
 def token_storage_adapter():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,17 @@ def mock_login_token_response():
 
 
 @pytest.fixture
+def client_login(monkeypatch):
+    monkeypatch.setenv("GLOBUS_CLI_CLIENT_ID", "fake_client_id")
+    monkeypatch.setenv("GLOBUS_CLI_CLIENT_SECRET", "fake_client_secret")
+
+
+@pytest.fixture()
+def client_login_no_secret(monkeypatch):
+    monkeypatch.setenv("GLOBUS_CLI_CLIENT_ID", "fake_client_id")
+
+
+@pytest.fixture
 def test_token_storage(mock_login_token_response):
     """Put memory-backed sqlite token storage in place for the testsuite to use."""
     mockstore = SQLiteAdapter(":memory:")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,11 @@ def client_login_no_secret(monkeypatch):
     monkeypatch.setenv("GLOBUS_CLI_CLIENT_ID", "fake_client_id")
 
 
+@pytest.fixture()
+def user_profile(monkeypatch):
+    monkeypatch.setenv("GLOBUS_PROFILE", "test_user_profile")
+
+
 @pytest.fixture
 def test_token_storage(mock_login_token_response):
     """Put memory-backed sqlite token storage in place for the testsuite to use."""

--- a/tests/unit/test_client_login.py
+++ b/tests/unit/test_client_login.py
@@ -1,0 +1,39 @@
+import globus_sdk
+import pytest
+
+from globus_cli.login_manager import get_client_login, is_client_login
+from globus_cli.login_manager.tokenstore import _resolve_namespace
+
+
+def test_is_client_login_success(client_login):
+    assert is_client_login() is True
+
+
+def test_is_client_login_no_login():
+    assert is_client_login() is False
+
+
+def test_is_client_login_no_secret(client_login_no_secret):
+    with pytest.raises(ValueError):
+        is_client_login()
+
+
+def test_get_client_login_success(client_login):
+    client = get_client_login()
+    assert isinstance(client, globus_sdk.ConfidentialAppAuthClient)
+    assert client.authorizer.username == "fake_client_id"
+    assert client.authorizer.password == "fake_client_secret"
+
+
+def test_get_client_login_no_login():
+    with pytest.raises(ValueError):
+        get_client_login()
+
+
+def test_get_client_login_no_secret(client_login_no_secret):
+    with pytest.raises(ValueError):
+        get_client_login()
+
+
+def test_client_namespace(client_login):
+    assert _resolve_namespace() == "clientprofile/production"

--- a/tests/unit/test_client_login.py
+++ b/tests/unit/test_client_login.py
@@ -2,7 +2,6 @@ import globus_sdk
 import pytest
 
 from globus_cli.login_manager import get_client_login, is_client_login
-from globus_cli.login_manager.tokenstore import _resolve_namespace
 
 
 def test_is_client_login_success(client_login):
@@ -33,7 +32,3 @@ def test_get_client_login_no_login():
 def test_get_client_login_no_secret(client_login_no_secret):
     with pytest.raises(ValueError):
         get_client_login()
-
-
-def test_client_namespace(client_login):
-    assert _resolve_namespace() == "clientprofile/production"

--- a/tests/unit/test_tokenstore.py
+++ b/tests/unit/test_tokenstore.py
@@ -1,0 +1,13 @@
+from globus_cli.login_manager.tokenstore import _resolve_namespace
+
+
+def test_default_namespace():
+    assert _resolve_namespace() == "userprofile/production"
+
+
+def test_profile_namespace(user_profile):
+    assert _resolve_namespace() == "userprofile/production/test_user_profile"
+
+
+def test_client_namespace(client_login):
+    assert _resolve_namespace() == "clientprofile/production/fake_client_id"


### PR DESCRIPTION
Work for allowing client identities to use the CLI by setting GLOBUS_CLI_CLIENT_ID and GLOBUS_CLI_CLIENT_SECRET environment variables.

One thing I haven't fully tested is switching identities without running logout. Once the old client's tokens have expired all should be well, but it might be possible to be in a bad state before then. Not sure how much we care about that, but we could potentially namespace by client id in the db if we wanted to avoid the issue altogether?