### PR TITLE
Add `group member remove` command

### DIFF
--- a/changelog.d/20220103_164410_rudyardrichter_add_group_member_remove.md
+++ b/changelog.d/20220103_164410_rudyardrichter_add_group_member_remove.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add a `globus group member remove` command to remove a user from a group

--- a/src/globus_cli/commands/group/member/__init__.py
+++ b/src/globus_cli/commands/group/member/__init__.py
@@ -1,4 +1,5 @@
 from globus_cli.commands.group.member.add import member_add
+from globus_cli.commands.group.member.remove import member_remove
 from globus_cli.parsing import group
 
 
@@ -8,3 +9,4 @@ def group_member() -> None:
 
 
 group_member.add_command(member_add)
+group_member.add_command(member_remove)

--- a/src/globus_cli/commands/group/member/remove.py
+++ b/src/globus_cli/commands/group/member/remove.py
@@ -5,20 +5,20 @@ from globus_cli.parsing import IdentityType, ParsedIdentity, command
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 from globus_cli.types import FIELD_LIST_T
 
-ADD_USER_FIELDS: FIELD_LIST_T = [
+REMOVED_USER_FIELDS: FIELD_LIST_T = [
     ("Group ID", "group_id"),
-    ("Added User ID", "identity_id"),
-    ("Added User Username", "username"),
+    ("Removed User ID", "identity_id"),
+    ("Removed User Username", "username"),
 ]
 
 
-@command("add", short_help="Add a member to a group")
+@command("remove", short_help="Remove a member from a group")
 @click.argument("group_id", type=click.UUID)
 @click.argument("user", type=IdentityType())
 @LoginManager.requires_login(LoginManager.GROUPS_RS)
-def member_add(group_id: str, user: ParsedIdentity, login_manager):
+def member_remove(group_id: str, user: ParsedIdentity, login_manager):
     """
-    Add a member to a group.
+    Remove a member from a group.
 
     The USER argument may be an identity ID or username (whereas the group must be
     specified with an ID).
@@ -28,17 +28,16 @@ def member_add(group_id: str, user: ParsedIdentity, login_manager):
     identity_id = auth_client.maybe_lookup_identity_id(user.value)
     if not identity_id:
         raise click.UsageError(f"Couldn't determine identity from user value: {user}")
-    actions = {"add": [{"identity_id": identity_id}]}
+    actions = {"remove": [{"identity_id": identity_id}]}
     response = groups_client.batch_membership_action(group_id, actions)
-    # If this call failed to return an added user, figure out an error to show
-    if not response.get("add", None):
+    if not response.get("remove", None):
         try:
-            raise ValueError(response["errors"]["add"][0]["detail"])
+            raise ValueError(response["errors"]["remove"][0]["detail"])
         except (IndexError, KeyError):
-            raise ValueError("Could not add user to group")
+            raise ValueError("Could not remove the user from the group")
     formatted_print(
         response,
         text_format=FORMAT_TEXT_RECORD,
-        fields=ADD_USER_FIELDS,
-        response_key=lambda data: data["add"][0],
+        fields=REMOVED_USER_FIELDS,
+        response_key=lambda data: data["remove"][0],
     )

--- a/tests/files/api_fixtures/groups.yaml
+++ b/tests/files/api_fixtures/groups.yaml
@@ -7,6 +7,7 @@ metadata:
   user1_id: "00000000-0000-0000-0000-000000000001"
   user1_username: "test_user1"
   group_already_added_user_id: "00000000-0000-0000-0000-000000000002"
+  group_user_remove_error: "bcb0b12e-fdde-4283-8d77-e484716ce310"
 
 groups:
   - path: /groups/my_groups
@@ -90,4 +91,19 @@ groups:
             "status": "removed"
           }
         ]
+      }
+  - path: /groups/bcb0b12e-fdde-4283-8d77-e484716ce310
+    method: post
+    json:
+      {
+        "remove": [],
+        "errors": {
+          "remove": [
+            {
+              "code": "NO_MEMBERSHIP",
+              "detail": "Identity has no membership in group.",
+              "identity_id": "00000000-0000-0000-0000-000000000001"
+            }
+          ]
+        }
       }

--- a/tests/files/api_fixtures/groups.yaml
+++ b/tests/files/api_fixtures/groups.yaml
@@ -3,6 +3,7 @@ metadata:
   group1_name: "Group 1"
   group2_id: "93fca046-1666-11ec-88b2-f50515619d57"
   group2_name: "Group 2"
+  group_remove_id: "7fa8b8c1-aad3-47cf-a844-4b1cdbf7c124"
   user1_id: "00000000-0000-0000-0000-000000000001"
   user1_username: "test_user1"
   group_already_added_user_id: "00000000-0000-0000-0000-000000000002"
@@ -74,4 +75,19 @@ groups:
             }
           ]
         }
+      }
+  # edit members request to test removal:
+  - path: /groups/7fa8b8c1-aad3-47cf-a844-4b1cdbf7c124
+    method: post
+    json:
+      {
+        "remove": [
+          {
+            "group_id": "7fa8b8c1-aad3-47cf-a844-4b1cdbf7c124",
+            "identity_id": "00000000-0000-0000-0000-000000000001",
+            "username": "test_user1",
+            "role": "member",
+            "status": "removed"
+          }
+        ]
       }

--- a/tests/functional/test_group.py
+++ b/tests/functional/test_group.py
@@ -69,3 +69,13 @@ def test_group_member_remove(run_line, load_api_fixtures):
     assert "remove" in sent_data
     assert len(sent_data["remove"]) == 1
     assert sent_data["remove"][0]["identity_id"] == member
+
+
+def test_group_member_already_removed(run_line, load_api_fixtures):
+    data = load_api_fixtures("groups.yaml")
+    group = data["metadata"]["group_user_remove_error"]
+    member = data["metadata"]["user1_id"]
+    result = run_line(
+        f"globus group member remove {group} {member}", assert_exit_code=1
+    )
+    assert "Identity has no membership in group" in result.stderr

--- a/tests/functional/test_group.py
+++ b/tests/functional/test_group.py
@@ -54,3 +54,18 @@ def test_group_member_add_already_in_group(run_line, load_api_fixtures):
     member = data["metadata"]["user1_id"]
     result = run_line(f"globus group member add {group} {member}", assert_exit_code=1)
     assert "already an active member of the group" in result.stderr
+
+
+def test_group_member_remove(run_line, load_api_fixtures):
+    data = load_api_fixtures("groups.yaml")
+    group = data["metadata"]["group_remove_id"]
+    member = data["metadata"]["user1_id"]
+    username = data["metadata"]["user1_username"]
+    result = run_line(f"globus group member remove {group} {member}")
+    assert member in result.output
+    assert username in result.output
+    assert group in result.output
+    sent_data = json.loads(responses.calls[-1].request.body)
+    assert "remove" in sent_data
+    assert len(sent_data["remove"]) == 1
+    assert sent_data["remove"][0]["identity_id"] == member


### PR DESCRIPTION
Add `group member remove` (basically the counterpart of `group member add`) and a couple test cases.

Also fix the docs on `member add` which say "one or more members", because it must be exactly one. It seems like it would be nice to have `IdentityType`, or a variant thereof, handle that case. It doesn't seem like that would be too complicated, so if that makes sense I can add that here (or maybe, add that to `member add` and then update this).