### PR TITLE
Add 'cli-profile-list' command + minor login fix

### DIFF
--- a/changelog.d/20220107_194442_sirosen_add_profile_list.md
+++ b/changelog.d/20220107_194442_sirosen_add_profile_list.md
@@ -1,0 +1,9 @@
+### Enhancements
+
+* Attempting to run `globus login` while using client credentials will show an
+  appropriate error message
+* A new command, `globus cli-profile-list` can be used to list values for
+  `GLOBUS_PROFILE` and `GLOBUS_CLI_CLIENT_ID` ("client profiles") which have
+  been used. By default, the default profile is not included in the listing and
+  it is restricted to the current environment. A hidden option (`--all`) can be
+  used to list all environments and include the default profiles

--- a/src/globus_cli/commands/__init__.py
+++ b/src/globus_cli/commands/__init__.py
@@ -1,4 +1,5 @@
 from globus_cli.commands.bookmark import bookmark_command
+from globus_cli.commands.cli_profile_list import cli_profile_list
 from globus_cli.commands.collection import collection_command
 from globus_cli.commands.delete import delete_command
 from globus_cli.commands.endpoint import endpoint_command
@@ -35,6 +36,7 @@ def main() -> None:
 
 
 main.add_command(list_commands)
+main.add_command(cli_profile_list)
 main.add_command(version_command)
 main.add_command(update_command)
 

--- a/src/globus_cli/commands/cli_profile_list.py
+++ b/src/globus_cli/commands/cli_profile_list.py
@@ -1,0 +1,97 @@
+import os
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+import click
+import globus_sdk.tokenstorage
+
+from globus_cli.login_manager import token_storage_adapter
+from globus_cli.parsing import command
+from globus_cli.termio import FORMAT_TEXT_TABLE, formatted_print
+from globus_cli.types import FIELD_LIST_T
+
+
+# TODO: upstream this into the SDK as a method of the SQLiteStorageAdapter
+def _iter_namespaces(adapter: globus_sdk.tokenstorage.SQLiteAdapter) -> Iterator[str]:
+    conn = adapter._connection
+
+    cursor = conn.execute("SELECT DISTINCT namespace FROM token_storage;")
+    for row in cursor:
+        yield row[0]
+
+
+def _profilestr_to_datadict(s: str) -> Optional[Dict[str, Any]]:
+    if s.count("/") < 1:
+        return None
+    if s.count("/") < 2:
+        category, env = s.split("/")
+        if category == "clientprofile":  # should not be possible
+            return None
+        return {"client": False, "env": env, "profile": None, "default": True}
+    else:
+        category, env, profile = s.split("/", 2)
+        return {
+            "client": category == "clientprofile",
+            "env": env,
+            "profile": profile,
+            "default": False,
+        }
+
+
+def _parse_and_filter_profiles(
+    all: bool,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    namespaces = list(_iter_namespaces(token_storage_adapter()))
+    globus_env = os.getenv("GLOBUS_SDK_ENVIRONMENT", "production")
+
+    client_profiles = []
+    user_profiles = []
+    for n in namespaces:
+        data = _profilestr_to_datadict(n)
+        if not data:  # skip any parse failures
+            continue
+        if (
+            data["env"] != globus_env and not all
+        ):  # unless --all was passed, skip other envs
+            continue
+        if data["client"]:
+            client_profiles.append(data)
+        else:
+            if all or data["profile"] is not None:
+                user_profiles.append(data)
+
+    return (client_profiles, user_profiles)
+
+
+@command(
+    "cli-profile-list",
+    disable_options=["format", "map_http_status"],
+)
+@click.option("--all", is_flag=True, hidden=True)
+def cli_profile_list(*, all: bool) -> None:
+    """
+    List all CLI profiles which have been used
+
+    These are the values for GLOBUS_PROFILE which have been recorded, as well as
+    GLOBUS_CLI_CLIENT_ID values which have been used.
+    """
+
+    client_profiles, user_profiles = _parse_and_filter_profiles(all)
+
+    if user_profiles:
+        fields: FIELD_LIST_T = [("GLOBUS_PROFILE", "profile")]
+        if all:
+            fields += [
+                ("GLOBUS_SDK_ENVIRONMENT", "env"),
+                ("is_default", lambda x: "True" if x["default"] else "False"),
+            ]
+        formatted_print(user_profiles, text_format=FORMAT_TEXT_TABLE, fields=fields)
+    if client_profiles:
+        click.echo(
+            """
+==========
+"""
+        )
+        fields = [("GLOBUS_CLI_CLIENT_ID", "profile")]
+        if all:
+            fields.append(("GLOBUS_SDK_ENVIRONMENT", "env"))
+        formatted_print(client_profiles, text_format=FORMAT_TEXT_TABLE, fields=fields)

--- a/src/globus_cli/commands/login.py
+++ b/src/globus_cli/commands/login.py
@@ -1,7 +1,7 @@
 import click
 from globus_sdk.scopes import GCSEndpointScopeBuilder
 
-from globus_cli.login_manager import LoginManager
+from globus_cli.login_manager import LoginManager, is_client_login
 from globus_cli.parsing import command, no_local_server_option
 
 _SHARED_EPILOG = """\
@@ -37,6 +37,13 @@ You may force a new login with
     )
     + _SHARED_EPILOG
 )
+
+_IS_CLIENT_ID_RESPONSE = """\
+GLOBUS_CLI_CLIENT_ID and GLOBUS_CLI_CLIENT_SECRET are both set.
+
+When using client credentials, do not run 'globus login'
+Clients are always "logged in"
+"""
 
 
 @command(
@@ -86,6 +93,9 @@ def login_command(no_local_server, force, gcs_servers):
     given access code from the web to the CLI.
     """
     manager = LoginManager()
+
+    if is_client_login():
+        raise click.UsageError(_IS_CLIENT_ID_RESPONSE)
 
     # add GCS servers to LoginManager requirements so that the login check and login
     # flow will make use of the requested GCS servers

--- a/src/globus_cli/login_manager/tokenstore.py
+++ b/src/globus_cli/login_manager/tokenstore.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import cast
 
 import globus_sdk
 from globus_sdk.tokenstorage import SQLiteAdapter
@@ -12,6 +13,11 @@ _CLIENT_DATA_CONFIG_KEY = "auth_client_data"
 
 # env vars used throughout this module
 GLOBUS_ENV = os.environ.get("GLOBUS_SDK_ENVIRONMENT")
+
+
+# stub to allow type casting of a function to an object with an attribute
+class _TokenStoreFuncProto:
+    _instance: SQLiteAdapter
 
 
 def _template_client_id():
@@ -98,18 +104,17 @@ def _resolve_namespace():
         return "userprofile/" + env + (f"/{profile}" if profile else "")
 
 
-def token_storage_adapter():
-    if not hasattr(token_storage_adapter, "_instance"):
+def token_storage_adapter() -> SQLiteAdapter:
+    as_proto = cast(_TokenStoreFuncProto, token_storage_adapter)
+    if not hasattr(as_proto, "_instance"):
         # when initializing the token storage adapter, check if the storage file exists
         # if it does not, then use this as a flag to clean the old config
         fname = _get_storage_filename()
         if not os.path.exists(fname):
             invalidate_old_config(internal_native_client())
         # namespace is equal to the current environment
-        token_storage_adapter._instance = SQLiteAdapter(
-            fname, namespace=_resolve_namespace()
-        )
-    return token_storage_adapter._instance
+        as_proto._instance = SQLiteAdapter(fname, namespace=_resolve_namespace())
+    return as_proto._instance
 
 
 def internal_auth_client():

--- a/src/globus_cli/termio/output_formatter.py
+++ b/src/globus_cli/termio/output_formatter.py
@@ -171,21 +171,33 @@ def print_table(iterable, fields, print_headers=True):
     # handle the case in which the column header is the widest thing
     widths = [max(w, len(h)) for w, h in zip(widths, headers)]
 
-    # create a format string based on column widths
-    format_str = " | ".join("{:" + str(w) + "}" for w in widths)
-
     def none_to_null(val):
         if val is None:
             return "NULL"
         return val
 
+    def format_line(inputs):
+        out = ""
+        last_offset = 3
+        for w, h, x in zip(widths, headers, inputs):
+            out += str(x).ljust(w)
+            if h:
+                out += " | "
+                last_offset = 3
+            else:
+                last_offset = 0
+        return out[:-last_offset]
+
     # print headers
     if print_headers:
-        click.echo(format_str.format(*(h for h in headers)))
-        click.echo(format_str.format(*("-" * w for w in widths)))
+        click.echo(format_line(headers))
+        click.echo(
+            format_line(["-" * w if h else " " * w for w, h in zip(widths, headers)])
+        )
+
     # print the rows of data
     for i in iterable:
-        click.echo(format_str.format(*(none_to_null(f(i)) for f in fields)))
+        click.echo(format_line([none_to_null(f(i)) for f in fields]))
 
 
 def formatted_print(

--- a/tests/functional/test_cli_profile_list.py
+++ b/tests/functional/test_cli_profile_list.py
@@ -1,0 +1,102 @@
+import uuid
+
+import pytest
+from globus_sdk.tokenstorage import SQLiteAdapter
+
+
+def _add_namespace_to_test_storage(storage, namespace, token_data):
+    alt_storage = SQLiteAdapter(":memory:", namespace=namespace)
+    alt_storage._connection = storage._connection
+    alt_storage.store(token_data)
+
+
+@pytest.fixture
+def dummy_client_id():
+    return str(uuid.uuid1())
+
+
+@pytest.fixture
+def setup_user_profiles(monkeypatch, test_token_storage, mock_login_token_response):
+    for profile_name in [
+        "production",  # default (no profile name)
+        "production/foo-profile",
+        "production/bar-profile",
+        "production/baz-profile",
+        "preview",  # default (no profile name)
+        "preview/fizz-profile",
+        "preview/buzz-profile",
+    ]:
+        _add_namespace_to_test_storage(
+            test_token_storage, "userprofile/" + profile_name, mock_login_token_response
+        )
+    # e.g. someone has tinkered with the DB and added other stuff; should be handled and
+    # ignored
+    _add_namespace_to_test_storage(
+        test_token_storage, "BAD_VALUE", mock_login_token_response
+    )
+    _add_namespace_to_test_storage(
+        test_token_storage, "clientprofile/BAD_VALUE", mock_login_token_response
+    )
+
+
+@pytest.fixture
+def setup_client_profiles(
+    monkeypatch, test_token_storage, mock_login_token_response, dummy_client_id
+):
+    for env in ("production", "preview"):
+        _add_namespace_to_test_storage(
+            test_token_storage,
+            f"clientprofile/{env}/{dummy_client_id}",
+            mock_login_token_response,
+        )
+
+
+@pytest.mark.parametrize("env", ["production", "preview"])
+def test_simple_profile_list(setup_user_profiles, run_line, monkeypatch, env):
+    monkeypatch.setenv("GLOBUS_SDK_ENVIRONMENT", env)
+    result = run_line("globus cli-profile-list")
+
+    for profile_name in ["foo-profile", "bar-profile", "baz-profile"]:
+        if env == "production":
+            assert profile_name in result.output
+        else:
+            assert profile_name not in result.output
+    for profile_name in ["fizz-profile", "buzz-profile"]:
+        if env == "production":
+            assert profile_name not in result.output
+        else:
+            assert profile_name in result.output
+
+    assert "GLOBUS_CLI_CLIENT_ID" not in result.output
+
+
+def test_profile_list_all(setup_user_profiles, run_line):
+    result = run_line("globus cli-profile-list --all")
+    for profile_name in [
+        "foo-profile",
+        "bar-profile",
+        "baz-profile",
+        "fizz-profile",
+        "buzz-profile",
+    ]:
+        assert profile_name in result.output
+
+    assert "GLOBUS_CLI_CLIENT_ID" not in result.output
+
+
+def test_profile_list_includes_clients(
+    setup_user_profiles, setup_client_profiles, dummy_client_id, run_line
+):
+    result = run_line("globus cli-profile-list --all")
+
+    for profile_name in [
+        "foo-profile",
+        "bar-profile",
+        "baz-profile",
+        "fizz-profile",
+        "buzz-profile",
+    ]:
+        assert profile_name in result.output
+
+    assert "GLOBUS_CLI_CLIENT_ID" in result.output
+    assert dummy_client_id in result.output


### PR DESCRIPTION
With the addition of client creds, I believe that it's important to have this command included in the same release.
For now, I've tried not to overthink it, and just list profiles and client creds in a single command with a separator in the output.

This is the last change I want to get included before we do the next CLI release.

---

Testing this work uncovered a minor issue with login, in which client creds do not trigger a specific message and error. This could be confusing. Rectify with a custom usage error.

To implement `globus cli-profile-list`, directly check the token storage database to list the namespaces which are in use. Filter to those created by the CLI, and then parse them (slash-delimited) to identify them by type (user vs client) and environment. Listing is done by table-printing the results.

Tests need to carefully inject data into the test token storage's in-memory DB to simulate the presence of additional profiles. Once done, several cases are tested in simple fashion, ensuring that expected profile names are or are not present in the output.

The `--all` option, which expands the listing to all environments, is kept hidden for now, on the assumption that it would confuse most users. If it is frequently used or the fact that it is hidden leads to confusion, it can be made public later.