### PR TITLE
show, create, update, and delete group commands

### DIFF
--- a/changelog.d/20220125_133502_aaschaer_group.md
+++ b/changelog.d/20220125_133502_aaschaer_group.md
@@ -1,0 +1,14 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section or sections which match your change. Use "Other" for all
+changes which do not match a different section.
+
+Fill in one or more bullet points with details of your change.
+
+Make sure you add the new file in `changelog.d/` to your pull request!
+-->
+
+### Enhancements
+
+* Add `show`, `create`, `update`, and `delete` commands to `globus groups`

--- a/changelog.d/20220125_133502_aaschaer_group.md
+++ b/changelog.d/20220125_133502_aaschaer_group.md
@@ -11,4 +11,8 @@ Make sure you add the new file in `changelog.d/` to your pull request!
 
 ### Enhancements
 
-* Add `show`, `create`, `update`, and `delete` commands to `globus groups`
+* Added new commands for manipulating groups
+** `globus group create` creates a new group
+** `globus group show` shows group information
+** `globus group update` updates group name or description
+** `globus group delete` deletes a group

--- a/src/globus_cli/commands/group/__init__.py
+++ b/src/globus_cli/commands/group/__init__.py
@@ -1,5 +1,9 @@
+from globus_cli.commands.group.create import group_create
+from globus_cli.commands.group.delete import group_delete
 from globus_cli.commands.group.list import group_list
 from globus_cli.commands.group.member import group_member
+from globus_cli.commands.group.show import group_show
+from globus_cli.commands.group.update import group_update
 from globus_cli.parsing import group
 
 
@@ -9,4 +13,8 @@ def group_command() -> None:
 
 
 group_command.add_command(group_list)
+group_command.add_command(group_show)
+group_command.add_command(group_create)
+group_command.add_command(group_update)
+group_command.add_command(group_delete)
 group_command.add_command(group_member)

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -15,7 +15,7 @@ def group_id_arg(f: Optional[Callable] = None, *, required=True):
 
 
 def parse_roles(res):
-    return ",".join(sorted(set(m["role"] for m in res["my_memberships"])))
+    return ",".join(sorted({m["role"] for m in res["my_memberships"]}))
 
 
 def format_session_enforcement(res):
@@ -29,14 +29,23 @@ def parse_visibility(res):
     return res["policies"]["group_visibility"]
 
 
-def group_create_and_update_params(f: Optional[Callable] = None) -> Callable:
+def group_create_and_update_params(
+    f: Optional[Callable] = None, *, create: bool = False
+) -> Callable:
     """
     Collection of options consumed by group create and update.
+    Passing create as True makes any values required for create
+    arguments instead of options.
     """
     if f is None:
-        return functools.partial(group_create_and_update_params)
+        return functools.partial(group_create_and_update_params, create=create)
 
-    f = click.argument("name")(f)
+    # name is required for create
+    if create:
+        f = click.argument("name")(f)
+    else:
+        f = click.option("--name", help="Name for the group.")(f)
+
     f = click.option("--description", help="Description for the group.")(f)
 
     return f

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -4,14 +4,10 @@ from typing import Callable, Optional
 import click
 
 
-def group_id_arg(f: Optional[Callable] = None, *, required=True):
-    """
-    By default, the group ID is made required; pass `required=False` to the
-    decorator arguments to make it optional.
-    """
+def group_id_arg(f: Optional[Callable] = None):
     if f is None:
-        return functools.partial(group_id_arg, required=required)
-    return click.argument("GROUP_ID", required=required)(f)
+        return functools.partial(group_id_arg)
+    return click.argument("GROUP_ID")(f)
 
 
 def parse_roles(res):

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -15,11 +15,7 @@ def group_id_arg(f: Optional[Callable] = None, *, required=True):
 
 
 def parse_roles(res):
-    roles = set()
-    for membership in res["my_memberships"]:
-        roles.add(membership["role"])
-
-    return ",".join(sorted(roles))
+    return ",".join(sorted(set(m["role"] for m in res["my_memberships"])))
 
 
 def format_session_enforcement(res):

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -1,0 +1,46 @@
+import functools
+from typing import Callable, Optional
+
+import click
+
+
+def group_id_arg(f: Optional[Callable] = None, *, required=True):
+    """
+    By default, the group ID is made required; pass `required=False` to the
+    decorator arguments to make it optional.
+    """
+    if f is None:
+        return functools.partial(group_id_arg, required=required)
+    return click.argument("GROUP_ID", required=required)(f)
+
+
+def parse_roles(res):
+    roles = set()
+    for membership in res["my_memberships"]:
+        roles.add(membership["role"])
+
+    return ",".join(sorted(roles))
+
+
+def format_session_enforcement(res):
+    if res.get("enforce_session"):
+        return "strict"
+    else:
+        return "not strict"
+
+
+def parse_visibility(res):
+    return res["policies"]["group_visibility"]
+
+
+def group_create_and_update_params(f: Optional[Callable] = None) -> Callable:
+    """
+    Collection of options consumed by group create and update.
+    """
+    if f is None:
+        return functools.partial(group_create_and_update_params)
+
+    f = click.argument("name")(f)
+    f = click.option("--description", help="Description for the group.")(f)
+
+    return f

--- a/src/globus_cli/commands/group/create.py
+++ b/src/globus_cli/commands/group/create.py
@@ -7,7 +7,7 @@ from globus_cli.termio import formatted_print
 from ._common import group_create_and_update_params
 
 
-@group_create_and_update_params()
+@group_create_and_update_params(create=True)
 @command("create", short_help="Create a new group")
 @LoginManager.requires_login(LoginManager.GROUPS_RS)
 def group_create(*, login_manager: LoginManager, **kwargs: Any):

--- a/src/globus_cli/commands/group/create.py
+++ b/src/globus_cli/commands/group/create.py
@@ -8,7 +8,7 @@ from ._common import group_create_and_update_params
 
 
 @group_create_and_update_params(create=True)
-@command("create", short_help="Create a new group")
+@command("create")
 @LoginManager.requires_login(LoginManager.GROUPS_RS)
 def group_create(*, login_manager: LoginManager, **kwargs: Any):
     """Create a new group"""

--- a/src/globus_cli/commands/group/create.py
+++ b/src/globus_cli/commands/group/create.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import formatted_print
+
+from ._common import group_create_and_update_params
+
+
+@group_create_and_update_params()
+@command("create", short_help="Create a new group")
+@LoginManager.requires_login(LoginManager.GROUPS_RS)
+def group_create(*, login_manager: LoginManager, **kwargs: Any):
+    """Create a new group"""
+    groups_client = login_manager.get_groups_client()
+
+    response = groups_client.create_group(kwargs)
+    group_id = response["id"]
+
+    formatted_print(response, simple_text=f"Group {group_id} created successfully")

--- a/src/globus_cli/commands/group/delete.py
+++ b/src/globus_cli/commands/group/delete.py
@@ -1,0 +1,17 @@
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import formatted_print
+
+from ._common import group_id_arg
+
+
+@group_id_arg
+@command("delete", short_help="Delete a group")
+@LoginManager.requires_login(LoginManager.GROUPS_RS)
+def group_delete(group_id, *, login_manager: LoginManager):
+    """Delete a group"""
+    groups_client = login_manager.get_groups_client()
+
+    response = groups_client.delete_group(group_id)
+
+    formatted_print(response, simple_text="Group deleted successfully")

--- a/src/globus_cli/commands/group/delete.py
+++ b/src/globus_cli/commands/group/delete.py
@@ -6,9 +6,13 @@ from ._common import group_id_arg
 
 
 @group_id_arg
-@command("delete", short_help="Delete a group")
+@command("delete")
 @LoginManager.requires_login(LoginManager.GROUPS_RS)
-def group_delete(group_id, *, login_manager: LoginManager):
+def group_delete(
+    *,
+    login_manager: LoginManager,
+    group_id: str,
+):
     """Delete a group"""
     groups_client = login_manager.get_groups_client()
 

--- a/src/globus_cli/commands/group/list.py
+++ b/src/globus_cli/commands/group/list.py
@@ -2,6 +2,8 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import formatted_print
 
+from ._common import format_session_enforcement, parse_roles
+
 
 def _format_session_enforcement(res):
     if res.get("enforce_session"):
@@ -32,7 +34,7 @@ def group_list(*, login_manager: LoginManager):
             ("Group ID", "id"),
             ("Name", "name"),
             ("Type", "group_type"),
-            ("Session Enforcement", _format_session_enforcement),
-            ("Roles", _parse_roles),
+            ("Session Enforcement", format_session_enforcement),
+            ("Roles", parse_roles),
         ],
     )

--- a/src/globus_cli/commands/group/show.py
+++ b/src/globus_cli/commands/group/show.py
@@ -11,9 +11,13 @@ from ._common import (
 
 
 @group_id_arg
-@command("show", short_help="Show a group definition")
+@command("show")
 @LoginManager.requires_login(LoginManager.GROUPS_RS)
-def group_show(*, login_manager: LoginManager, group_id):
+def group_show(
+    *,
+    login_manager: LoginManager,
+    group_id: str,
+):
     """Show a group definition"""
     groups_client = login_manager.get_groups_client()
 

--- a/src/globus_cli/commands/group/show.py
+++ b/src/globus_cli/commands/group/show.py
@@ -1,0 +1,34 @@
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+
+from ._common import (
+    format_session_enforcement,
+    group_id_arg,
+    parse_roles,
+    parse_visibility,
+)
+
+
+@group_id_arg
+@command("show", short_help="Show a group definition")
+@LoginManager.requires_login(LoginManager.GROUPS_RS)
+def group_show(*, login_manager: LoginManager, group_id):
+    """Show a group definition"""
+    groups_client = login_manager.get_groups_client()
+
+    query_params = {"include": "my_memberships"}
+    group = groups_client.get_group(group_id, query_params=query_params)
+
+    formatted_print(
+        group,
+        text_format=FORMAT_TEXT_RECORD,
+        fields=[
+            ("Name", "name"),
+            ("Description", "description"),
+            ("Type", "group_type"),
+            ("Visibility", parse_visibility),
+            ("Session Enforcement", format_session_enforcement),
+            ("Roles", parse_roles),
+        ],
+    )

--- a/src/globus_cli/commands/group/update.py
+++ b/src/globus_cli/commands/group/update.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import formatted_print
+
+from ._common import group_create_and_update_params, group_id_arg
+
+
+@group_create_and_update_params()
+@group_id_arg
+@command("update", short_help="Update an existing group")
+@LoginManager.requires_login(LoginManager.GROUPS_RS)
+def group_update(group_id, *, login_manager: LoginManager, **kwargs: Any):
+    """Update an existing group. Any fields not given will be set to null."""
+    groups_client = login_manager.get_groups_client()
+
+    # response = groups_client.update_group(group_id, kwargs)
+    response = groups_client.put(f"/groups/{group_id}", data=kwargs)
+
+    formatted_print(response, simple_text="Group updated successfully")

--- a/src/globus_cli/commands/group/update.py
+++ b/src/globus_cli/commands/group/update.py
@@ -12,10 +12,21 @@ from ._common import group_create_and_update_params, group_id_arg
 @command("update", short_help="Update an existing group")
 @LoginManager.requires_login(LoginManager.GROUPS_RS)
 def group_update(group_id, *, login_manager: LoginManager, **kwargs: Any):
-    """Update an existing group. Any fields not given will be set to null."""
+    """Update an existing group."""
     groups_client = login_manager.get_groups_client()
 
+    # get the current state of the group
+    group = groups_client.get_group(group_id)
+
+    # assemble put data using existing values for any field not given
+    data = {}
+    for field in ["name", "description"]:
+        if kwargs.get(field) is not None:
+            data[field] = kwargs.get(field)
+        else:
+            data[field] = group[field]
+
     # response = groups_client.update_group(group_id, kwargs)
-    response = groups_client.put(f"/groups/{group_id}", data=kwargs)
+    response = groups_client.put(f"/groups/{group_id}", data=data)
 
     formatted_print(response, simple_text="Group updated successfully")

--- a/src/globus_cli/commands/group/update.py
+++ b/src/globus_cli/commands/group/update.py
@@ -9,9 +9,9 @@ from ._common import group_create_and_update_params, group_id_arg
 
 @group_create_and_update_params()
 @group_id_arg
-@command("update", short_help="Update an existing group")
+@command("update")
 @LoginManager.requires_login(LoginManager.GROUPS_RS)
-def group_update(group_id, *, login_manager: LoginManager, **kwargs: Any):
+def group_update(*, login_manager: LoginManager, group_id: str, **kwargs: Any):
     """Update an existing group."""
     groups_client = login_manager.get_groups_client()
 
@@ -19,13 +19,15 @@ def group_update(group_id, *, login_manager: LoginManager, **kwargs: Any):
     group = groups_client.get_group(group_id)
 
     # assemble put data using existing values for any field not given
+    # note that the API does not accept the full group document, so we must
+    # specify name and description instead of just iterating kwargs
     data = {}
     for field in ["name", "description"]:
         if kwargs.get(field) is not None:
-            data[field] = kwargs.get(field)
+            data[field] = kwargs[field]
         else:
             data[field] = group[field]
 
-    response = groups_client.update_group(group_id, kwargs)
+    response = groups_client.update_group(group_id, data)
 
     formatted_print(response, simple_text="Group updated successfully")

--- a/src/globus_cli/commands/group/update.py
+++ b/src/globus_cli/commands/group/update.py
@@ -26,7 +26,6 @@ def group_update(group_id, *, login_manager: LoginManager, **kwargs: Any):
         else:
             data[field] = group[field]
 
-    # response = groups_client.update_group(group_id, kwargs)
-    response = groups_client.put(f"/groups/{group_id}", data=data)
+    response = groups_client.update_group(group_id, kwargs)
 
     formatted_print(response, simple_text="Group updated successfully")

--- a/tests/files/api_fixtures/groups.yaml
+++ b/tests/files/api_fixtures/groups.yaml
@@ -1,6 +1,7 @@
 metadata:
   group1_id: "8b7d57bc-1666-11ec-88b2-f50515619d57"
   group1_name: "Group 1"
+  group1_description: "The first group."
   group2_id: "93fca046-1666-11ec-88b2-f50515619d57"
   group2_name: "Group 2"
   group_remove_id: "7fa8b8c1-aad3-47cf-a844-4b1cdbf7c124"
@@ -48,6 +49,86 @@ groups:
           ]
         }
     ]
+  - path: /groups
+    method: post
+    json:
+      {
+        "id": "8b7d57bc-1666-11ec-88b2-f50515619d57",
+        "name": "Group 1",
+        "description": "The first group.",
+        "group_type": "regular",
+        "enforce_session": false,
+        "policies": {
+          "authentication_assurance_timeout": 28800,
+          "group_members_visibility": "managers",
+          "group_visibility": "private",
+          "is_high_assurance": false,
+          "join_requests": false,
+          "signup_fields": []
+        }
+      }
+  - path: /groups/8b7d57bc-1666-11ec-88b2-f50515619d57
+    method: get
+    json:
+      {
+        "id": "8b7d57bc-1666-11ec-88b2-f50515619d57",
+        "name": "Group 1",
+        "description": "The first group.",
+        "group_type": "regular",
+        "enforce_session": false,
+        "my_memberships": [
+            {
+                "group_id": "8b7d57bc-1666-11ec-88b2-f50515619d57",
+                "identity_id": "a24d6e82-1666-11ec-88b2-f50515619d57",
+                "username": "alice@example.com",
+                "role": "admin"
+            }
+        ],
+        "policies": {
+          "authentication_assurance_timeout": 28800,
+          "group_members_visibility": "managers",
+          "group_visibility": "private",
+          "is_high_assurance": false,
+          "join_requests": false,
+          "signup_fields": []
+        }
+      }
+  - path: /groups/8b7d57bc-1666-11ec-88b2-f50515619d57
+    method: put
+    json:
+      {
+        "id": "8b7d57bc-1666-11ec-88b2-f50515619d57",
+        "name": "New Name",
+        "description": "New Description",
+        "group_type": "regular",
+        "enforce_session": false,
+        "policies": {
+          "authentication_assurance_timeout": 28800,
+          "group_members_visibility": "managers",
+          "group_visibility": "private",
+          "is_high_assurance": false,
+          "join_requests": false,
+          "signup_fields": []
+        }
+      }
+  - path: /groups/8b7d57bc-1666-11ec-88b2-f50515619d57
+    method: delete
+    json:
+      {
+        "id": "8b7d57bc-1666-11ec-88b2-f50515619d57",
+        "name": "Group 1",
+        "description": "The first group.",
+        "group_type": "regular",
+        "enforce_session": false,
+        "policies": {
+          "authentication_assurance_timeout": 28800,
+          "group_members_visibility": "managers",
+          "group_visibility": "private",
+          "is_high_assurance": false,
+          "join_requests": false,
+          "signup_fields": []
+        }
+      }
   - path: /groups/8b7d57bc-1666-11ec-88b2-f50515619d57
     method: post
     json:

--- a/tests/functional/test_group.py
+++ b/tests/functional/test_group.py
@@ -64,7 +64,8 @@ def test_group_update(run_line, load_api_fixtures):
     group1_id = data["metadata"]["group1_id"]
 
     result = run_line(
-        f"globus group update {group1_id} 'New Name' --description 'New Description'"
+        f"globus group update {group1_id} "
+        "--name 'New Name' --description 'New Description'"
     )
 
     assert "Group updated successfully" in result.output

--- a/tests/functional/test_group.py
+++ b/tests/functional/test_group.py
@@ -22,6 +22,67 @@ def test_group_list(run_line, load_api_fixtures):
     assert group2_name in result.output
 
 
+def test_group_show(run_line, load_api_fixtures):
+    """
+    Basic success test for globus group show
+    """
+    data = load_api_fixtures("groups.yaml")
+
+    group1_id = data["metadata"]["group1_id"]
+    group1_name = data["metadata"]["group1_name"]
+    group1_description = data["metadata"]["group1_description"]
+
+    result = run_line(f"globus group show {group1_id}")
+
+    assert group1_name in result.output
+    assert group1_description in result.output
+
+
+def test_group_create(run_line, load_api_fixtures):
+    """
+    Basic success test for globus group create
+    """
+    data = load_api_fixtures("groups.yaml")
+
+    group1_id = data["metadata"]["group1_id"]
+    group1_name = data["metadata"]["group1_name"]
+    group1_description = data["metadata"]["group1_description"]
+
+    result = run_line(
+        f"globus group create '{group1_name}' --description '{group1_description}'"
+    )
+
+    assert f"Group {group1_id} created successfully" in result.output
+
+
+def test_group_update(run_line, load_api_fixtures):
+    """
+    Basic success test for globus group update
+    """
+    data = load_api_fixtures("groups.yaml")
+
+    group1_id = data["metadata"]["group1_id"]
+
+    result = run_line(
+        f"globus group update {group1_id} 'New Name' --description 'New Description'"
+    )
+
+    assert "Group updated successfully" in result.output
+
+
+def test_group_delete(run_line, load_api_fixtures):
+    """
+    Basic success test for globus group delete
+    """
+    data = load_api_fixtures("groups.yaml")
+
+    group1_id = data["metadata"]["group1_id"]
+
+    result = run_line(f"globus group delete {group1_id}")
+
+    assert "Group deleted successfully" in result.output
+
+
 def test_group_member_add(run_line, load_api_fixtures):
     data = load_api_fixtures("groups.yaml")
     group = data["metadata"]["group1_id"]


### PR DESCRIPTION
We might want to have different fields for show depending on if `show-policies` or `policies show` end up being separate commands. But I think the current set of fields is at least reasonable?

As far as I can tell name and description are the only documented fields for the group document as opposed to the policy document, which leaves those commands surprisingly barren.

`group update` not using patchy put behavior feels a little odd since it makes name a required field on update and sets description to null if not provided. I guess we could do a get and then put any unchanged values if we wanted patchy put behavior?

`group update` is also currently using a raw `client.put` call, once the SDK release goes out that should probably be updated to use the helper.