### PR TITLE
Update dependency versions: dev + globus-sdk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,41 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace
     - id: end-of-file-fixer
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.7.1
+  rev: 0.10.0
   hooks:
     - id: check-github-workflows
 - repo: https://github.com/python/black
-  rev: 21.11b1
+  rev: 21.12b0
   hooks:
     - id: black
 - repo: https://github.com/pycqa/flake8
   rev: 4.0.1
   hooks:
     - id: flake8
-      additional_dependencies: ['flake8-bugbear==21.11.29']
+      additional_dependencies: ['flake8-bugbear==22.1.11']
 - repo: https://github.com/timothycrosley/isort
   rev: 5.10.1
   hooks:
     - id: isort
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.29.1
+  rev: v2.31.0
   hooks:
     - id: pyupgrade
       args: ["--py36-plus"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910-1
+  rev: v0.931
   hooks:
     - id: mypy
       additional_dependencies:
         - types-setuptools
         - types-requests
         - click
-        - 'globus-sdk==3.2.0'
+        - 'globus-sdk==3.3.1'
 - repo: local
   hooks:
     - id: fix-changelog

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ DEV_REQUIREMENTS = [
     # lint
     "flake8<5",
     "isort<6",
-    "black==21.11b1",
-    "flake8-bugbear==21.11.29",
-    "mypy==0.910",
+    "black==21.12b0",
+    "flake8-bugbear==22.1.11",
+    "mypy==0.931",
     # tests
     "pytest<7",
     "pytest-cov<3",
@@ -48,7 +48,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.6",
     install_requires=[
-        "globus-sdk==3.2.0",
+        "globus-sdk==3.3.1",
         "click>=8.0.0,<9",
         "jmespath==0.10.0",
         # these are dependencies of the SDK, but they are used directly in the CLI

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     types-requests
     typing-extensions
     click
-    globus-sdk==3.2.0
+    globus-sdk==3.3.1
 commands = mypy src/
 
 [testenv:reference]


### PR DESCRIPTION
Dev dependencies specified in pre-commit were updated with `pre-commit autoupdate`.
Additionally, bump those specified in setup.py to match.

Bump globus-sdk to the latest version, v3.3.1