### PR TITLE
Use pypa's `build` to build dists

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands_pre = rm -rf dist/
 # check that twine validating package data works
 commands =
     python -m build
-   twine check dist/*
+    twine check dist/*
 
 [testenv:prepare-release]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -52,13 +52,15 @@ commands = python ./reference/_generate.py
 
 [testenv:twine-check]
 skip_install = true
-deps = twine
-       wheel
+deps =
+    build
+    twine
 whitelist_externals = rm
 commands_pre = rm -rf dist/
 # check that twine validating package data works
-commands = python setup.py sdist bdist_wheel
-           twine check dist/*
+commands =
+    python -m build
+   twine check dist/*
 
 [testenv:prepare-release]
 skip_install = true
@@ -69,11 +71,12 @@ commands =
 
 [testenv:publish-release]
 skip_install = true
-deps = twine
-       wheel
+deps =
+    build
+    twine
 # clean the build dir before rebuilding
 whitelist_externals = rm
 commands_pre = rm -rf dist/
 commands =
-    python setup.py sdist bdist_wheel
+    python -m build
     twine upload dist/*


### PR DESCRIPTION
I was in a hurry to add `build` for `globus-sdk` as it was the best path to fixing the bad build which I had released.
This PR is the same change, but for the CLI. We can therefore take a bit more time to review and confirm that this is what we want.



---

`build` replaces use of `setup.py sdist bdist_wheel`. It has several advantages over the older approach of using `setuptools` and `wheel` directly:
- it builds in an isolated environment (by default), so that it can't be confused by local files when building a wheel
- it can support alternative build backends via pyproject.toml (if we add these), per [PEP517](https://www.python.org/dev/peps/pep-0517/)
- it's the more modern (and therefore documented) way of doing a build

A pyproject.toml is not needed for this change. `build` touts itself as an implementation of the standard set out in PEP517, and the spec states:

>  If the pyproject.toml file is absent, or the build-backend key is  missing, the source tree is not using this specification, and tools should revert to the legacy behaviour of running setup.py

This is our case, so `build` works as expected and desired.