### PR TITLE
group set-policies command

### DIFF
--- a/changelog.d/20220222_140127_aaschaer_groups.md
+++ b/changelog.d/20220222_140127_aaschaer_groups.md
@@ -1,0 +1,27 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section or sections which match your change. Use "Other" for all
+changes which do not match a different section.
+
+Fill in one or more bullet points with details of your change.
+
+Make sure you add the new file in `changelog.d/` to your pull request!
+-->
+
+<!--
+### Bugfixes
+
+* A bullet item for the Bugfixes category.
+
+-->
+### Enhancements
+
+* Add `globus groups set-policies` command for managing a groups policies
+
+<!--
+### Other
+
+* A bullet item for the Other category.
+
+-->

--- a/changelog.d/20220222_140127_aaschaer_groups.md
+++ b/changelog.d/20220222_140127_aaschaer_groups.md
@@ -17,7 +17,7 @@ Make sure you add the new file in `changelog.d/` to your pull request!
 -->
 ### Enhancements
 
-* Add `globus groups set-policies` command for managing a groups policies
+* Add `globus groups set-policies` command for managing a group's policies
 
 <!--
 ### Other

--- a/src/globus_cli/commands/group/__init__.py
+++ b/src/globus_cli/commands/group/__init__.py
@@ -5,6 +5,7 @@ from globus_cli.commands.group.join import group_join
 from globus_cli.commands.group.leave import group_leave
 from globus_cli.commands.group.list import group_list
 from globus_cli.commands.group.member import group_member
+from globus_cli.commands.group.set_policies import group_set_policies
 from globus_cli.commands.group.show import group_show
 from globus_cli.commands.group.update import group_update
 from globus_cli.parsing import group
@@ -24,3 +25,4 @@ group_command.add_command(group_member)
 group_command.add_command(group_invite)
 group_command.add_command(group_join)
 group_command.add_command(group_leave)
+group_command.add_command(group_set_policies)

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -28,6 +28,18 @@ def parse_visibility(res):
     return res["policies"]["group_visibility"]
 
 
+def parse_members_visibility(res):
+    return res["policies"]["group_members_visibility"]
+
+
+def parse_join_requests(res):
+    return res["policies"]["join_requests"]
+
+
+def parse_signup_fields(res):
+    return ",".join(sorted({f for f in res["policies"]["signup_fields"]}))
+
+
 def group_create_and_update_params(
     f: Optional[Callable] = None, *, create: bool = False
 ) -> Callable:

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -37,7 +37,7 @@ def parse_join_requests(res):
 
 
 def parse_signup_fields(res):
-    return ",".join(sorted({f for f in res["policies"]["signup_fields"]}))
+    return ",".join(sorted(f for f in res["policies"]["signup_fields"]))
 
 
 def group_create_and_update_params(

--- a/src/globus_cli/commands/group/set_policies.py
+++ b/src/globus_cli/commands/group/set_policies.py
@@ -27,7 +27,7 @@ SIGNUP_FIELDS = [
 @click.option(
     "--high-assurance/--no-high-assurance",
     default=None,
-    help="Flag if the group will enforce high assurance access policies or not.",
+    help="Whether the group should enforce high assurance access policies or not.",
 )
 @click.option(
     "--authentication-timeout",

--- a/src/globus_cli/commands/group/set_policies.py
+++ b/src/globus_cli/commands/group/set_policies.py
@@ -8,20 +8,6 @@ from globus_cli.termio import formatted_print
 
 from ._common import MEMBERSHIP_FIELDS, group_id_arg
 
-SIGNUP_FIELDS = [
-    "address",
-    "address1",
-    "address2",
-    "city",
-    "country",
-    "current_project_name",
-    "department",
-    "field_of_science",
-    "institution",
-    "phone",
-    "state",
-    "zip",
-]
 
 
 @click.option(

--- a/src/globus_cli/commands/group/set_policies.py
+++ b/src/globus_cli/commands/group/set_policies.py
@@ -25,7 +25,7 @@ SIGNUP_FIELDS = [
 
 
 @click.option(
-    "--high-assurance/--not-high-assurance",
+    "--high-assurance/--no-high-assurance",
     default=None,
     help="Flag if the group will enforce high assurance access policies or not.",
 )

--- a/src/globus_cli/commands/group/set_policies.py
+++ b/src/globus_cli/commands/group/set_policies.py
@@ -9,7 +9,6 @@ from globus_cli.termio import formatted_print
 from ._common import MEMBERSHIP_FIELDS, group_id_arg
 
 
-
 @click.option(
     "--high-assurance/--no-high-assurance",
     default=None,

--- a/src/globus_cli/commands/group/set_policies.py
+++ b/src/globus_cli/commands/group/set_policies.py
@@ -1,0 +1,88 @@
+import click
+
+from typing import Any
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import formatted_print
+
+from ._common import group_id_arg
+
+
+@click.option(
+    "--high-assurance/--not-high-assurance",
+    help="Flag if the group will enforce high assurance access policies or not."
+)
+@click.option(
+    "--authentication-timeout",
+    type=int,
+    help=("Time in seconds before a user must reauthenticate to access a "
+          "high assurance group")
+)
+@click.option(
+    "--visibility",
+    type=click.Choice(("authenticated", "private"), case_sensitive=False),
+    help=(
+        "Determine who can see the group. "
+        "If authenticated, all authenticated users can see the group. "
+        "If private, only members and managers can see the group."
+    ),
+)
+@click.option(
+    "--member-visibility",
+    type=click.Choice(("members", "managers"), case_sensitive=False),
+    help=(
+        "Determine who can see members of the group. "
+        "If members, members can see all other members. "
+        "If managers, only managers can see members."
+    ),
+)
+@click.option(
+    "--join-requests/--no-join-requests",
+    help="Flag if request to join the group are allowed or not."
+)
+@click.option(
+    "--signup-field",
+    type=click.Choice(
+        ("institution", "current_project_name", "address", "city", "state",
+         "country", "address1", "address2", "zip", "phone", "department",
+         "field_of_science"), case_sensitive=False),
+    multiple=True,
+    help=(
+        "Field required from users to apply for group membership. "
+        "Pass this option multiple times to require multiple fields. "
+        "Any existing required fields will be overwritten if given."
+    )
+)
+@group_id_arg
+@command("set-policies")
+@LoginManager.requires_login(LoginManager.GROUPS_RS)
+def group_set_policies(*, login_manager: LoginManager, group_id: str, **kwargs: Any):
+    """Update an existing group's policies"""
+    groups_client = login_manager.get_groups_client()
+
+    # get the current state of the group's policies
+    existing_policies = groups_client.get_group_policies(group_id)
+
+    # map of groups API field names to CLI option names
+    field_option_map = {
+        "is_high_assurance": "high_assurance",
+        "authentication_assurance_timeout": "authentication_timeout",
+        "group_visibility": "visibility",
+        "group_members_visibility": "member_visibility",
+        "join_requests": "join_requests",
+        "signup_fields": "signup_field",
+    }
+
+    # assemble data using existing values for any field not given
+    print(kwargs)
+    data = {}
+    for field, existing_value in existing_policies.data.items():
+        option_name = field_option_map.get(field)
+        if option_name and kwargs.get(option_name) not in (None, ()):
+            data[field] = kwargs[option_name]
+        else:
+            data[field] = existing_value
+
+    response = groups_client.set_group_policies(group_id, data)
+    formatted_print(response, simple_text="Group policies updated successfully")

--- a/src/globus_cli/commands/group/show.py
+++ b/src/globus_cli/commands/group/show.py
@@ -5,7 +5,10 @@ from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 from ._common import (
     format_session_enforcement,
     group_id_arg,
+    parse_join_requests,
+    parse_members_visibility,
     parse_roles,
+    parse_signup_fields,
     parse_visibility,
 )
 
@@ -31,7 +34,10 @@ def group_show(
             ("Description", "description"),
             ("Type", "group_type"),
             ("Visibility", parse_visibility),
+            ("Membership Visibility", parse_members_visibility),
             ("Session Enforcement", format_session_enforcement),
+            ("Join Requests Allowed", parse_join_requests),
+            ("Signup Fields", parse_signup_fields),
             ("Roles", parse_roles),
         ],
     )

--- a/tests/functional/groups/test_group_set_policies.py
+++ b/tests/functional/groups/test_group_set_policies.py
@@ -38,31 +38,28 @@ def _register_group_responses():
 
 
 @pytest.mark.parametrize(
-    "option_data",
+    "add_args, field_name, expected_value",
     [
-        ("--high-assurance", None, "is_high_assurance", True),
-        ("--no-high-assurance", None, "is_high_assurance", False),
-        ("--authentication-timeout", 100, "authentication_assurance_timeout", 100),
-        ("--visibility", "authenticated", "group_visibility", "authenticated"),
-        ("--members-visibility", "members", "group_members_visibility", "members"),
-        ("--join-requests", None, "join_requests", True),
-        ("--no-join-requests", None, "join_requests", False),
-        ("--signup-fields", "address", "signup_fields", ["address"]),
+        (["--high-assurance"], "is_high_assurance", True),
+        (["--no-high-assurance"], "is_high_assurance", False),
+        (["--authentication-timeout", "100"], "authentication_assurance_timeout", 100),
+        (["--visibility", "authenticated"], "group_visibility", "authenticated"),
+        (["--members-visibility", "members"], "group_members_visibility", "members"),
+        (["--join-requests"], "join_requests", True),
+        (["--no-join-requests"], "join_requests", False),
+        (["--signup-fields", "address"], "signup_fields", ["address"]),
         (
-            "--signup-fields",
-            "address1,address2",
+            ["--signup-fields", "address1,address2"],
             "signup_fields",
             ["address1", "address2"],
         ),
     ],
 )
-def test_group_set_policies(run_line, option_data):
+def test_group_set_policies(run_line, add_args, field_name, expected_value):
     fixtures = load_response_set("get_and_set_group_policies")
     group_id = fixtures.metadata["group_id"]
 
-    option, arg, field_name, expected_value = option_data
-    arg_str = f" {arg}" if arg else ""
-    result = run_line(f"globus group set-policies {option}{arg_str} {group_id}")
+    result = run_line(["globus", "group", "set-policies", group_id] + add_args)
     assert "Group policies updated successfully" in result.output
 
     # TODO: expose get_last_request in globus_sdk._testing ?

--- a/tests/functional/groups/test_group_set_policies.py
+++ b/tests/functional/groups/test_group_set_policies.py
@@ -1,0 +1,78 @@
+import json
+
+import pytest
+import responses
+from globus_sdk._testing import load_response_set, register_response_set
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _register_group_responses():
+    group_id = "ca3c5adc-a0ba-11ec-b51e-91e0c9a2d44f"
+
+    register_response_set(
+        "get_and_set_group_policies",
+        {
+            "get_group_policies": {
+                "service": "groups",
+                "path": f"/groups/{group_id}/policies",
+                "json": {
+                    "is_high_assurance": False,
+                    "authentication_assurance_timeout": 28800,
+                    "group_visibility": "private",
+                    "group_members_visibility": "managers",
+                    "join_requests": False,
+                    "signup_fields": [],
+                },
+            },
+            "set_group_policies": {
+                "service": "groups",
+                "method": "PUT",
+                "path": f"/groups/{group_id}/policies",
+                "json": {"foo": "bar"},
+            },
+        },
+        metadata={
+            "group_id": group_id,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "option_data",
+    [
+        ("--high-assurance", None, "is_high_assurance", True),
+        ("--no-high-assurance", None, "is_high_assurance", False),
+        ("--authentication-timeout", 100, "authentication_assurance_timeout", 100),
+        ("--visibility", "authenticated", "group_visibility", "authenticated"),
+        ("--members-visibility", "members", "group_members_visibility", "members"),
+        ("--join-requests", None, "join_requests", True),
+        ("--no-join-requests", None, "join_requests", False),
+        ("--signup-fields", "address", "signup_fields", ["address"]),
+        (
+            "--signup-fields",
+            "address1,address2",
+            "signup_fields",
+            ["address1", "address2"],
+        ),
+    ],
+)
+def test_group_set_policies(run_line, option_data):
+    fixtures = load_response_set("get_and_set_group_policies")
+    group_id = fixtures.metadata["group_id"]
+
+    option, arg, field_name, expected_value = option_data
+    arg_str = f" {arg}" if arg else ""
+    result = run_line(f"globus group set-policies {option}{arg_str} {group_id}")
+    assert "Group policies updated successfully" in result.output
+
+    # TODO: expose get_last_request in globus_sdk._testing ?
+    last_req = responses.calls[-1].request
+    body = json.loads(last_req.body)
+
+    # confirm expected put body values
+    get_response = fixtures.lookup("get_group_policies")
+    for field, value in body.items():
+        if field != field_name:
+            assert value == get_response.json[field]
+        else:
+            assert value == expected_value


### PR DESCRIPTION
Making a draft PR so we can discuss some design questions that came up while working on this:

* `group set-policy` or `group set-policies` ?

* should all policy fields be visible on a normal `group show`, or should there be something like an `--include-policies` flag?

* should `group_visibility` and `group_members_visibility` be flags rather than enums?

* there is currently no way to unset `signup_fields`, what would be a good UI for doing that?