### PR TITLE
Add 'group member list' command

### DIFF
--- a/changelog.d/20220304_003517_sirosen_group_member_list.md
+++ b/changelog.d/20220304_003517_sirosen_group_member_list.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add `globus group member list`, a command to list members of a group

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -2,6 +2,9 @@ import functools
 from typing import Callable, Optional
 
 import click
+import globus_sdk
+
+MEMBERSHIP_FIELDS = {x.value for x in globus_sdk.GroupRequiredSignupFields}
 
 
 def group_id_arg(f: Optional[Callable] = None):

--- a/src/globus_cli/commands/group/member/__init__.py
+++ b/src/globus_cli/commands/group/member/__init__.py
@@ -1,6 +1,8 @@
-from globus_cli.commands.group.member.add import member_add
-from globus_cli.commands.group.member.remove import member_remove
 from globus_cli.parsing import group
+
+from .add import member_add
+from .list import member_list
+from .remove import member_remove
 
 
 @group("member")
@@ -10,3 +12,4 @@ def group_member() -> None:
 
 group_member.add_command(member_add)
 group_member.add_command(member_remove)
+group_member.add_command(member_list)

--- a/src/globus_cli/commands/group/member/list.py
+++ b/src/globus_cli/commands/group/member/list.py
@@ -1,0 +1,53 @@
+from typing import List, Optional
+
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import CommaDelimitedList, command
+from globus_cli.termio import FORMAT_TEXT_TABLE, formatted_print
+
+from .._common import MEMBERSHIP_FIELDS, group_id_arg
+
+
+def _str2field(fieldname: str):
+    def get_field(data):
+        return data["membership_fields"].get(fieldname, "")
+
+    return (fieldname.title(), get_field)
+
+
+@group_id_arg
+@click.option(
+    "--fields",
+    help="Additional membership fields to display in the output, as a comma-delimited "
+    "string. Has no effect on non-text output.",
+    type=CommaDelimitedList(choices=MEMBERSHIP_FIELDS, convert_values=str.lower),
+)
+@command("list")
+@LoginManager.requires_login(LoginManager.GROUPS_RS)
+def member_list(
+    *,
+    login_manager: LoginManager,
+    group_id: str,
+    fields: Optional[List[str]],
+):
+    """List group members"""
+    groups_client = login_manager.get_groups_client()
+
+    group = groups_client.get_group(group_id, include="memberships")
+
+    add_fields = []
+    if fields:
+        add_fields = [_str2field(x) for x in fields]
+
+    formatted_print(
+        group,
+        text_format=FORMAT_TEXT_TABLE,
+        fields=[
+            ("Username", "username"),
+            ("Role", "role"),
+            ("Status", "status"),
+        ]
+        + add_fields,
+        response_key="memberships",
+    )

--- a/src/globus_cli/parsing/param_types/comma_delimited.py
+++ b/src/globus_cli/parsing/param_types/comma_delimited.py
@@ -1,14 +1,29 @@
+from typing import Callable, Iterable, Optional
+
 import click
 
 
 class CommaDelimitedList(click.ParamType):
+    def __init__(
+        self,
+        *,
+        convert_values: Optional[Callable[[str], str]] = None,
+        choices: Optional[Iterable[str]] = None,
+    ):
+        super().__init__()
+        self.convert_values = convert_values
+        self.choices = list(choices) if choices is not None else None
+
     def get_metavar(self, param):
+        if self.choices is not None:
+            return "{" + ",".join(self.choices) + "}"
         return "TEXT,TEXT,..."
 
     def convert(self, value, param, ctx):
         value = super().convert(value, param, ctx)
         if value is None:
             return None
+
         # if `--foo` is a comma delimited list and someone passes
         # `--foo ""`, take that as `foo=[]` rather than foo=[""]
         #
@@ -18,7 +33,18 @@ class CommaDelimitedList(click.ParamType):
         # it means that if you take
         # `--foo={",".join(original)}`, you will get a value equal to
         # `original` back if `original=[]` (but not if `original=[""]`)
-        elif value == "":
-            return []
-        else:
-            return value.split(",")
+        resolved = value.split(",") if value else []
+
+        if self.convert_values is not None:
+            resolved = [self.convert_values(x) for x in resolved]
+
+        if self.choices is not None:
+            bad_values = [x for x in resolved if x not in self.choices]
+            if bad_values:
+                self.fail(
+                    f"the values {bad_values} were not valid choices",
+                    param=param,
+                    ctx=ctx,
+                )
+
+        return resolved

--- a/tests/functional/groups/test_group_basics.py
+++ b/tests/functional/groups/test_group_basics.py
@@ -1,8 +1,139 @@
 import json
+import uuid
 
 import pytest
 import responses
-from globus_sdk._testing import RegisteredResponse, load_response, load_response_set
+from globus_sdk._testing import (
+    RegisteredResponse,
+    load_response,
+    load_response_set,
+    register_response_set,
+)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _register_group_responses():
+    group_id = "efdab3ca-cff1-11e4-9b86-123139260d4e"
+    register_response_set(
+        "get_group?include=memberships",
+        dict(
+            default=dict(
+                service="groups",
+                path=f"/groups/{group_id}",
+                json={
+                    "description": "Ipso facto",
+                    "enforce_session": False,
+                    "group_type": "regular",
+                    "id": group_id,
+                    "memberships": [
+                        {
+                            "group_id": group_id,
+                            "identity_id": "ae332d86-d274-11e5-b885-b31714a110e9",
+                            "membership_fields": {
+                                "department": "Globus Testing",
+                                "email": "sirosen@globus.org",
+                                "field_of_science": "CS",
+                                "institution": "Computation Institute",
+                                "phone": "867-5309",
+                            },
+                            "role": "admin",
+                            "status": "active",
+                            "username": "sirosen@globusid.org",
+                        },
+                        {
+                            "group_id": group_id,
+                            "identity_id": "508e5ef6-cb9b-11e5-abe1-431ce3f42be1",
+                            "membership_fields": {},
+                            "role": "member",
+                            "status": "invited",
+                            "username": "sirosen@xsede.org",
+                        },
+                        {
+                            "group_id": group_id,
+                            "identity_id": "ae2f7f60-d274-11e5-b879-afc598dd59d4",
+                            "membership_fields": {
+                                "institution": "University of Chicago",
+                                "name": "Bryce Allen",
+                                "department": "Globus",
+                            },
+                            "role": "member",
+                            "status": "active",
+                            "username": "ballen@globusid.org",
+                        },
+                        {
+                            "group_id": group_id,
+                            "identity_id": "b0e8f24a-d274-11e5-8c98-8fd1e61c0a76",
+                            "membership_fields": {
+                                "current_project_name": "Petrel support",
+                                "department": "UChicago",
+                            },
+                            "role": "member",
+                            "status": "rejected",
+                            "username": "smartin@globusid.org",
+                        },
+                        {
+                            "group_id": group_id,
+                            "identity_id": "6b487878-d2a1-11e5-b689-a7dd99513a65",
+                            "membership_fields": {
+                                "department": (
+                                    "Columbia University department "
+                                    "of Witchcraft and History"
+                                ),
+                            },
+                            "role": "member",
+                            "status": "active",
+                            "username": "jss2253@columbia.edu",
+                        },
+                        {
+                            "group_id": group_id,
+                            "identity_id": "ae2a1750-d274-11e5-b867-e74762c29f57",
+                            "membership_fields": {},
+                            "role": "member",
+                            "status": "invited",
+                            "username": "bjmc@globusid.org",
+                        },
+                    ],
+                    "name": "Claptrap Presents Claptrap's Rough Riders",
+                    "parent_id": None,
+                    "policies": {
+                        "authentication_assurance_timeout": 28800,
+                        "group_members_visibility": "managers",
+                        "group_visibility": "private",
+                        "is_high_assurance": False,
+                        "join_requests": False,
+                        "signup_fields": [],
+                    },
+                    "session_limit": 28800,
+                    "session_timeouts": {
+                        "ae341a98-d274-11e5-b888-dbae3a8ba545": {
+                            "expire_time": "2022-02-08T06:05:54+00:00",
+                            "expires_in": 0,
+                        }
+                    },
+                },
+                metadata={
+                    "group_id": group_id,
+                    "known_members": [
+                        {
+                            "role": "admin",
+                            "status": "active",
+                            "username": "sirosen@globusid.org",
+                        },
+                        {
+                            "role": "member",
+                            "status": "invited",
+                            "username": "bjmc@globusid.org",
+                        },
+                        {
+                            "role": "member",
+                            "status": "rejected",
+                            "username": "smartin@globusid.org",
+                        },
+                    ],
+                },
+            )
+        ),
+    )
 
 
 def test_group_list(run_line):
@@ -326,3 +457,47 @@ def test_group_invite_failure(run_line, action, error_detail_present):
     assert action in sent_data
     assert len(sent_data[action]) == 1
     assert sent_data[action][0]["identity_id"] == identity_id
+
+
+@pytest.mark.parametrize(
+    "add_args,expect_data",
+    [
+        ([], []),
+        (
+            ["--fields", "institution,department"],
+            [
+                "Computation Institute",
+                "University of Chicago",
+                "Witchcraft and History",
+            ],
+        ),
+        (
+            ["--fields", "current_project_name"],
+            ["Petrel support"],
+        ),
+    ],
+)
+def test_group_member_list(run_line, add_args, expect_data):
+    meta = load_response("get_group?include=memberships").metadata
+    result = run_line(
+        ["globus", "group", "member", "list", meta["group_id"]] + add_args
+    )
+    for item in expect_data:
+        assert item in result.output
+    for item in meta["known_members"]:
+        username, role, status = item["username"], item["role"], item["status"]
+        matching_lines = [
+            line
+            for line in result.output.splitlines()
+            if username in line and role in line and status in line
+        ]
+        assert len(matching_lines) == 1
+
+
+def test_group_member_list_rejects_unknown_field(run_line):
+    dummy_id = uuid.UUID(int=0)
+    result = run_line(
+        f"globus group member list {dummy_id} --fields country,foo",
+        assert_exit_code=2,
+    )
+    assert "the values ['foo'] were not valid choices" in result.stderr


### PR DESCRIPTION
Basic implementation of this command, with a `--fields` argument for including membership fields.

I've expanded `CommaDelimitedList` to take a choices argument and a `convert_values` callback, so that we can lowercase things by passing `str.lower`. These let us support `--fields` more nicely.

I chose to format the metavar for a comma-delimited list when there are choices in an imperfect way -- very open to ideas about that.