### PR TITLE
Add `group invite [accept|decline]` commands

### DIFF
--- a/changelog.d/20220308_200825_sirosen_group_invite.md
+++ b/changelog.d/20220308_200825_sirosen_group_invite.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Add two new commands for interacting with invitations to groups
+  `globus group invite accept` and `globus group invite decline`

--- a/src/globus_cli/commands/group/__init__.py
+++ b/src/globus_cli/commands/group/__init__.py
@@ -1,5 +1,6 @@
 from globus_cli.commands.group.create import group_create
 from globus_cli.commands.group.delete import group_delete
+from globus_cli.commands.group.invite import group_invite
 from globus_cli.commands.group.list import group_list
 from globus_cli.commands.group.member import group_member
 from globus_cli.commands.group.show import group_show
@@ -18,3 +19,4 @@ group_command.add_command(group_create)
 group_command.add_command(group_update)
 group_command.add_command(group_delete)
 group_command.add_command(group_member)
+group_command.add_command(group_invite)

--- a/src/globus_cli/commands/group/invite/__init__.py
+++ b/src/globus_cli/commands/group/invite/__init__.py
@@ -1,0 +1,13 @@
+from globus_cli.parsing import group
+
+from .accept import invite_accept
+from .decline import invite_decline
+
+
+@group("invite")
+def group_invite() -> None:
+    """Manage invitations to a Globus Group"""
+
+
+group_invite.add_command(invite_accept)
+group_invite.add_command(invite_decline)

--- a/src/globus_cli/commands/group/invite/_common.py
+++ b/src/globus_cli/commands/group/invite/_common.py
@@ -1,0 +1,51 @@
+import sys
+import uuid
+from typing import Dict, List, Optional
+
+import click
+import globus_sdk
+
+from globus_cli.parsing import ParsedIdentity
+from globus_cli.services.auth import CustomAuthClient
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+
+def get_invite_formatter(case: Literal["accept", "decline"]):
+    action_word = "Accepted" if case == "accept" else "Declined"
+
+    def formatter(data):
+        values = [f"{x['identity_id']} ({x['username']})" for x in data[case]]
+        if len(values) == 1:
+            click.echo(f"{action_word} invitation as {values[0]}")
+        else:
+            click.echo(f"{action_word} invitation as")
+            for v in values:
+                click.echo(f"  {v}")
+
+    return formatter
+
+
+def build_invite_actions(
+    auth_client: CustomAuthClient,
+    groups_client: globus_sdk.GroupsClient,
+    action: Literal["accept", "decline"],
+    group_id: uuid.UUID,
+    identity: Optional[ParsedIdentity],
+) -> Dict[str, List[Dict[str, str]]]:
+    if identity:
+        identity_id = auth_client.maybe_lookup_identity_id(identity.value)
+        if not identity_id:
+            raise click.UsageError(
+                f"Couldn't determine identity from value: {identity}"
+            )
+        return {action: [{"identity_id": identity_id}]}
+    else:
+        group = groups_client.get_group(group_id, include="my_memberships")
+        invitations = [x for x in group["my_memberships"] if x["status"] == "invited"]
+        if not invitations:
+            raise click.ClickException(f"You have no invitations for {group_id}")
+        return {action: [{"identity_id": x["identity_id"]} for x in invitations]}

--- a/src/globus_cli/commands/group/invite/decline.py
+++ b/src/globus_cli/commands/group/invite/decline.py
@@ -1,0 +1,48 @@
+import uuid
+from typing import Optional
+
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import IdentityType, ParsedIdentity, command
+from globus_cli.termio import formatted_print
+
+from ._common import build_invite_actions, get_invite_formatter
+
+
+@command("decline", short_help="Decline an invitation")
+@click.argument("group_id", type=click.UUID)
+@click.option(
+    "--identity",
+    type=IdentityType(),
+    help="Only decline invitations for a specific identity",
+)
+@LoginManager.requires_login(LoginManager.GROUPS_RS)
+def invite_decline(
+    *,
+    group_id: uuid.UUID,
+    identity: Optional[ParsedIdentity],
+    login_manager: LoginManager
+):
+    """
+    Decline an invitation to a group
+
+    By default, all invitations to the group are declined. To restrict this action to
+    only specific invitations when there are multiple, use the `--identity` flag.
+    """
+    auth_client = login_manager.get_auth_client()
+    groups_client = login_manager.get_groups_client()
+
+    actions = build_invite_actions(
+        auth_client, groups_client, "decline", group_id, identity
+    )
+    response = groups_client.batch_membership_action(group_id, actions)
+
+    # if this failed to return at least one accepted user, figure out an error to show
+    if not response.get("decline", None):
+        try:
+            raise ValueError(response["errors"]["decline"][0]["detail"])
+        except LookupError:
+            raise ValueError("Could not decline invite")
+
+    formatted_print(response, text_format=get_invite_formatter("decline"))

--- a/src/globus_cli/commands/group/show.py
+++ b/src/globus_cli/commands/group/show.py
@@ -21,8 +21,7 @@ def group_show(
     """Show a group definition"""
     groups_client = login_manager.get_groups_client()
 
-    query_params = {"include": "my_memberships"}
-    group = groups_client.get_group(group_id, query_params=query_params)
+    group = groups_client.get_group(group_id, include="my_memberships")
 
     formatted_print(
         group,

--- a/tests/functional/groups/test_invite.py
+++ b/tests/functional/groups/test_invite.py
@@ -1,0 +1,263 @@
+import json
+
+import pytest
+import responses
+from globus_sdk._testing import load_response, register_response_set
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _register_invitation_responses():
+    group_id = "ee49e222-d007-11e4-8b51-22000aa51e6e"
+    identity_id = "00000000-0000-0000-0000-000000000001"
+    username = "test_user1"
+    identity_id2 = "00000000-0000-0000-0000-000000000002"
+    username2 = "test_user2"
+
+    _group_common = {
+        "description": "Un film Italiano muy bien conocido",
+        "enforce_session": False,
+        "group_type": "regular",
+        "id": group_id,
+        "name": "La Dolce Vita",
+        "parent_id": None,
+        "policies": {
+            "authentication_assurance_timeout": 28800,
+            "group_members_visibility": "managers",
+            "group_visibility": "authenticated",
+            "is_high_assurance": False,
+            "join_requests": False,
+            "signup_fields": [],
+        },
+        "session_limit": 28800,
+        "session_timeouts": {},
+    }
+    _common_metadata = {
+        "group_id": group_id,
+        "identity_id": identity_id,
+        "username": username,
+        "identity_id2": identity_id2,
+        "username2": username,
+    }
+
+    def action_response(
+        action: str, success, *, error_detail_present=True, add_ids=None
+    ):
+        identities = [identity_id]
+        if add_ids:
+            identities += add_ids
+        return {
+            "service": "groups",
+            "path": f"/groups/{group_id}",
+            "method": "POST",
+            "json": {
+                action: [
+                    {
+                        "group_id": group_id,
+                        "identity_id": iid,
+                        "username": username,
+                        "role": "member",
+                        "status": "active" if action == "accept" else "declined",
+                    }
+                    for iid in identities
+                ]
+            }
+            if success
+            else {
+                action: [],
+                "errors": {
+                    action: [
+                        {
+                            "code": "ERROR_ERROR_IT_IS_AN_ERROR",
+                            "identity_id": iid,
+                            **(
+                                {"detail": "Domo arigato, Mr. Roboto"}
+                                if error_detail_present
+                                else {}
+                            ),
+                        }
+                        for iid in identities
+                    ]
+                },
+            },
+        }
+
+    register_response_set(
+        "group_w_invitation",
+        {
+            "default": {
+                "service": "groups",
+                "path": f"/groups/{group_id}",
+                "json": {
+                    "my_memberships": [
+                        {
+                            "group_id": group_id,
+                            "identity_id": identity_id,
+                            "membership_fields": {},
+                            "role": "member",
+                            "status": "invited",
+                            "username": username,
+                        },
+                    ],
+                    **_group_common,
+                },
+                "metadata": _common_metadata,
+            },
+            "multiple": {
+                "service": "groups",
+                "path": f"/groups/{group_id}",
+                "json": {
+                    "my_memberships": [
+                        {
+                            "group_id": group_id,
+                            "identity_id": identity_id,
+                            "membership_fields": {},
+                            "role": "member",
+                            "status": "invited",
+                            "username": username,
+                        },
+                        {
+                            "group_id": group_id,
+                            "identity_id": identity_id2,
+                            "membership_fields": {},
+                            "role": "member",
+                            "status": "invited",
+                            "username": username2,
+                        },
+                    ],
+                    **_group_common,
+                },
+                "metadata": _common_metadata,
+            },
+        },
+        metadata=_common_metadata,
+    )
+    register_response_set(
+        "group_wo_invitation",
+        {
+            "default": {
+                "service": "groups",
+                "path": f"/groups/{group_id}",
+                "json": {"my_memberships": [], **_group_common},
+                "metadata": _common_metadata,
+            }
+        },
+        metadata=_common_metadata,
+    )
+    register_response_set(
+        "action_response",
+        {
+            "accept_success": action_response("accept", True),
+            "decline_success": action_response("decline", True),
+            "accept_success_multiple": action_response(
+                "accept", True, add_ids=[identity_id2]
+            ),
+            "decline_success_multiple": action_response(
+                "decline", True, add_ids=[identity_id2]
+            ),
+            "accept_error": action_response("accept", False),
+            "decline_error": action_response("decline", False),
+            "accept_error_multiple": action_response(
+                "accept", False, add_ids=[identity_id2]
+            ),
+            "decline_error_multiple": action_response(
+                "decline", False, add_ids=[identity_id2]
+            ),
+            "accept_error_nodetail": action_response(
+                "accept", False, error_detail_present=False
+            ),
+            "decline_error_nodetail": action_response(
+                "decline", False, error_detail_present=False
+            ),
+        },
+        metadata=_common_metadata,
+    )
+
+
+@pytest.mark.parametrize("action", ("accept", "decline"))
+@pytest.mark.parametrize("with_id_arg", (True, False))
+def test_group_invite(run_line, action, with_id_arg):
+    meta = load_response("group_w_invitation").metadata
+    load_response("action_response", case=f"{action}_success")
+
+    add_args = []
+    if with_id_arg:
+        add_args = ["--identity", meta["identity_id"]]
+    result = run_line(
+        ["globus", "group", "invite", action, meta["group_id"]] + add_args
+    )
+    assert meta["identity_id"] in result.output
+
+    sent_data = json.loads(responses.calls[-1].request.body)
+    assert action in sent_data
+    assert len(sent_data[action]) == 1
+    assert sent_data[action][0]["identity_id"] == meta["identity_id"]
+
+
+@pytest.mark.parametrize("action", ("accept", "decline"))
+@pytest.mark.parametrize("error_detail_present", (True, False))
+def test_group_invite_failure(run_line, action, error_detail_present):
+    meta = load_response("group_w_invitation").metadata
+    load_response(
+        "action_response",
+        case=f"{action}_error" if error_detail_present else f"{action}_error_nodetail",
+    )
+
+    result = run_line(
+        ["globus", "group", "invite", action, meta["group_id"]], assert_exit_code=1
+    )
+    assert "Error" in result.stderr
+    if error_detail_present:
+        assert "Domo arigato" in result.stderr
+    else:
+        assert f"Could not {action} invite" in result.stderr
+
+    # the request sent was as expected
+    sent_data = json.loads(responses.calls[-1].request.body)
+    assert action in sent_data
+    assert len(sent_data[action]) == 1
+    assert sent_data[action][0]["identity_id"] == meta["identity_id"]
+
+
+@pytest.mark.parametrize("action", ("accept", "decline"))
+def test_group_invite_failure_no_invitation(run_line, action):
+    meta = load_response("group_wo_invitation").metadata
+    result = run_line(
+        ["globus", "group", "invite", action, meta["group_id"]], assert_exit_code=1
+    )
+    assert "You have no invitations" in result.stderr
+    # only one request sent (get group)
+    assert len(responses.calls) == 1
+
+
+@pytest.mark.parametrize("action", ("accept", "decline"))
+@pytest.mark.parametrize("success", (True, False))
+def test_group_invite_multiple(run_line, action, success):
+    meta = load_response("group_w_invitation", case="multiple").metadata
+    load_response(
+        "action_response", case=f"{action}_{'success' if success else 'error'}_multiple"
+    )
+
+    result = run_line(
+        ["globus", "group", "invite", action, meta["group_id"]],
+        assert_exit_code=0 if success else 1,
+    )
+    if success:
+        if action == "accept":
+            assert "Accepted invitation as" in result.output
+        else:
+            assert "Declined invitation as" in result.output
+        assert meta["identity_id"] in result.output
+        assert meta["identity_id2"] in result.output
+        assert meta["username"] in result.output
+        assert meta["username2"] in result.output
+    else:
+        assert "Error" in result.stderr
+        assert "Domo arigato" in result.stderr
+
+    sent_data = json.loads(responses.calls[-1].request.body)
+    assert action in sent_data
+    assert len(sent_data[action]) == 2
+    assert {x["identity_id"] for x in sent_data[action]} == {
+        meta["identity_id"],
+        meta["identity_id2"],
+    }


### PR DESCRIPTION
`invite [accept|decline]` commands for accepting or rejecting group invitations. They take the same form, either accepting an identity argument or operating over all invitations to a group.

Because the new tests feature rather extensive mock data in a fixture, the group tests are here also being split into multiple files.

---

A bit of background/meta about this PR: I realized that the way the webapp behaves makes it possible to invite a client ID to a group (this is easy). However, there's no way for the client ID to accept that invitation. With CLIENT_ID/CLIENT_SECRET support now in the CLI, if we add `invite accept|decline`, then a new potential user-facing workflow opens up.