### PR TITLE
Add `group member [approve|reject|invite]`

### DIFF
--- a/changelog.d/20220310_152327_sirosen_remaining_group_commands.md
+++ b/changelog.d/20220310_152327_sirosen_remaining_group_commands.md
@@ -1,0 +1,8 @@
+### Enhancements
+
+* New commands for handling user invitations and requests to join groups
+  * `globus group member invite` invites a member to join a group
+  * `globus group member approve` approves a member who has requested to join a group
+  * `globus group member reject` rejects a member who has requested to join a group
+* `globus group member add` now supports the `--role` argument for adding
+    members with the `manager` and `admin` roles

--- a/src/globus_cli/commands/group/member/__init__.py
+++ b/src/globus_cli/commands/group/member/__init__.py
@@ -1,7 +1,10 @@
 from globus_cli.parsing import group
 
 from .add import member_add
+from .approve import member_approve
+from .invite import member_invite
 from .list import member_list
+from .reject import member_reject
 from .remove import member_remove
 
 
@@ -13,3 +16,6 @@ def group_member() -> None:
 group_member.add_command(member_add)
 group_member.add_command(member_remove)
 group_member.add_command(member_list)
+group_member.add_command(member_approve)
+group_member.add_command(member_reject)
+group_member.add_command(member_invite)

--- a/src/globus_cli/commands/group/member/approve.py
+++ b/src/globus_cli/commands/group/member/approve.py
@@ -5,29 +5,21 @@ from globus_cli.parsing import IdentityType, ParsedIdentity, command
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 from globus_cli.types import FIELD_LIST_T
 
-ADD_USER_FIELDS: FIELD_LIST_T = [
+APPROVED_USER_FIELDS: FIELD_LIST_T = [
     ("Group ID", "group_id"),
-    ("Added User ID", "identity_id"),
-    ("Added User Username", "username"),
+    ("Approved User ID", "identity_id"),
+    ("Approved User Username", "username"),
 ]
 
 
-@command("add", short_help="Add a member to a group")
+@command("approve", short_help="Approve a member to join a group")
 @click.argument("group_id", type=click.UUID)
 @click.argument("user", type=IdentityType())
-@click.option(
-    "--role",
-    type=click.Choice(("member", "manager", "admin")),
-    default="member",
-    help="The role for the added user",
-    show_default=True,
-)
 @LoginManager.requires_login(LoginManager.GROUPS_RS)
-def member_add(
-    *, group_id: str, user: ParsedIdentity, role: str, login_manager: LoginManager
-):
+def member_approve(group_id: str, user: ParsedIdentity, login_manager):
     """
-    Add a member to a group.
+    Approve a pending member to join a group, changing their status from 'invited'
+    to 'active'.
 
     The USER argument may be an identity ID or username (whereas the group must be
     specified with an ID).
@@ -37,17 +29,16 @@ def member_add(
     identity_id = auth_client.maybe_lookup_identity_id(user.value)
     if not identity_id:
         raise click.UsageError(f"Couldn't determine identity from user value: {user}")
-    actions = {"add": [{"identity_id": identity_id, "role": role}]}
+    actions = {"approve": [{"identity_id": identity_id}]}
     response = groups_client.batch_membership_action(group_id, actions)
-    # If this call failed to return an added user, figure out an error to show
-    if not response.get("add", None):
+    if not response.get("approve", None):
         try:
-            raise ValueError(response["errors"]["add"][0]["detail"])
+            raise ValueError(response["errors"]["approve"][0]["detail"])
         except (IndexError, KeyError):
-            raise ValueError("Could not add user to group")
+            raise ValueError("Could not approve the user to join the group")
     formatted_print(
         response,
         text_format=FORMAT_TEXT_RECORD,
-        fields=ADD_USER_FIELDS,
-        response_key=lambda data: data["add"][0],
+        fields=APPROVED_USER_FIELDS,
+        response_key=lambda data: data["approve"][0],
     )

--- a/src/globus_cli/commands/group/member/reject.py
+++ b/src/globus_cli/commands/group/member/reject.py
@@ -5,29 +5,20 @@ from globus_cli.parsing import IdentityType, ParsedIdentity, command
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 from globus_cli.types import FIELD_LIST_T
 
-ADD_USER_FIELDS: FIELD_LIST_T = [
+REJECTED_USER_FIELDS: FIELD_LIST_T = [
     ("Group ID", "group_id"),
-    ("Added User ID", "identity_id"),
-    ("Added User Username", "username"),
+    ("Rejected User ID", "identity_id"),
+    ("Rejected User Username", "username"),
 ]
 
 
-@command("add", short_help="Add a member to a group")
+@command("reject", short_help="Reject a member from a group")
 @click.argument("group_id", type=click.UUID)
 @click.argument("user", type=IdentityType())
-@click.option(
-    "--role",
-    type=click.Choice(("member", "manager", "admin")),
-    default="member",
-    help="The role for the added user",
-    show_default=True,
-)
 @LoginManager.requires_login(LoginManager.GROUPS_RS)
-def member_add(
-    *, group_id: str, user: ParsedIdentity, role: str, login_manager: LoginManager
-):
+def member_reject(*, group_id: str, user: ParsedIdentity, login_manager: LoginManager):
     """
-    Add a member to a group.
+    Reject a pending member from a group.
 
     The USER argument may be an identity ID or username (whereas the group must be
     specified with an ID).
@@ -37,17 +28,16 @@ def member_add(
     identity_id = auth_client.maybe_lookup_identity_id(user.value)
     if not identity_id:
         raise click.UsageError(f"Couldn't determine identity from user value: {user}")
-    actions = {"add": [{"identity_id": identity_id, "role": role}]}
+    actions = {"reject": [{"identity_id": identity_id}]}
     response = groups_client.batch_membership_action(group_id, actions)
-    # If this call failed to return an added user, figure out an error to show
-    if not response.get("add", None):
+    if not response.get("reject", None):
         try:
-            raise ValueError(response["errors"]["add"][0]["detail"])
+            raise ValueError(response["errors"]["reject"][0]["detail"])
         except (IndexError, KeyError):
-            raise ValueError("Could not add user to group")
+            raise ValueError("Could not reject the user from the group")
     formatted_print(
         response,
         text_format=FORMAT_TEXT_RECORD,
-        fields=ADD_USER_FIELDS,
-        response_key=lambda data: data["add"][0],
+        fields=REJECTED_USER_FIELDS,
+        response_key=lambda data: data["reject"][0],
     )


### PR DESCRIPTION
All three commands are nearly identical, with some word substitutions.
As a result, tests can be done very simply with some parametrization.