### PR TITLE
Add 'sdkmain' build to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,6 @@ jobs:
   test-sdk-main:
     strategy:
       matrix:
-        os: [ubuntu-latest]
         python-version: ["3.6", "3.10"]
     runs-on: ubuntu-latest
     name: "sdk-main"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,6 +84,21 @@ jobs:
       - name: test
         run: tox -e py-mindeps
 
+  test-sdk-main:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.6", "3.10"]
+    runs-on: ubuntu-latest
+    name: "sdk-main"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install -U tox
+      - run: tox -e py-sdkmain
+
   # use the oldest python version we support for this build
   test-ancient-virtualenv:
     name: "test on py3.6, using old virtualenv"

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     mindeps: requests==2.19.1
     mindeps: pyjwt==2.0.0
     mindeps: cryptography==2.0
+    sdkmain: https://github.com/globus/globus-sdk-python/archive/main.tar.gz
 commands = pytest --cov-append --cov-report= {posargs}
 depends =
     {py36-mindeps,py36,py37,py38,py39}: cov-clean


### PR DESCRIPTION
Ensure that the CLI tests are always passing with the 'main' branch of the SDK.

This can be run locally with tox, e.g. `tox -e py310-sdkmain`, but the main purpose is to put this test into CI. It is not included in the default tox env list.