### PR TITLE
Cleanup linting config / dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
       additional_dependencies:
         - types-setuptools
         - types-requests
+        - types-jmespath
         - click
         - 'globus-sdk==3.5.0'
 - repo: local

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ ignore = W503,W504,E203
 
 [mypy]
 # disallow_untyped_defs = true
-ignore_missing_imports = true
 warn_unreachable = true
 warn_unused_ignores = true
 warn_redundant_casts = true

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,6 @@ import re
 from setuptools import find_packages, setup
 
 DEV_REQUIREMENTS = [
-    # lint
-    "flake8<5",
-    "isort<6",
-    "black==21.12b0",
-    "flake8-bugbear==22.1.11",
-    "mypy==0.931",
     # tests
     "pytest<7",
     "pytest-cov<3",

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
     mypy
     types-jwt
     types-requests
+    types-jmespath
 commands = mypy src/
 
 [testenv:reference]


### PR DESCRIPTION
This started with the addition of `types-jmespath` (stubs from typeshed) and removal of `mypy.ignore_missing_imports`.

However, we have linting tools listed in the `dev` extra. Keeping these in sync with `.pre-commit-config.yaml` is a manual job and the purpose is no longer clear since the advent of pre-commit. The pre-commit config has correct (and enforced) tool versions. For now, just remove the lint tools from `dev`. Solutions (e.g. `pip-compile-multi`) can be pursued if easy developer installation of these tools is or becomes a priority.