### PR TITLE
Note that - can be used for query document filename

### DIFF
--- a/src/globus_cli/commands/search/query.py
+++ b/src/globus_cli/commands/search/query.py
@@ -24,7 +24,10 @@ def _print_subjects(data):
 @click.option(
     "--query-document",
     type=click.File("r"),
-    help="A complete query document to use to search the index.",
+    help=(
+        "A complete query document to use to search the index. Use the special `-` "
+        "value to read from stdin instead of a file."
+    ),
 )
 @click.option("--limit", type=int, help="Limit the number of results to return")
 @click.option(

--- a/src/globus_cli/parsing/shared_options.py
+++ b/src/globus_cli/parsing/shared_options.py
@@ -243,7 +243,7 @@ def delete_and_rm_options(
             type=click.File("r"),
             help=(
                 "Accept a batch of source/dest path pairs from a file. Use the "
-                " special `-` value to read from stdin; otherwise opens the file from "
+                "special `-` value to read from stdin; otherwise opens the file from "
                 "the argument and passes through lines from that file. Uses "
                 "SOURCE_ENDPOINT_ID and DEST_ENDPOINT_ID as passed on the commandline. "
                 "Commandline paths are still allowed and are used as prefixes to the "


### PR DESCRIPTION
Since `--query-document` is using `click.File`, we get the `-` behavior for free too (yay!), so add a note here to explain that.

I also noticed another site with a similar note has an extra space.