### PR TITLE
Fix 'endpoint activate --web', handle env setting

### DIFF
--- a/changelog.d/20220328_160404_sirosen_fix_web_activate_url.md
+++ b/changelog.d/20220328_160404_sirosen_fix_web_activate_url.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* `globus endpoint activate --web` now correctly respects the environment when
+  it is set

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional, Union
 
 import click
 from globus_sdk import GlobusHTTPResponse
+from globus_sdk.config import get_webapp_url
 
 from globus_cli.login_manager import LoginManager, is_remote_session
 from globus_cli.parsing import command, endpoint_id_arg, mutex_option_group
@@ -276,7 +277,7 @@ def endpoint_activate(
 
     # web activation
     elif web:
-        url = f"https://app.globus.org/file-manager?origin_id={endpoint_id}"
+        url = f"{get_webapp_url()}file-manager?origin_id={endpoint_id}"
         if no_browser or is_remote_session():
             res = {"message": f"Web activation url: {url}", "url": url}
         else:

--- a/tests/functional/endpoint/test_endpoint_activate.py
+++ b/tests/functional/endpoint/test_endpoint_activate.py
@@ -1,0 +1,22 @@
+import os
+
+
+def test_webapp_url_in_endpoint_activation_is_env_sensitive(
+    run_line, monkeypatch, go_ep1_id
+):
+    command = [
+        "globus",
+        "endpoint",
+        "activate",
+        "--web",
+        "--no-browser",
+        "--force",
+        "--no-autoactivate",
+        go_ep1_id,
+    ]
+    result = run_line(command)
+    assert "https://app.globus.org/file-manager" in result.output
+
+    monkeypatch.setitem(os.environ, "GLOBUS_SDK_ENVIRONMENT", "preview")
+    result = run_line(command)
+    assert "https://app.preview.globus.org/file-manager" in result.output


### PR DESCRIPTION
The `--web` option was always using the production app URL. This is not correct if the CLI is being used against a non-production stack.

Swap out the hardcoded URL for `get_webapp_url()` from `globus_sdk.config`, and add a test that ensures that this produces the correct string.