### PR TITLE
Add 'globus api' command

### DIFF
--- a/changelog.d/20220408_040756_sirosen_api_cmd.md
+++ b/changelog.d/20220408_040756_sirosen_api_cmd.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* A new command `globus api` can be used to make requests to curl-like requests
+ to Globus services using the credentials from a globus-cli login

--- a/src/globus_cli/commands/__init__.py
+++ b/src/globus_cli/commands/__init__.py
@@ -21,6 +21,8 @@ from globus_cli.commands.version import version_command
 from globus_cli.commands.whoami import whoami_command
 from globus_cli.parsing import main_group
 
+from .api import api_command
+
 
 @main_group
 def main() -> None:
@@ -43,6 +45,7 @@ main.add_command(update_command)
 main.add_command(login_command)
 main.add_command(logout_command)
 main.add_command(whoami_command)
+main.add_command(api_command)
 
 main.add_command(get_identities_command)
 main.add_command(ls_command)

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -25,15 +25,17 @@ class QueryParamType(click.ParamType):
 
 class HeaderParamType(click.ParamType):
     def get_metavar(self, param):
-        return '"Key: Value"'
+        return "Key:Value"
 
     def convert(self, value, param, ctx):
         value = super().convert(value, param, ctx)
         if value is None:
             return None
-        if ": " not in value:
+        if ":" not in value:
             self.fail("invalid header param", param=param, ctx=ctx)
-        left, right = value.split(": ", 1)
+        left, right = value.split(":", 1)
+        if right.startswith(" "):
+            right = right[1:]
         return (left, right)
 
 

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -198,6 +198,7 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
         help="If the server responds with a redirect (a 3xx response with a Location "
         "header), follow the redirect. By default, redirects are not followed.",
     )
+    @click.option("--no-retry", is_flag=True, help="Disable built-in request retries")
     @mutex_option_group("--body", "--body-file")
     def service_command(
         *,
@@ -211,6 +212,7 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
         content_type: str,
         allow_errors: bool,
         allow_redirects: bool,
+        no_retry: bool,
     ):
         # the overall flow of this command will be as follows:
         # - prepare a client
@@ -222,6 +224,8 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
 
         client = _get_client(login_manager, service_name)
         client.app_name = version.app_name + " raw-api-command"
+        if no_retry:
+            client.transport.max_retries = 0
 
         # Prepare Query Params
         query_params_d = {}

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -1,0 +1,120 @@
+import json
+from typing import List, Optional, Tuple
+
+import click
+import globus_sdk
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command, group
+from globus_cli.termio import formatted_print
+
+
+class QueryParamType(click.ParamType):
+    def get_metavar(self, param):
+        return "x=y"
+
+    def convert(self, value, param, ctx):
+        value = super().convert(value, param, ctx)
+        if value is None:
+            return None
+        if "=" not in value:
+            self.fail("invalid query param", param=param, ctx=ctx)
+        left, right = value.split("=", 1)
+        return (left, right)
+
+
+def _deduce_content_type(content_type: str, body: Optional[str]) -> Optional[str]:
+    if content_type == "json":
+        return "application/json"
+    elif content_type == "form":
+        return "application/x-www-form-urlencoded"
+    elif content_type == "auto":
+        if body is None:
+            return None
+        try:
+            json.loads(body)
+            return "application/json"
+        except ValueError:
+            return None
+    else:
+        raise NotImplementedError(f"did not recognize content-type '{content_type}'")
+
+
+_SERVICE_MAP = {
+    "auth": LoginManager.AUTH_RS,
+    "groups": LoginManager.GROUPS_RS,
+    "search": LoginManager.SEARCH_RS,
+    "transfer": LoginManager.TRANSFER_RS,
+}
+
+
+def _get_client(
+    login_manager: LoginManager, service_name: str
+) -> globus_sdk.BaseClient:
+    if service_name == "auth":
+        return login_manager.get_auth_client()
+    elif service_name == "groups":
+        return login_manager.get_groups_client()
+    elif service_name == "search":
+        return login_manager.get_search_client()
+    elif service_name == "transfer":
+        return login_manager.get_transfer_client()
+    else:
+        raise NotImplementedError(f"unrecognized service: {service_name}")
+
+
+def _format_json(res):
+    click.echo(json.dumps(res.data, indent=2, separators=(",", ": "), sort_keys=True))
+
+
+@group("api")
+def api_command():
+    """Make API calls to Globus services"""
+
+
+for service_name in _SERVICE_MAP:
+
+    @command(service_name, help=f"Make API calls to Globus {service_name.title()}")
+    @LoginManager.requires_login(_SERVICE_MAP[service_name])
+    @click.argument(
+        "method",
+        type=click.Choice(
+            ("HEAD", "GET", "PUT", "POST", "PATCH", "DELETE"), case_sensitive=False
+        ),
+    )
+    @click.argument("path")
+    @click.option("--query-param", "-Q", type=QueryParamType(), multiple=True)
+    @click.option(
+        "--content-type",
+        type=click.Choice(("json", "form", "text", "none", "auto")),
+        default="auto",
+    )
+    @click.option("--body")
+    def service_command(
+        *,
+        login_manager: LoginManager,
+        method: str,
+        path: str,
+        query_param: List[Tuple[str, str]],
+        body: Optional[str],
+        content_type: str,
+    ):
+        client = _get_client(login_manager, service_name)
+        query_params_d = {}
+        for param_name, param_value in query_param:
+            query_params_d[param_name] = param_value
+        headers = {}
+        if content_type != "none":
+            deduced_content_type = _deduce_content_type(content_type, body)
+            if deduced_content_type is not None:
+                headers["Content-Type"] = deduced_content_type
+        res = client.request(
+            method.upper(),
+            path,
+            query_params=query_params_d,
+            data=body,
+            headers=headers,
+        )
+        formatted_print(res, text_format=_format_json)
+
+    api_command.add_command(service_command)

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -1,17 +1,17 @@
 import json
-from typing import List, Optional, Tuple
+from typing import List, Optional, TextIO, Tuple
 
 import click
 import globus_sdk
 
+from globus_cli import termio, version
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import command, group
-from globus_cli.termio import formatted_print
+from globus_cli.parsing import command, group, mutex_option_group
 
 
 class QueryParamType(click.ParamType):
     def get_metavar(self, param):
-        return "x=y"
+        return "Key=Value"
 
     def convert(self, value, param, ctx):
         value = super().convert(value, param, ctx)
@@ -23,19 +23,53 @@ class QueryParamType(click.ParamType):
         return (left, right)
 
 
-def _deduce_content_type(content_type: str, body: Optional[str]) -> Optional[str]:
+class HeaderParamType(click.ParamType):
+    def get_metavar(self, param):
+        return '"Key: Value"'
+
+    def convert(self, value, param, ctx):
+        value = super().convert(value, param, ctx)
+        if value is None:
+            return None
+        if ": " not in value:
+            self.fail("invalid header param", param=param, ctx=ctx)
+        left, right = value.split(": ", 1)
+        return (left, right)
+
+
+def _looks_like_form(body: str) -> bool:
+    # very weak detection for form-encoded data
+    # if it's a single line of non-whitespace data with at least one '=', that will do!
+    body = body.strip()
+    if "\n" in body:
+        return False
+    if "=" not in body:
+        return False
+    return True
+
+
+def _looks_like_json(body: str) -> bool:
+    try:
+        json.loads(body)
+        return True
+    except ValueError:
+        return False
+
+
+def _detect_content_type(content_type: str, body: Optional[str]) -> Optional[str]:
     if content_type == "json":
         return "application/json"
     elif content_type == "form":
         return "application/x-www-form-urlencoded"
+    elif content_type == "text":
+        return "text/plain"
     elif content_type == "auto":
-        if body is None:
-            return None
-        try:
-            json.loads(body)
-            return "application/json"
-        except ValueError:
-            return None
+        if body is not None:
+            if _looks_like_json(body):
+                return "application/json"
+            if _looks_like_form(body):
+                return "application/x-www-form-urlencoded"
+        return None
     else:
         raise NotImplementedError(f"did not recognize content-type '{content_type}'")
 
@@ -63,18 +97,40 @@ def _get_client(
         raise NotImplementedError(f"unrecognized service: {service_name}")
 
 
-def _format_json(res):
+def _get_url(service_name: str) -> str:
+    return {
+        "auth": "https://auth.globus.org/",
+        "groups": "https://groups.api.globus.org/v2/",
+        "search": "https://search.api/globus.org/",
+        "transfer": "https://transfer.api.globus.org/v0.10/",
+    }[service_name]
+
+
+def _format_json(res: globus_sdk.GlobusHTTPResponse) -> None:
     click.echo(json.dumps(res.data, indent=2, separators=(",", ": "), sort_keys=True))
 
 
 @group("api")
-def api_command():
+def api_command() -> None:
     """Make API calls to Globus services"""
 
 
 for service_name in _SERVICE_MAP:
 
-    @command(service_name, help=f"Make API calls to Globus {service_name.title()}")
+    @command(
+        service_name,
+        help=f"""\
+Make API calls to Globus {service_name.title()}
+
+The arguments are an HTTP method name and a path within the service to which the request
+should be made. The path will be joined with the known service URL.
+For example, a call of
+
+    globus api {service_name} GET /foo/bar
+
+sends a 'GET' request to '{_get_url(service_name)}foo/bar'
+""",
+    )
     @LoginManager.requires_login(_SERVICE_MAP[service_name])
     @click.argument(
         "method",
@@ -83,38 +139,74 @@ for service_name in _SERVICE_MAP:
         ),
     )
     @click.argument("path")
-    @click.option("--query-param", "-Q", type=QueryParamType(), multiple=True)
+    @click.option(
+        "--query-param",
+        "-Q",
+        type=QueryParamType(),
+        multiple=True,
+        help="A query parameter, given as 'key=value'. Use this option multiple "
+        "times to pass multiple query parameters.",
+    )
     @click.option(
         "--content-type",
         type=click.Choice(("json", "form", "text", "none", "auto")),
         default="auto",
+        help="Use a specific Content-Type header for the request. "
+        "The default (auto) detects a content type from the data being included in "
+        "the request body, while the other names refer to common data encodings. "
+        "Any explicit Content-Type header set via '--header' will override this",
     )
-    @click.option("--body")
+    @click.option(
+        "--header",
+        "-H",
+        type=HeaderParamType(),
+        multiple=True,
+        help="A header, specified as 'Key: Value'. Use this option multiple "
+        "times to pass multiple headers.",
+    )
+    @click.option("--body", help="A request body to include, as text")
+    @click.option(
+        "--body-file",
+        type=click.File("r"),
+        help="A request body to include, as a file. Mutually exclusive with --body",
+    )
+    @mutex_option_group("--body", "--body-file")
     def service_command(
         *,
         login_manager: LoginManager,
         method: str,
         path: str,
         query_param: List[Tuple[str, str]],
+        header: List[Tuple[str, str]],
         body: Optional[str],
+        body_file: Optional[TextIO],
         content_type: str,
     ):
         client = _get_client(login_manager, service_name)
+        client.app_name = version.app_name + " raw-api-command"
+
         query_params_d = {}
         for param_name, param_value in query_param:
             query_params_d[param_name] = param_value
-        headers = {}
+
+        if body_file:
+            body = body_file.read()
+
+        headers_d = {}
         if content_type != "none":
-            deduced_content_type = _deduce_content_type(content_type, body)
-            if deduced_content_type is not None:
-                headers["Content-Type"] = deduced_content_type
+            detected_content_type = _detect_content_type(content_type, body)
+            if detected_content_type is not None:
+                headers_d["Content-Type"] = detected_content_type
+        for header_name, header_value in header:
+            headers_d[header_name] = header_value
+
         res = client.request(
             method.upper(),
             path,
             query_params=query_params_d,
             data=body,
-            headers=headers,
+            headers=headers_d,
         )
-        formatted_print(res, text_format=_format_json)
+        termio.formatted_print(res, text_format=_format_json)
 
     api_command.add_command(service_command)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,12 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(autouse=True)
+def mocksleep():
+    with mock.patch("time.sleep") as m:
+        yield m
+
+
+@pytest.fixture(autouse=True)
 def set_login_manager_testmode():
     globus_cli.login_manager.LoginManager._TEST_MODE = True
 

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -3,10 +3,12 @@ from globus_sdk._testing import RegisteredResponse, load_response
 
 
 @pytest.mark.parametrize("service_name", ["auth", "transfer", "groups", "search"])
-def test_api_command_get(run_line, service_name):
+@pytest.mark.parametrize("is_error_response", (False, True))
+def test_api_command_get(run_line, service_name, is_error_response):
     load_response(
         RegisteredResponse(
             service=service_name,
+            status=500 if is_error_response else 200,
             path="/foo",
             json={"foo": "bar"},
         )

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -1,0 +1,23 @@
+import pytest
+from globus_sdk._testing import RegisteredResponse, load_response
+
+
+@pytest.mark.parametrize("service_name", ["auth", "transfer", "groups", "search"])
+def test_api_command_get(run_line, service_name):
+    load_response(
+        RegisteredResponse(
+            service=service_name,
+            path="/foo",
+            json={"foo": "bar"},
+        )
+    )
+
+    result = run_line(f"globus api {service_name}  get /foo")
+    assert (
+        result.output
+        == """\
+{
+  "foo": "bar"
+}
+"""
+    )

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -14,12 +14,8 @@ def test_api_command_get(run_line, service_name, is_error_response):
         )
     )
 
-    result = run_line(f"globus api {service_name}  get /foo")
-    assert (
-        result.output
-        == """\
-{
-  "foo": "bar"
-}
-"""
+    result = run_line(
+        ["globus", "api", service_name, "get", "/foo"]
+        + (["--no-retry", "--allow-errors"] if is_error_response else [])
     )
+    assert result.output == '{"foo": "bar"}\n'

--- a/tests/functional/test_rm.py
+++ b/tests/functional/test_rm.py
@@ -1,20 +1,7 @@
 import json
 
-import pytest
 import responses
 from globus_sdk._testing import load_response_set
-
-
-@pytest.fixture
-def patch_sleep(monkeypatch):
-    sleep_calls = []
-
-    def mock_sleep(*args, **kwargs):
-        sleep_calls.append((args, kwargs))
-
-    monkeypatch.setattr("time.sleep", mock_sleep)
-
-    return sleep_calls
 
 
 def _get_delete_call():
@@ -87,7 +74,7 @@ def test_ignore_missing(run_line, go_ep1_id):
     assert sent_data["ignore_missing"] is True
 
 
-def test_timeout(run_line, patch_sleep, go_ep1_id):
+def test_timeout(run_line, go_ep1_id):
     """
     If a task is retrying without success, `rm` should wait and eventually time out.
     """
@@ -102,7 +89,7 @@ def test_timeout(run_line, patch_sleep, go_ep1_id):
     assert "Task has yet to complete after 2 seconds" in result.stderr
 
 
-def test_timeout_explicit_status(run_line, patch_sleep, go_ep1_id):
+def test_timeout_explicit_status(run_line, go_ep1_id):
     """
     As above, submit a task which sits queued and times out.
     Confirms rm exits STATUS after given timeout, where

--- a/tests/unit/test_api_command_helpers.py
+++ b/tests/unit/test_api_command_helpers.py
@@ -1,0 +1,90 @@
+import click
+import pytest
+
+from globus_cli.commands.api import HeaderParamType, QueryParamType, detect_content_type
+
+
+@pytest.mark.parametrize(
+    "content_type_arg,expect",
+    [
+        ("json", "application/json"),
+        ("form", "application/x-www-form-urlencoded"),
+        ("text", "text/plain"),
+        ("auto", None),
+    ],
+)
+def test_detect_content_type_no_body(content_type_arg, expect):
+    assert detect_content_type(content_type_arg, None) == expect
+
+
+def test_auto_detect_content_type_from_body():
+    assert detect_content_type("auto", "{}") == "application/json"
+    assert detect_content_type("auto", "x=y") == "application/x-www-form-urlencoded"
+    assert detect_content_type("auto", "{") is None
+    # things that would be form-data if not for...
+    # has newline
+    assert detect_content_type("auto", "x=y\nk=v") is None
+    # no equal-sign
+    assert detect_content_type("auto", "xy") is None
+
+
+def test_query_param_parsing(runner):
+    # simple case
+    @click.command()
+    @click.option("-q", type=QueryParamType())
+    def foo(q):
+        x, y = q
+        click.echo(f"x={x} y={y}")
+
+    result = runner.invoke(foo, ["-q", "k=v"])
+    assert result.output == "x=k y=v\n"
+
+    result = runner.invoke(foo, ["-q", "kv"])
+    assert result.exit_code == 2
+    assert "invalid query param" in result.output
+
+    # multiple case
+    @click.command()
+    @click.option("-q", type=QueryParamType(), multiple=True)
+    def foo(q):
+        for param in q:
+            x, y = param
+            click.echo(f"x={x} y={y}")
+
+    result = runner.invoke(foo, [])
+    assert result.output == ""
+    result = runner.invoke(foo, ["-q", "k1=v1", "-q", "k2=v2"])
+    assert result.output == "x=k1 y=v1\nx=k2 y=v2\n"
+
+
+def test_header_parsing(runner):
+    # simple case
+    @click.command()
+    @click.option("-h", type=HeaderParamType())
+    def foo(h):
+        x, y = h
+        click.echo(f"x={x} y={y}")
+
+    result = runner.invoke(foo, ["-h", "k: v"])
+    assert result.output == "x=k y=v\n"
+
+    result = runner.invoke(foo, ["-h", "kv"])
+    assert result.exit_code == 2
+    assert "invalid header param" in result.output
+
+    result = runner.invoke(foo, ["-h", "k:v"])  # missing space
+    assert result.exit_code == 2
+    assert "invalid header param" in result.output
+
+    # multiple case
+    @click.command()
+    @click.option("-h", type=HeaderParamType(), multiple=True)
+    def foo(h):
+        for param in h:
+            x, y = param
+            click.echo(f"x={x} y={y}")
+
+    result = runner.invoke(foo, [])
+    assert result.output == ""
+    result = runner.invoke(foo, ["-h", "k1: v1", "-h", "k2: v2"])
+    assert result.output == "x=k1 y=v1\nx=k2 y=v2\n"

--- a/tests/unit/test_api_command_helpers.py
+++ b/tests/unit/test_api_command_helpers.py
@@ -65,14 +65,18 @@ def test_header_parsing(runner):
         x, y = h
         click.echo(f"x={x} y={y}")
 
+    # simple
+    result = runner.invoke(foo, ["-h", "k:v"])
+    assert result.output == "x=k y=v\n"
+    # with leading space stripped
     result = runner.invoke(foo, ["-h", "k: v"])
     assert result.output == "x=k y=v\n"
+    # colons after the first are preserved
+    result = runner.invoke(foo, ["-h", "k:v:v2"])
+    assert result.output == "x=k y=v:v2\n"
 
+    # no colon -> parse error
     result = runner.invoke(foo, ["-h", "kv"])
-    assert result.exit_code == 2
-    assert "invalid header param" in result.output
-
-    result = runner.invoke(foo, ["-h", "k:v"])  # missing space
     assert result.exit_code == 2
     assert "invalid header param" in result.output
 


### PR DESCRIPTION
Right now, this is just a "first cut", and needs a bit more work. However, I was able to use it to do a few Transfer calls and it seems okay.

This is lacking in testing, there's no detailed documentation, and several parameters need more docs.
In no particular order, these are the TODO items which I still have on this:
- [x] add `--body-file`, make it mutex with `--body`
- [x] update SDK upstream to fix annotations to allow `data: str` for request bodies
- [x] add tests for content-type detection
- [x] add a `--header` option with `multiple=True`
- [x] set `app_name` on clients in the api commands to `"globus-cli-raw"` + CLI version info
- [x] add some basic tests

---

Update: This is now ready for review.

It add `globus api [transfer|auth|groups|search] [HEAD|GET|PUT|POST|DELETE] PATH`, with options for setting headers and query params with some basic parsing.

Some specifics on `Content-Type`:
Because many Globus APIs expect or require a content-type when reading JSON data, it seemed worthwhile to add some special handling for it. Namely, there is some simple Content-Type detection which will treat json-parseable data as `Content-Type: application/json`, and this can be controlled or fine-tuned with `--content-type`. It is applied to the headers _before_ `--header` values are parsed and handled, so that `--header "Content-Type: application/octet-stream"` works as desired/expected and overrides the autodetect behavior.