### PR TITLE
Start on stricter mypy settings (--disallow-untyped-defs)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,18 @@ no_implicit_optional = true
 
 [mypy-globus_cli.endpointish.*]
 disallow_untyped_defs = true
+
+[mypy-globus_cli.principal_resolver]
+disallow_untyped_defs = true
+
+[mypy-globus_cli.utils]
+disallow_untyped_defs = true
+
+[mypy-globus_cli.types]
+disallow_untyped_defs = true
+
+[mypy-globus_cli.version]
+disallow_untyped_defs = true
+
+[mypy-globus_cli.constants]
+disallow_untyped_defs = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,14 @@
+[mypy]
+# we are beginning the gradual rollout of
+#   disallow_untyped_defs = true
+# and may eventually set strict=true
+# do not set it at the top level -- it is set for subpackages below
+warn_unreachable = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_no_return = true
+no_implicit_optional = true
+
+[mypy-globus_cli.endpointish.*]
+disallow_untyped_defs = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,16 +8,6 @@ max-line-length = 88
 ignore = W503,W504,E203
 
 
-[mypy]
-# disallow_untyped_defs = true
-warn_unreachable = true
-warn_unused_ignores = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_no_return = true
-no_implicit_optional = true
-
-
 [tool:pytest]
 addopts = --cov=src --no-cov-on-fail --timeout 3
 filterwarnings =

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -5,9 +5,10 @@ from globus_cli.parsing import collection_id_arg, command
 from globus_cli.principal_resolver import default_identity_id_resolver
 from globus_cli.services.gcs import connector_id_to_display_name
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+from globus_cli.types import FIELD_LIST_T
 from globus_cli.utils import filter_fields, sorted_json_field
 
-STANDARD_FIELDS = [
+STANDARD_FIELDS: FIELD_LIST_T = [
     ("Display Name", "display_name"),
     ("Owner", default_identity_id_resolver.field),
     ("ID", "id"),
@@ -33,7 +34,7 @@ STANDARD_FIELDS = [
     ("Collection Info Link", "info_link"),
 ]
 
-PRIVATE_FIELDS = [
+PRIVATE_FIELDS: FIELD_LIST_T = [
     ("Root Path", "root_path"),
     ("Default Directory", "default_directory"),
     ("Sharing Path Restrictions", sorted_json_field("sharing_restrict_paths")),
@@ -64,7 +65,7 @@ def collection_show(
     gcs_client = login_manager.get_gcs_client(collection_id=collection_id)
 
     query_params = {}
-    fields = STANDARD_FIELDS
+    fields: FIELD_LIST_T = STANDARD_FIELDS
 
     if include_private_policies:
         query_params["include"] = "private_policies"

--- a/src/globus_cli/constants.py
+++ b/src/globus_cli/constants.py
@@ -5,7 +5,7 @@ It should not depend on any other part of the globus-cli codebase.
 (If you need to import something else, maybe it's not simple enough to be a constant...)
 """
 
-__all__ = ["EXPLICIT_NULL"]
+__all__ = ("EXPLICIT_NULL",)
 
 
 class _ExplicitNullClass:
@@ -15,10 +15,10 @@ class _ExplicitNullClass:
     provided
     """
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "null"
 
 

--- a/src/globus_cli/endpointish/endpointish.py
+++ b/src/globus_cli/endpointish/endpointish.py
@@ -42,7 +42,7 @@ class Endpointish:
         self,
         expect_types: Union[Tuple[EndpointType, ...], EndpointType],
         error_class: Type[WrongEndpointTypeError] = WrongEndpointTypeError,
-    ):
+    ) -> None:
         if isinstance(expect_types, EndpointType):
             expect_types = (expect_types,)
         if self.ep_type not in expect_types:
@@ -53,17 +53,17 @@ class Endpointish:
                 expect_types,
             )
 
-    def assert_is_gcsv5_collection(self):
+    def assert_is_gcsv5_collection(self) -> None:
         self.assert_ep_type(
             EndpointType.collections(), error_class=ExpectedCollectionError
         )
 
-    def assert_is_not_collection(self):
+    def assert_is_not_collection(self) -> None:
         self.assert_ep_type(
             EndpointType.non_collection_types(), error_class=ExpectedEndpointError
         )
 
-    def assert_is_traditional_endpoint(self):
+    def assert_is_traditional_endpoint(self) -> None:
         self.assert_ep_type(
             EndpointType.traditional_endpoints(), error_class=ExpectedEndpointError
         )

--- a/src/globus_cli/endpointish/errors.py
+++ b/src/globus_cli/endpointish/errors.py
@@ -61,10 +61,10 @@ class WrongEndpointTypeError(ValueError):
 
 
 class ExpectedCollectionError(WrongEndpointTypeError):
-    def _get_expected_message(self):
+    def _get_expected_message(self) -> str:
         return f"Expected {self.endpoint_id} to be a collection ID."
 
 
 class ExpectedEndpointError(WrongEndpointTypeError):
-    def _get_expected_message(self):
+    def _get_expected_message(self) -> str:
         return f"Expected {self.endpoint_id} to be an endpoint ID."

--- a/src/globus_cli/types.py
+++ b/src/globus_cli/types.py
@@ -1,19 +1,27 @@
 """
 Internal types for type annotations
 """
-from typing import TYPE_CHECKING, Callable, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Tuple, Union
+
+from globus_sdk import GlobusHTTPResponse
 
 # all imports from globus_cli modules done here are done under TYPE_CHECKING
 # in order to ensure that the use of type annotations never introduces circular
 # imports at runtime
 if TYPE_CHECKING:
     from globus_cli.termio import FormatField
+    from globus_cli.utils import CLIStubResponse
 
 
 FIELD_T = Union[
     "FormatField",
     Tuple[str, str],
     Tuple[str, Callable[..., str]],
+    # NOTE: this type is redundant with the previous two, but is needed to ensure
+    # type agreement (mypy may flag it as a false negative otherwise)
+    Tuple[str, Union[str, Callable[..., str]]],
 ]
 
 FIELD_LIST_T = List[FIELD_T]
+
+DATA_CONTAINER_T = Union[Mapping[str, Any], GlobusHTTPResponse, "CLIStubResponse"]

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+from typing import Optional, Tuple
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
@@ -9,7 +10,7 @@ app_name = f"Globus CLI v{__version__}"
 
 
 # pull down version data from PyPi
-def get_versions():
+def get_versions() -> Tuple[Optional[LooseVersion], LooseVersion]:
     """
     Wrap in a function to ensure that we don't run this every time a CLI
     command runs or when version number is loaded by setuptools.


### PR DESCRIPTION
This is the single most useful part of strict-mypy to start rolling out.
For now, I've focused on only a few modules where the changes were quite limited.

Because the config will become fairly long until we can set `disallow_untyped_defs = true` at the top level, I've moved it from setup.cfg to mypy.ini .

There's only one noteworthy functional change, in the filter_fields helper method. Rather than assuming that the inputs are always tuples, it now handles a FormatField object gracefully (but does not check it against the filter). It's very minor and doesn't come up in practice.