### PR TITLE
Add commands for interacting with Search Subjects

### DIFF
--- a/changelog.d/20220503_212343_sirosen_add_search_subject_commands.md
+++ b/changelog.d/20220503_212343_sirosen_add_search_subject_commands.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Add commands for interacting with individual documents in Globus Search:
+  `globus search subject show` and `globus search subject delete`

--- a/src/globus_cli/commands/search/__init__.py
+++ b/src/globus_cli/commands/search/__init__.py
@@ -4,6 +4,7 @@ from .delete_by_query import delete_by_query_command
 from .index import index_command
 from .ingest import ingest_command
 from .query import query_command
+from .subject import subject_command
 from .task import task_command
 
 
@@ -16,4 +17,5 @@ search_command.add_command(ingest_command)
 search_command.add_command(index_command)
 search_command.add_command(query_command)
 search_command.add_command(delete_by_query_command)
+search_command.add_command(subject_command)
 search_command.add_command(task_command)

--- a/src/globus_cli/commands/search/subject/__init__.py
+++ b/src/globus_cli/commands/search/subject/__init__.py
@@ -1,0 +1,13 @@
+from globus_cli.parsing import group
+
+from .delete import delete_command
+from .show import show_command
+
+
+@group("subject", short_help="Manage data by subject")
+def subject_command() -> None:
+    """View and manage individual documents in an index by subject"""
+
+
+subject_command.add_command(delete_command)
+subject_command.add_command(show_command)

--- a/src/globus_cli/commands/search/subject/delete.py
+++ b/src/globus_cli/commands/search/subject/delete.py
@@ -1,0 +1,39 @@
+import uuid
+
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+
+from .._common import index_id_arg
+
+
+@command("delete")
+@index_id_arg
+@click.argument("subject")
+@LoginManager.requires_login(LoginManager.SEARCH_RS)
+def delete_command(
+    *,
+    index_id: uuid.UUID,
+    subject: str,
+    login_manager: LoginManager,
+):
+    """Delete a subject (requires writer, admin, or owner)
+
+    Delete a submit a delete_by_subject task on an index. This requires writer or
+    stronger privileges on the index.
+
+    Returns the 'task_id' for the deletion task. Deletions are not guaranteed to be
+    immediate, but will be put into the task queue for that index. Monitor tasks using
+    commands like 'globus search task show'
+    """
+    search_client = login_manager.get_search_client()
+    formatted_print(
+        search_client.delete_subject(index_id, subject),
+        text_format=FORMAT_TEXT_RECORD,
+        fields=[
+            ("Message", lambda _x: "delete-by-subject task successfully submitted"),
+            ("Task ID", "task_id"),
+        ],
+    )

--- a/src/globus_cli/commands/search/subject/show.py
+++ b/src/globus_cli/commands/search/subject/show.py
@@ -1,0 +1,40 @@
+import json
+import uuid
+
+import click
+import globus_sdk
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import formatted_print
+
+from .._common import index_id_arg
+
+
+def _print_subject(subject_doc: globus_sdk.GlobusHTTPResponse):
+    entries = subject_doc["entries"]
+    if len(entries) == 1:
+        click.echo(json.dumps(entries[0], indent=2, separators=(",", ": ")))
+    else:
+        click.echo(json.dumps(entries, indent=2, separators=(",", ": ")))
+
+
+@command("show")
+@index_id_arg
+@click.argument("subject")
+@LoginManager.requires_login(LoginManager.SEARCH_RS, LoginManager.AUTH_RS)
+def show_command(
+    *, login_manager: LoginManager, index_id: uuid.UUID, subject: str
+) -> None:
+    """Show the data for a given subject in an index
+
+    This is subject the visible_to access control list on the entries for that subject.
+    If there are one or more entries visible to the current user, they will be
+    displayed.
+
+    If there are no entries visible to the current user, a NotFound error will be
+    raised.
+    """
+    search_client = login_manager.get_search_client()
+    res = search_client.get_subject(index_id, subject)
+    formatted_print(res, text_format=_print_subject)

--- a/tests/files/api_fixtures/search.yaml
+++ b/tests/files/api_fixtures/search.yaml
@@ -4,6 +4,7 @@ metadata:
   error_index_id: 2ac1f660-298b-432f-89ae-c1299ad4233e
   task_id: 49869cb5-4fca-4f19-bbb6-8b0a18bd1f95
   pending_task_id: cfdedea7-9c52-42cb-84a6-6daa8217f772
+  delete_by_subject_task_id: 0c21ee5d-e847-415f-831f-b325af794716
   index_list_data:
     "6f831ac8-4c41-4812-b383-6fb04f8b9f9f":
       display_name: "example_cookery"
@@ -27,6 +28,8 @@ metadata:
     "MDQ0ODkz":
       role: writer
       value: "Globus Group (9da26beb-33f5-4e1a-b9f6-a44a624c4ddd)"
+  subject: "https://en.wikipedia.org/wiki/Salsa_verde"
+  multi_entry_subject: "multi-entry-subject"
 
 search:
   - path: /v1/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f/search
@@ -467,4 +470,124 @@ search:
           "role_name": "writer"
         },
         "success": true
+      }
+  - path: /v1/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f/subject
+    query_params:
+      subject: "https://en.wikipedia.org/wiki/Salsa_verde"
+    method: get
+    json:
+      {
+        "entries": [
+          {
+            "content": {
+              "cuisine": [
+                "mexican"
+              ],
+              "handle": "salsa-verde",
+              "ingredients": [
+                {
+                  "amount": {
+                    "number": 10
+                  },
+                  "default": "tomatillo",
+                  "preparation": "simmer 20 minutes",
+                  "type": "fruit"
+                },
+                {
+                  "amount": {
+                    "number": 2
+                  },
+                  "default": "serrano pepper",
+                  "preparation": "seeded",
+                  "substitutes": [
+                    "jalapeno",
+                    "thai bird chili"
+                  ],
+                  "type": "fruit"
+                },
+                {
+                  "amount": {
+                    "number": 2,
+                    "unit": "clove"
+                  },
+                  "default": "garlic",
+                  "type": "vegetable"
+                },
+                {
+                  "amount": {
+                    "number": 0.5
+                  },
+                  "default": "yellow onion",
+                  "type": "vegetable"
+                },
+                {
+                  "amount": {
+                    "number": 2,
+                    "unit": "tsp"
+                  },
+                  "default": "salt",
+                  "type": "spice"
+                },
+                {
+                  "amount": {
+                    "number": 2,
+                    "unit": "tbsp"
+                  },
+                  "default": "coriander",
+                  "preparation": "ground",
+                  "subsitutes": [
+                    "cumin"
+                  ],
+                  "type": "spice"
+                }
+              ],
+              "keywords": [
+                "salsa",
+                "tomatillo",
+                "coriander",
+                "serrano pepper"
+              ],
+              "origin": {
+                "author": "Diana Kennedy",
+                "title": "Regional Mexican Cooking",
+                "type": "book"
+              }
+            },
+            "entry_id": null,
+            "matched_principal_sets": []
+          }
+        ],
+        "subject": "https://en.wikipedia.org/wiki/Salsa_verde"
+      }
+  - path: /v1/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f/subject
+    query_params:
+      subject: "multi-entry-subject"
+    method: get
+    json:
+      {
+        "entries": [
+          {
+            "content": {
+              "foo": "bar"
+            },
+            "entry_id": "foo",
+            "matched_principal_sets": []
+          },
+          {
+            "content": {
+              "bar": "baz"
+            },
+            "entry_id": "bar",
+            "matched_principal_sets": []
+          }
+        ],
+        "subject": "multi-entry-subject"
+      }
+  - path: /v1/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f/subject
+    query_params:
+      subject: "https://en.wikipedia.org/wiki/Salsa_verde"
+    method: delete
+    json:
+      {
+        "task_id": "0c21ee5d-e847-415f-831f-b325af794716"
       }

--- a/tests/functional/search/test_subject_commands.py
+++ b/tests/functional/search/test_subject_commands.py
@@ -1,0 +1,43 @@
+import json
+
+import pytest
+import responses
+from globus_sdk._testing import load_response_set
+
+
+@pytest.mark.parametrize("multiple_entries", (False, True))
+def test_search_subject_show(run_line, multiple_entries):
+    meta = load_response_set("cli.search").metadata
+    index_id = meta["index_id"]
+    subject = meta["multi_entry_subject"] if multiple_entries else meta["subject"]
+
+    res = run_line(["globus", "search", "subject", "show", index_id, subject])
+    data = json.loads(res.output)
+    if multiple_entries:
+        assert isinstance(data, list)
+        for item in data:
+            assert "entry_id" in item
+            assert "content" in item
+    else:
+        assert isinstance(data, dict)
+        assert "content" in data
+        assert "entry_id" in data
+
+    sent = responses.calls[-1].request
+    assert sent.method == "GET"
+    assert sent.params == {"subject": subject}
+    assert sent.body is None
+
+
+def test_search_subject_delete(run_line):
+    meta = load_response_set("cli.search").metadata
+    index_id = meta["index_id"]
+    subject = meta["subject"]
+
+    res = run_line(["globus", "search", "subject", "delete", index_id, subject])
+    assert meta["delete_by_subject_task_id"] in res.output
+
+    sent = responses.calls[-1].request
+    assert sent.method == "DELETE"
+    assert sent.params == {"subject": subject}
+    assert sent.body is None


### PR DESCRIPTION
'subject show' and 'subject delete' are added here. 'subject delete' has relatively simple output, displaying a task ID in record format.

'subject show' does JSON-formatted output even when the requested output mode is text, but trimmed down to the part that a user is likely to find interesting. It chooses whether or not to unwrap the "entries" array based on the length -- unwrap if `len() == 1`.

New tests cover these behaviors, including new test fixture data.