### PR TITLE
Dedent help in generated documentation

### DIFF
--- a/reference/_generate.py
+++ b/reference/_generate.py
@@ -4,6 +4,7 @@
 based originally on click-man, but significantly specialized for the globus-cli
 """
 import os
+import textwrap
 import time
 
 import click
@@ -114,7 +115,7 @@ class AdocPage:
     def __init__(self, ctx):
         self.commandname = ctx.command_path
         self.short_help = ctx.command.get_short_help_str()
-        self.description = ctx.command.help.replace("\b\n", "")
+        self.description = textwrap.dedent(ctx.command.help).replace("\b\n", "")
         self.synopsis = ctx.command.adoc_synopsis or _format_synopsis(
             ctx.command.collect_usage_pieces(ctx)
         )

--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -32,10 +32,10 @@ class GlobusCommand(click.Command):
 
     AUTOMATIC_ACTIVATION_HELPTEXT = """=== Automatic Endpoint Activation
 
-This command requires all endpoints it uses to be activated. It will attempt to
-auto-activate any endpoints that are not active, but if auto-activation fails,
-you will need to manually activate the endpoint. See 'globus endpoint activate'
-for more details."""
+    This command requires all endpoints it uses to be activated. It will attempt to
+    auto-activate any endpoints that are not active, but if auto-activation fails,
+    you will need to manually activate the endpoint. See 'globus endpoint activate'
+    for more details."""
 
     def __init__(self, *args, **kwargs):
         self.adoc_skip = kwargs.pop("adoc_skip", False)


### PR DESCRIPTION
`Command.help` now includes a leading indent. Remove this explicitly with `textwrap.dedent()`.

You can see the change by looking at `tox -e reference` and looking at `reference/transfer.adoc` for the result.