### PR TITLE
Add behavior like no-args-is-help to commands

### DIFF
--- a/changelog.d/20220513_160219_sirosen_improve_cmd_help.md
+++ b/changelog.d/20220513_160219_sirosen_improve_cmd_help.md
@@ -1,0 +1,6 @@
+### Enhancements
+
+* Commands which have required arguments will print their helptext if invoked
+  with no arguments. They still `exit(2)` (usage error). This only applies to
+  the case of a command with required arguments being called with no arguments
+  at all.

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -36,7 +36,7 @@ def test_command_missing_args(run_line):
     Runs get-identities without values, confirms exit_code 2
     """
     result = run_line("globus get-identities", assert_exit_code=2)
-    assert "Error: Missing argument" in result.stderr
+    assert "Missing argument" in result.stderr
 
 
 def test_invalid_command(run_line):

--- a/tests/unit/test_command_decorators.py
+++ b/tests/unit/test_command_decorators.py
@@ -1,0 +1,53 @@
+import click
+
+from globus_cli.parsing import command
+
+
+def test_custom_command_missing_param_helptext(runner):
+    @command()
+    @click.option("--bar", help="BAR-STRING-HERE", required=True)
+    def foo(bar):
+        click.echo(bar or "none")
+
+    # call with `--help` to confirm help behavior
+    result = runner.invoke(foo, ["--help"])
+    assert result.exit_code == 0
+    assert "BAR-STRING-HERE" in result.output
+
+    # no args should produce the same, but with an exit status of 2
+    result = runner.invoke(foo, [])
+    assert result.exit_code == 2
+    assert "BAR-STRING-HERE" in result.output
+    # should include missing arg message
+    assert "Missing option '--bar'" in result.output
+
+
+def test_custom_command_missing_param_helptext_suppressed_when_args_present(runner):
+    @command()
+    @click.option("--bar", help="BAR-STRING-HERE", required=True)
+    @click.option("--baz", help="BAZ-STRING-HERE", required=True)
+    def foo(bar, baz):
+        click.echo(bar or "none")
+        click.echo(baz or "none")
+
+    # call with `--help` to confirm help behavior
+    result = runner.invoke(foo, ["--help"])
+    assert result.exit_code == 0
+    assert "BAR-STRING-HERE" in result.output
+    assert "BAZ-STRING-HERE" in result.output
+
+    # no args should produce the same, but with an exit status of 2
+    # and a missing arg message
+    result = runner.invoke(foo, [])
+    assert result.exit_code == 2
+    assert "Missing option" in result.output
+    assert "BAR-STRING-HERE" in result.output
+    assert "BAZ-STRING-HERE" in result.output
+
+    # partial args should produce the missing arg message
+    # but not helptext
+    result = runner.invoke(foo, ["--bar", "X"])
+    assert result.exit_code == 2
+    assert "Missing option '--baz'" in result.output
+    assert "BAR-STRING-HERE" not in result.output
+    assert "BAZ-STRING-HERE" not in result.output


### PR DESCRIPTION
Unlike the builtin no_args_is_help option, we do not want this behavior to trigger on commands which take no arguments (all args are optional).

In our custom command class, override the behavior of `parse_args` to check for MissingParameter errors combined with an empty arg list. Such a situation indicates that a command requires arguments (e.g. `globus transfer`) and none were given. In this situation, print the MissingParameter error message, followed by the full helptext for the current command, then exit(2) .

If there were arguments and a MissingParameter error is encountered, just reraise and trust click to handle it as normal.

---

@rudyardrichter, we discussed the variant of this in timer-cli. I considered that and almost lifted it into here. I didn't really like handling other errors beyond MissingParameter (easy to tweak), so I cut it down. But then I had to construct artificial Groups for my testing to ensure there would be a parent context (because that approach catches the errors outside of `make_context`). That "felt wrong" and manually touching usage parts with the help formatter was fiddly, so I started looking at [the no_args_is_help implementation](https://github.com/pallets/click/blob/c96545f6f4ba0eab99de6ec8b4ceb77c9bdb2528/src/click/core.py#L1370-L1372). That looks like a good place to hook in, so this is just wrapping the `click` behavior with a little bit of extra handling.