### PR TITLE
Implement partial lazy importing in globus-cli

### DIFF
--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -1,4 +1,3 @@
-import webbrowser
 from typing import Dict, Optional, Union
 
 import click
@@ -277,6 +276,8 @@ def endpoint_activate(
 
     # web activation
     elif web:
+        import webbrowser
+
         url = f"{get_webapp_url()}file-manager?origin_id={endpoint_id}"
         if no_browser or is_remote_session():
             res = {"message": f"Web activation url: {url}", "url": url}

--- a/src/globus_cli/commands/update.py
+++ b/src/globus_cli/commands/update.py
@@ -1,6 +1,5 @@
 import atexit
 import os
-import pathlib
 import site
 import subprocess
 import sys
@@ -29,6 +28,8 @@ def _is_user_install() -> bool:
 # pipx home discovery extracted from pipx itself. see:
 #   https://github.com/pypa/pipx/blob/878f03504417fa4cc9a6676b1bc24aef2ba3e491/src/pipx/constants.py#L8
 def _is_pipx_install() -> bool:
+    import pathlib
+
     _DEFAULT_PIPX_HOME = pathlib.Path.home() / ".local/pipx"
     _PIPX_HOME = pathlib.Path(os.getenv("PIPX_HOME", _DEFAULT_PIPX_HOME)).resolve()
     return __file__.startswith(str(_PIPX_HOME))

--- a/src/globus_cli/login_manager/__init__.py
+++ b/src/globus_cli/login_manager/__init__.py
@@ -1,6 +1,5 @@
 from .client_login import get_client_login, is_client_login
 from .errors import MissingLoginError
-from .local_server import is_remote_session
 from .manager import LoginManager
 from .tokenstore import (
     delete_templated_client,
@@ -8,6 +7,7 @@ from .tokenstore import (
     internal_native_client,
     token_storage_adapter,
 )
+from .utils import is_remote_session
 
 __all__ = [
     "MissingLoginError",

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -1,8 +1,5 @@
-import webbrowser
-
 import click
 
-from .local_server import LocalServerError, start_local_server
 from .tokenstore import internal_auth_client, token_storage_adapter
 
 _STORE_CONFIG_USERINFO = "auth_user_data"
@@ -50,6 +47,10 @@ def do_local_server_auth_flow(scopes, *, session_params=None):
     Starts a local http server, opens a browser to have the user authenticate,
     and gets the code redirected to the server (no copy and pasting required)
     """
+    import webbrowser
+
+    from .local_server import LocalServerError, start_local_server
+
     session_params = session_params or {}
 
     # start local server and create matching redirect_uri

--- a/src/globus_cli/login_manager/local_server.py
+++ b/src/globus_cli/login_manager/local_server.py
@@ -1,6 +1,5 @@
 import http.client
 import logging
-import os
 import queue
 import sys
 import threading
@@ -24,10 +23,6 @@ def enable_requests_logging():
     requests_log = logging.getLogger("requests.packages.urllib3")
     requests_log.setLevel(logging.DEBUG)
     requests_log.propagate = True
-
-
-def is_remote_session():
-    return os.environ.get("SSH_TTY", os.environ.get("SSH_CONNECTION"))
 
 
 class RedirectHandler(BaseHTTPRequestHandler):

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -21,8 +21,8 @@ from ..services.transfer import CustomTransferClient
 from .auth_flows import do_link_auth_flow, do_local_server_auth_flow
 from .client_login import get_client_login, is_client_login
 from .errors import MissingLoginError
-from .local_server import is_remote_session
 from .tokenstore import internal_auth_client, token_storage_adapter
+from .utils import is_remote_session
 
 
 class LoginManager:

--- a/src/globus_cli/login_manager/tokenstore.py
+++ b/src/globus_cli/login_manager/tokenstore.py
@@ -5,7 +5,6 @@ from typing import cast
 import globus_sdk
 from globus_sdk.tokenstorage import SQLiteAdapter
 
-from ._old_config import invalidate_old_config
 from .client_login import get_client_login, is_client_login
 
 # internal constants
@@ -111,6 +110,8 @@ def token_storage_adapter() -> SQLiteAdapter:
         # if it does not, then use this as a flag to clean the old config
         fname = _get_storage_filename()
         if not os.path.exists(fname):
+            from ._old_config import invalidate_old_config
+
             invalidate_old_config(internal_native_client())
         # namespace is equal to the current environment
         as_proto._instance = SQLiteAdapter(fname, namespace=_resolve_namespace())

--- a/src/globus_cli/login_manager/utils.py
+++ b/src/globus_cli/login_manager/utils.py
@@ -1,0 +1,5 @@
+import os
+
+
+def is_remote_session():
+    return os.environ.get("SSH_TTY", os.environ.get("SSH_CONNECTION"))

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -3,7 +3,6 @@ import warnings
 from typing import Callable
 
 import click
-import jmespath
 
 # Format Enum for output formatting
 # could use a namedtuple, but that's overkill
@@ -81,6 +80,8 @@ def format_option(f: Callable) -> Callable:
     def jmespath_callback(ctx, param, value):
         if value is None:
             return
+
+        import jmespath
 
         state = ctx.ensure_object(CommandState)
         state.jmespath_expr = jmespath.compile(value)

--- a/src/globus_cli/services/transfer/delegate_proxy.py
+++ b/src/globus_cli/services/transfer/delegate_proxy.py
@@ -3,10 +3,6 @@ import os
 import re
 import struct
 
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes, serialization
-
 
 def fill_delegate_proxy_activation_requirements(
     requirements_data, cred_file, lifetime_hours=12
@@ -54,6 +50,10 @@ def create_proxy_credentials(issuer_cred, public_key, lifetime_hours):
     proxy lifetime, returns credentials as a unicode string in PEM format
     containing a new proxy certificate and an extended proxy chain.
     """
+
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+
     # parse the issuer credential
     loaded_cert, loaded_private_key, issuer_chain = parse_issuer_cred(issuer_cred)
 
@@ -94,6 +94,10 @@ def parse_issuer_cred(issuer_cred):
     Returns the issuer cert and private key as loaded cryptography objects
     and the proxy chain as a potentially empty string.
     """
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+
     # get each section of the PEM file
     sections = re.findall(
         "-----BEGIN.*?-----.*?-----END.*?-----", issuer_cred, flags=re.DOTALL
@@ -143,6 +147,10 @@ def create_proxy_cert(
     a private_key, and an int for lifetime in hours, creates a proxy
     cert from the issuer and public key signed by the private key.
     """
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import hashes
+
     builder = x509.CertificateBuilder()
 
     # create a serial number for the new proxy
@@ -204,6 +212,8 @@ def confirm_not_old_proxy(loaded_cert):
     Given a cryptography object for the issuer cert, checks if the cert is
     an "old proxy" and raise an error if so.
     """
+    from cryptography import x509
+
     # Examine the last CommonName to see if it looks like an old proxy.
     last_cn = loaded_cert.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[
         -1
@@ -221,6 +231,8 @@ def validate_key_usage(loaded_cert):
     the keyUsage extension is being used that the digital signature
     bit has been asserted. (As specified in RFC 3820 section 3.1.)
     """
+    from cryptography import x509
+
     try:
         key_usage = loaded_cert.extensions.get_extension_for_oid(
             x509.oid.ExtensionOID.KEY_USAGE

--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from distutils.util import strtobool
 from typing import Optional
 
 import click
@@ -75,6 +74,8 @@ def env_interactive() -> Optional[bool]:
     Check the `GLOBUS_CLI_INTERACTIVE` environment variable for a boolean, and *let*
     `strtobool` raise a `ValueError` if it doesn't parse.
     """
+    from distutils.util import strtobool
+
     explicit_val = os.getenv("GLOBUS_CLI_INTERACTIVE")
     if explicit_val is None:
         return None

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -1,6 +1,4 @@
-import inspect
 import json
-import shlex
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TextIO, cast
 
 import click
@@ -20,6 +18,8 @@ def get_current_option_help(
 
 
 def supported_parameters(c: Callable) -> List[str]:
+    import inspect
+
     sig = inspect.signature(c)
     return list(sig.parameters.keys())
 
@@ -170,6 +170,8 @@ def shlex_process_stream(process_command: click.Command, stream: TextIO) -> None
     processing single lines of input. helptext is prepended to the standard
     message printed to interactive sessions.
     """
+    import shlex
+
     # use readlines() rather than implicit file read line looping to force
     # python to properly capture EOF (otherwise, EOF acts as a flush and
     # things get weird)

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -1,5 +1,7 @@
-from distutils.version import LooseVersion
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
+
+if TYPE_CHECKING:
+    from distutils.version import LooseVersion
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
@@ -10,7 +12,7 @@ app_name = f"Globus CLI v{__version__}"
 
 
 # pull down version data from PyPi
-def get_versions() -> Tuple[Optional[LooseVersion], LooseVersion]:
+def get_versions() -> Tuple[Optional["LooseVersion"], "LooseVersion"]:
     """
     Wrap in a function to ensure that we don't run this every time a CLI
     command runs or when version number is loaded by setuptools.
@@ -20,6 +22,8 @@ def get_versions() -> Tuple[Optional[LooseVersion], LooseVersion]:
     # import in the func (rather than top-level scope) so that at setup time,
     # `requests` isn't required -- otherwise, setuptools will fail to run
     # because it isn't installed yet.
+    from distutils.version import LooseVersion
+
     import requests
 
     try:


### PR DESCRIPTION
This relates very closely to https://github.com/globus/globus-sdk-python/pull/560 . Ideally, both improvements are combined when testing, resulting in the most significant possible performance improvement for commands like `globus --help` and tab completion.

---

Defer imports of the following stdlib modules until they are needed:

- webbrowser
- http.client
- http.server
- distutils
- shlex
- inspect
- pathlib
- configparser

And defer imports of the following 3rd party modules:

- jmespath
- cryptography

In concert with partial lazy importing in globus-sdk, this results in a dramatic improvement in the responsiveness of many commands. `globus --help` times fall as much as 80% , and completion becomes significantly more responsive without a deeper and more complex refactor (e.g. lazily loaded subcommands).