### PR TITLE
Add support for 'localsdk' tox factor + env var

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,25 @@ minversion = 3.0.0
 [testenv]
 usedevelop = true
 extras = development
+passenv = GLOBUS_SDK_PATH
 deps =
     mindeps: click==8.0.0
     mindeps: requests==2.19.1
     mindeps: pyjwt==2.0.0
     mindeps: cryptography==2.0
     sdkmain: https://github.com/globus/globus-sdk-python/archive/main.tar.gz
-commands = pytest --cov-append --cov-report= {posargs}
+# the 'localsdk' factor allows CLI tests to be run against a local repo copy of globus-sdk
+# it requires that the GLOBUS_SDK_PATH env var is set and uses subprocess and os to pass it as
+# an argument to 'pip'
+#
+# This is unfortunately necessary: tox does not expand env vars in commands
+#
+# usage examples:
+#   GLOBUS_SDK_PATH=../globus-sdk tox -e py310-localsdk
+#   GLOBUS_SDK_PATH=../globus-sdk tox -e 'py{37,38,39,310}-localsdk
+commands =
+    localsdk: python -c 'import os, subprocess, sys; subprocess.run([sys.executable, "-m", "pip", "install", "-e", os.environ["GLOBUS_SDK_PATH"]])'
+    pytest --cov-append --cov-report= {posargs}
 depends =
     {py36-mindeps,py36,py37,py38,py39}: cov-clean
     cov-report: py36-mindeps,py36,py37,py38,py39


### PR DESCRIPTION
For testing against a local copy of the SDK repo.

Usage is like so:

    GLOBUS_SDK_PATH=../globus-sdk tox -e py39-localsdk

I refrained from adding a make target or anything else. You can also run a matrix as in

    tox -e 'py{37,38,39,310}-localsdk'