### PR TITLE
Fix `globus api` to respect format args

### DIFF
--- a/changelog.d/20220520_202320_sirosen_fix_jq_on_api.md
+++ b/changelog.d/20220520_202320_sirosen_fix_jq_on_api.md
@@ -1,0 +1,5 @@
+### Bugfixes
+
+* Fix behavior of `globus api` to respect formatting options. `--jmespath` can
+  be used on results, and `-Fjson` will pretty-print JSON responses if the
+  original response body is compact JSON

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -7,6 +7,7 @@ import globus_sdk
 from globus_cli import termio, version
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, group, mutex_option_group
+from globus_cli.termio import formatted_print
 
 
 class QueryParamType(click.ParamType):
@@ -90,7 +91,10 @@ def print_error_or_response(
     if isinstance(data, globus_sdk.GlobusAPIError):
         click.echo(data.raw_text)
     else:
-        click.echo(data.text)
+        # however, we will pass this through formatted_print using 'simple_text' to get
+        # the right semantics
+        # specifically: respect `--jmespath` and pretty-print JSON if `-Fjson` is used
+        formatted_print(data, simple_text=data.text)
 
 
 _SERVICE_MAP = {

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -19,3 +19,17 @@ def test_api_command_get(run_line, service_name, is_error_response):
         + (["--no-retry", "--allow-errors"] if is_error_response else [])
     )
     assert result.output == '{"foo": "bar"}\n'
+
+
+def test_api_command_can_use_jmespath(run_line):
+    load_response(
+        RegisteredResponse(
+            service="transfer",
+            status=200,
+            path="/foo",
+            json={"foo": "bar"},
+        )
+    )
+
+    result = run_line(["globus", "api", "transfer", "get", "/foo", "--jmespath", "foo"])
+    assert result.output == '"bar"\n'


### PR DESCRIPTION
`globus api ... --jq '...'` was not applying the jmespath expression to the response data. This is a side-effect of it using `click.echo` directly and bypassing the response formatter.

This only applies to success-case output. In the failure case, nothing extra is done.