### PR TITLE
Increase output width of all commands

### DIFF
--- a/changelog.d/20220523_140701_rudyardrichter.md
+++ b/changelog.d/20220523_140701_rudyardrichter.md
@@ -1,0 +1,3 @@
+### Other
+
+* Increase the maximum width of help output to 80% of the terminal size.

--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -8,6 +8,7 @@ and all other components will be hidden internals.
 
 import logging
 import sys
+from shutil import get_terminal_size
 from typing import List
 
 import click
@@ -51,6 +52,15 @@ class GlobusCommand(click.Command):
             kwargs["help"] = helptext.format(
                 AUTOMATIC_ACTIVATION=self.AUTOMATIC_ACTIVATION_HELPTEXT
             )
+        if "context_settings" not in kwargs:
+            kwargs["context_settings"] = {}
+        if "max_content_width" not in kwargs["context_settings"]:
+            try:
+                cols = get_terminal_size(fallback=(80, 20)).columns
+                content_width = cols if cols < 100 else int(0.8 * cols)
+                kwargs["context_settings"]["max_content_width"] = content_width
+            except OSError:
+                pass
         super().__init__(*args, **kwargs)
 
     def invoke(self, ctx):


### PR DESCRIPTION
Use the `context_settings` argument to `click.Command` to adjust max content width to 80% of the terminal size.