### PR TITLE
Eliminate a warning about _custom_text_formatter

### DIFF
--- a/src/globus_cli/termio/output_formatter.py
+++ b/src/globus_cli/termio/output_formatter.py
@@ -285,6 +285,8 @@ def formatted_print(
         elif text_format == FORMAT_TEXT_RAW:
             click.echo(data)
         elif text_format == FORMAT_TEXT_CUSTOM:
+            # _custom_text_formatter is set along with FORMAT_TEXT_CUSTOM
+            assert _custom_text_formatter
             _custom_text_formatter(data)
 
         # if there's an epilog, print it after any text


### PR DESCRIPTION
Pyright, which I'm using as an LSP extension, issues the warning here: `Object of type "None" cannot be called`. (I'm not certain if this corresponds to some stricter mypy setting?) In any case it's easy to eliminate & document the logic.