### PR TITLE
Lazily load SDK components and other imports for speed

### DIFF
--- a/changelog.d/20220602_153909_sirosen_half_lazy_imports.md
+++ b/changelog.d/20220602_153909_sirosen_half_lazy_imports.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* The globus CLI is now faster to start in many cases. Tab completions are most
+  significantly improved, but other commands may demonstrate an improvement as
+  well

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,11 @@ exclude = .git,.tox,__pycache__,.eggs,dist,venv,.venv*,venv27,virtualenv,adoc,bu
 max-line-length = 88
 ignore = W503,W504,E203
 
+[flake8:local-plugins]
+extension =
+    CLI = globus_cli_flake8:Plugin
+paths = ./src/globus_cli/
+
 
 [tool:pytest]
 addopts = --cov=src --no-cov-on-fail --timeout 3

--- a/src/globus_cli/commands/_common.py
+++ b/src/globus_cli/commands/_common.py
@@ -1,14 +1,16 @@
 import sys
+from typing import TYPE_CHECKING
 
 import click
 
 from globus_cli.termio import FORMAT_SILENT, formatted_print
 
-from ..services.transfer import CustomTransferClient
+if TYPE_CHECKING:
+    from ..services.transfer import CustomTransferClient
 
 
 def transfer_task_wait_with_io(
-    transfer_client: CustomTransferClient,
+    transfer_client: "CustomTransferClient",
     meow,
     heartbeat,
     polling_interval,

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -109,7 +109,7 @@ _SERVICE_MAP = {
 
 def _get_client(
     login_manager: LoginManager, service_name: str
-) -> globus_sdk.BaseClient:
+) -> "globus_sdk.BaseClient":
     if service_name == "auth":
         return login_manager.get_auth_client()
     elif service_name == "groups":

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -109,7 +109,7 @@ _SERVICE_MAP = {
 
 def _get_client(
     login_manager: LoginManager, service_name: str
-) -> "globus_sdk.BaseClient":
+) -> globus_sdk.BaseClient:
     if service_name == "auth":
         return login_manager.get_auth_client()
     elif service_name == "groups":

--- a/src/globus_cli/commands/bookmark/list.py
+++ b/src/globus_cli/commands/bookmark/list.py
@@ -1,11 +1,7 @@
-from globus_sdk import TransferAPIError
+import globus_sdk
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import (
-    display_name_or_cname,
-    iterable_response_to_dict,
-)
 from globus_cli.termio import formatted_print
 
 
@@ -37,6 +33,11 @@ $ globus bookmark list --jmespath='DATA[*].[name, endpoint_id]' --format=unix
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def bookmark_list(*, login_manager: LoginManager):
     """List all bookmarks for the current user"""
+    from globus_cli.services.transfer import (
+        display_name_or_cname,
+        iterable_response_to_dict,
+    )
+
     transfer_client = login_manager.get_transfer_client()
 
     bookmark_iterator = transfer_client.bookmark_list()
@@ -46,7 +47,7 @@ def bookmark_list(*, login_manager: LoginManager):
         try:
             ep_doc = transfer_client.get_endpoint(ep_id)
             return display_name_or_cname(ep_doc)
-        except TransferAPIError as err:
+        except globus_sdk.TransferAPIError as err:
             if err.code == "EndpointDeleted":
                 return "[DELETED ENDPOINT]"
             else:

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -3,36 +3,40 @@ import click
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import collection_id_arg, command
 from globus_cli.principal_resolver import default_identity_id_resolver
-from globus_cli.services.gcs import connector_id_to_display_name
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 from globus_cli.types import FIELD_LIST_T
 from globus_cli.utils import filter_fields, sorted_json_field
 
-STANDARD_FIELDS: FIELD_LIST_T = [
-    ("Display Name", "display_name"),
-    ("Owner", default_identity_id_resolver.field),
-    ("ID", "id"),
-    ("Collection Type", "collection_type"),
-    ("Storage Gateway ID", "storage_gateway_id"),
-    ("Connector", lambda x: connector_id_to_display_name(x["connector_id"])),
-    ("Allow Guest Collections", "allow_guest_collections"),
-    ("Disable Anonymous Writes", "disable_anonymous_writes"),
-    ("High Assurance", "high_assurance"),
-    ("Authentication Timeout", "authentication_timeout_mins"),
-    ("Multi-factor Authentication", "require_mfa"),
-    ("Manager URL", "manager_url"),
-    ("HTTPS URL", "https_url"),
-    ("TLSFTP URL", "tlsftp_url"),
-    ("Force Encryption", "force_encryption"),
-    ("Public", "public"),
-    ("Organization", "organization"),
-    ("Department", "department"),
-    ("Keywords", "keywords"),
-    ("Description", "description"),
-    ("Contact E-mail", "contact_email"),
-    ("Contact Info", "contact_info"),
-    ("Collection Info Link", "info_link"),
-]
+
+def _get_standard_fields() -> FIELD_LIST_T:
+    from globus_cli.services.gcs import connector_id_to_display_name
+
+    return [
+        ("Display Name", "display_name"),
+        ("Owner", default_identity_id_resolver.field),
+        ("ID", "id"),
+        ("Collection Type", "collection_type"),
+        ("Storage Gateway ID", "storage_gateway_id"),
+        ("Connector", lambda x: connector_id_to_display_name(x["connector_id"])),
+        ("Allow Guest Collections", "allow_guest_collections"),
+        ("Disable Anonymous Writes", "disable_anonymous_writes"),
+        ("High Assurance", "high_assurance"),
+        ("Authentication Timeout", "authentication_timeout_mins"),
+        ("Multi-factor Authentication", "require_mfa"),
+        ("Manager URL", "manager_url"),
+        ("HTTPS URL", "https_url"),
+        ("TLSFTP URL", "tlsftp_url"),
+        ("Force Encryption", "force_encryption"),
+        ("Public", "public"),
+        ("Organization", "organization"),
+        ("Department", "department"),
+        ("Keywords", "keywords"),
+        ("Description", "description"),
+        ("Contact E-mail", "contact_email"),
+        ("Contact Info", "contact_info"),
+        ("Collection Info Link", "info_link"),
+    ]
+
 
 PRIVATE_FIELDS: FIELD_LIST_T = [
     ("Root Path", "root_path"),
@@ -65,7 +69,7 @@ def collection_show(
     gcs_client = login_manager.get_gcs_client(collection_id=collection_id)
 
     query_params = {}
-    fields: FIELD_LIST_T = STANDARD_FIELDS
+    fields: FIELD_LIST_T = _get_standard_fields()
 
     if include_private_policies:
         query_params["include"] = "private_policies"

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import click
-from globus_sdk import GuestCollectionDocument, MappedCollectionDocument
+import globus_sdk
 
 from globus_cli import utils
 from globus_cli.constants import EXPLICIT_NULL
@@ -213,10 +213,11 @@ def collection_update(
 
     if gcs_client.source_epish.ep_type == EndpointType.GUEST_COLLECTION:
         doc_class: (
-            type[GuestCollectionDocument] | type[MappedCollectionDocument]
-        ) = GuestCollectionDocument
+            type[globus_sdk.GuestCollectionDocument]
+            | type[globus_sdk.MappedCollectionDocument]
+        ) = globus_sdk.GuestCollectionDocument
     else:
-        doc_class = MappedCollectionDocument
+        doc_class = globus_sdk.MappedCollectionDocument
 
     # convert keyword args as follows:
     # - filter out Nones

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -1,5 +1,5 @@
 import click
-from globus_sdk import DeleteData
+import globus_sdk
 
 from globus_cli import utils
 from globus_cli.login_manager import LoginManager
@@ -10,7 +10,6 @@ from globus_cli.parsing import (
     delete_and_rm_options,
     task_submission_options,
 )
-from globus_cli.services.transfer import autoactivate
 from globus_cli.termio import (
     FORMAT_TEXT_RECORD,
     err_is_terminal,
@@ -119,6 +118,8 @@ def delete_command(
 
     {AUTOMATIC_ACTIVATION}
     """
+    from globus_cli.services.transfer import autoactivate
+
     endpoint_id, path = endpoint_plus_path
     if path is None and (not batch):
         raise click.UsageError("delete requires either a PATH OR --batch")
@@ -129,7 +130,7 @@ def delete_command(
     if not skip_activation_check:
         autoactivate(transfer_client, endpoint_id, if_expires_in=60)
 
-    delete_data = DeleteData(
+    delete_data = globus_sdk.DeleteData(
         transfer_client,
         endpoint_id,
         label=label,

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 import click
-from globus_sdk import GlobusHTTPResponse
-from globus_sdk.config import get_webapp_url
+import globus_sdk
 
 from globus_cli.login_manager import LoginManager, is_remote_session
 from globus_cli.parsing import command, endpoint_id_arg, mutex_option_group
-from globus_cli.services.transfer import (
-    activation_requirements_help_text,
-    fill_delegate_proxy_activation_requirements,
-)
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -173,6 +168,11 @@ def endpoint_activate(
     user the error will not be detected until the user attempts to perform an
     operation on the endpoint.
     """
+    from globus_cli.services.transfer import (
+        activation_requirements_help_text,
+        fill_delegate_proxy_activation_requirements,
+    )
+
     transfer_client = login_manager.get_transfer_client()
 
     # validate options
@@ -197,7 +197,7 @@ def endpoint_activate(
     # check if endpoint is already activated unless --force
     if not force:
         res: (
-            dict[str, str] | GlobusHTTPResponse
+            dict[str, str] | globus_sdk.GlobusHTTPResponse
         ) = transfer_client.endpoint_autoactivate(endpoint_id, if_expires_in=60)
 
         if "AlreadyActivated" == res["code"]:
@@ -277,6 +277,8 @@ def endpoint_activate(
     # web activation
     elif web:
         import webbrowser
+
+        from globus_sdk.config import get_webapp_url
 
         url = f"{get_webapp_url()}file-manager?origin_id={endpoint_id}"
         if no_browser or is_remote_session():

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import webbrowser
-
 import click
 from globus_sdk import GlobusHTTPResponse
 from globus_sdk.config import get_webapp_url
@@ -278,6 +276,8 @@ def endpoint_activate(
 
     # web activation
     elif web:
+        import webbrowser
+
         url = f"{get_webapp_url()}file-manager?origin_id={endpoint_id}"
         if no_browser or is_remote_session():
             res = {"message": f"Web activation url: {url}", "url": url}

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -9,7 +9,6 @@ from globus_cli.parsing import (
     mutex_option_group,
     one_use_option,
 )
-from globus_cli.services.transfer import assemble_generic_doc, autoactivate
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 from ._common import (
@@ -94,6 +93,8 @@ def endpoint_create(
     with the `--personal` flag, it returns a setup key which can be passed to
     Globus Connect Personal during setup.
     """
+    from globus_cli.services.transfer import assemble_generic_doc, autoactivate
+
     transfer_client = login_manager.get_transfer_client()
 
     endpoint_type = "personal" if personal else "server" if server else "shared"

--- a/src/globus_cli/commands/endpoint/is_activated.py
+++ b/src/globus_cli/commands/endpoint/is_activated.py
@@ -6,7 +6,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import activation_requirements_help_text
 from globus_cli.termio import formatted_print
 
 
@@ -98,6 +97,8 @@ def endpoint_is_activated(
     If the endpoint is not activated, this command will output a link for web
     activation, or you can use 'globus endpoint activate' to activate the endpoint.
     """
+    from globus_cli.services.transfer import activation_requirements_help_text
+
     transfer_client = login_manager.get_transfer_client()
     res = transfer_client.endpoint_get_activation_requirements(endpoint_id)
 

--- a/src/globus_cli/commands/endpoint/local_id.py
+++ b/src/globus_cli/commands/endpoint/local_id.py
@@ -1,5 +1,5 @@
 import click
-from globus_sdk import LocalGlobusConnectPersonal
+import globus_sdk
 
 from globus_cli.parsing import command, one_use_option
 
@@ -54,7 +54,7 @@ def local_id(personal: bool) -> None:
     """
     if personal:
         try:
-            ep_id = LocalGlobusConnectPersonal().endpoint_id
+            ep_id = globus_sdk.LocalGlobusConnectPersonal().endpoint_id
         except OSError as e:
             click.echo(e, err=True)
             click.get_current_context().exit(1)

--- a/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
+++ b/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
@@ -1,6 +1,5 @@
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import ENDPOINT_LIST_FIELDS
 from globus_cli.termio import formatted_print
 
 
@@ -21,6 +20,8 @@ def my_shared_endpoint_list(*, login_manager: LoginManager, endpoint_id: str) ->
     Show a list of all shared endpoints hosted on the target endpoint for which the user
     has the "administrator" or "access_manager" effective roles.
     """
+    from globus_cli.services.transfer import ENDPOINT_LIST_FIELDS
+
     transfer_client = login_manager.get_transfer_client()
     ep_iterator = transfer_client.my_shared_endpoint_list(endpoint_id)
 

--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -2,7 +2,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command, security_principal_opts
-from globus_cli.services.transfer import assemble_generic_doc
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 
@@ -67,6 +66,8 @@ def create_command(
     '--anonymous', '--group', or '--identity' is required to know to whom permissions
     are being granted.
     """
+    from globus_cli.services.transfer import assemble_generic_doc
+
     endpoint_id, path = endpoint_plus_path
     principal_type, principal_val = principal
 

--- a/src/globus_cli/commands/endpoint/permission/list.py
+++ b/src/globus_cli/commands/endpoint/permission/list.py
@@ -1,4 +1,4 @@
-from globus_sdk import IdentityMap
+import globus_sdk
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
@@ -24,7 +24,7 @@ def list_command(*, login_manager: LoginManager, endpoint_id):
 
     rules = transfer_client.endpoint_acl_list(endpoint_id)
 
-    resolved_ids = IdentityMap(
+    resolved_ids = globus_sdk.IdentityMap(
         auth_client,
         (x["principal"] for x in rules if x["principal_type"] == "identity"),
     )

--- a/src/globus_cli/commands/endpoint/permission/update.py
+++ b/src/globus_cli/commands/endpoint/permission/update.py
@@ -2,7 +2,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import assemble_generic_doc
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -35,6 +34,8 @@ def update_command(*, login_manager: LoginManager, permissions, rule_id, endpoin
     The --permissions option is required, as it is currently the only field
     that can be updated.
     """
+    from globus_cli.services.transfer import assemble_generic_doc
+
     transfer_client = login_manager.get_transfer_client()
 
     rule_data = assemble_generic_doc("access", permissions=permissions)

--- a/src/globus_cli/commands/endpoint/role/create.py
+++ b/src/globus_cli/commands/endpoint/role/create.py
@@ -2,7 +2,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg, security_principal_opts
-from globus_cli.services.transfer import assemble_generic_doc
 from globus_cli.termio import formatted_print
 
 
@@ -46,6 +45,8 @@ def role_create(*, login_manager: LoginManager, role, principal, endpoint_id):
     The term "Principal" is used in the sense of "a security principal", an entity
     which has some privileges associated with it.
     """
+    from globus_cli.services.transfer import assemble_generic_doc
+
     principal_type, principal_val = principal
 
     transfer_client = login_manager.get_transfer_client()

--- a/src/globus_cli/commands/endpoint/role/list.py
+++ b/src/globus_cli/commands/endpoint/role/list.py
@@ -1,4 +1,4 @@
-from globus_sdk import IdentityMap
+import globus_sdk
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
@@ -38,7 +38,7 @@ def role_list(*, login_manager: LoginManager, endpoint_id):
     transfer_client = login_manager.get_transfer_client()
     roles = transfer_client.endpoint_role_list(endpoint_id)
 
-    resolved_ids = IdentityMap(
+    resolved_ids = globus_sdk.IdentityMap(
         login_manager.get_auth_client(),
         (x["principal"] for x in roles if x["principal_type"] == "identity"),
     )

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -4,7 +4,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import ENDPOINT_LIST_FIELDS, iterable_response_to_dict
 from globus_cli.termio import formatted_print
 from globus_cli.utils import PagingWrapper
 
@@ -84,6 +83,11 @@ def endpoint_search(
     legacy name, description, organization, department, keywords) that match the
     search text will be returned. The result size limit is 100 endpoints.
     """
+    from globus_cli.services.transfer import (
+        ENDPOINT_LIST_FIELDS,
+        iterable_response_to_dict,
+    )
+
     if filter_scope == "all" and not filter_fulltext:
         raise click.UsageError(
             "When searching all endpoints (--filter-scope=all, the default), "

--- a/src/globus_cli/commands/endpoint/server/add.py
+++ b/src/globus_cli/commands/endpoint/server/add.py
@@ -1,6 +1,5 @@
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import assemble_generic_doc
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 from ._common import server_add_and_update_opts
@@ -37,6 +36,8 @@ def server_add(
 
     An endpoint must be a Globus Connect Server endpoint to have servers.
     """
+    from globus_cli.services.transfer import assemble_generic_doc
+
     transfer_client = login_manager.get_transfer_client()
 
     server_doc = assemble_generic_doc(

--- a/src/globus_cli/commands/endpoint/server/list.py
+++ b/src/globus_cli/commands/endpoint/server/list.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from globus_sdk import GlobusHTTPResponse
+import globus_sdk
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
@@ -28,7 +28,9 @@ def server_list(*, login_manager: LoginManager, endpoint_id):
     # raises usage error on shares for us
     endpoint_w_server_list = transfer_client.get_endpoint_w_server_list(endpoint_id)
     endpoint = endpoint_w_server_list[0]
-    server_list: (str | dict[str, Any] | GlobusHTTPResponse) = endpoint_w_server_list[1]
+    server_list: (
+        str | dict[str, Any] | globus_sdk.GlobusHTTPResponse
+    ) = endpoint_w_server_list[1]
 
     if server_list == "S3":  # not GCS -- this is an S3 endpoint
         server_list = {"s3_url": endpoint["s3_url"]}

--- a/src/globus_cli/commands/endpoint/server/update.py
+++ b/src/globus_cli/commands/endpoint/server/update.py
@@ -1,6 +1,5 @@
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import assemble_generic_doc
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 from ._common import server_add_and_update_opts, server_id_arg
@@ -40,6 +39,8 @@ def server_update(
 
     At least one field must be updated.
     """
+    from globus_cli.services.transfer import assemble_generic_doc
+
     transfer_client = login_manager.get_transfer_client()
 
     server_doc = assemble_generic_doc(

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -1,7 +1,6 @@
 from globus_cli.endpointish import Endpointish
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import assemble_generic_doc
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 from ._common import (
@@ -16,6 +15,8 @@ from ._common import (
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_update(*, login_manager: LoginManager, **kwargs):
     """Update attributes of an endpoint"""
+    from globus_cli.services.transfer import assemble_generic_doc
+
     transfer_client = login_manager.get_transfer_client()
     endpoint_id = kwargs.pop("endpoint_id")
 

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -4,9 +4,25 @@ import functools
 from typing import Callable
 
 import click
-import globus_sdk
 
-MEMBERSHIP_FIELDS = {x.value for x in globus_sdk.GroupRequiredSignupFields}
+# cannot do this because it causes immediate imports and ruins the lazy import
+# performance gain
+#
+# MEMBERSHIP_FIELDS = {x.value for x in globus_sdk.GroupRequiredSignupFields}
+MEMBERSHIP_FIELDS = {
+    "institution",
+    "current_project_name",
+    "address",
+    "city",
+    "state",
+    "country",
+    "address1",
+    "address2",
+    "zip",
+    "phone",
+    "department",
+    "field_of_science",
+}
 
 
 def group_id_arg(f: Callable | None = None):

--- a/src/globus_cli/commands/group/invite/_common.py
+++ b/src/globus_cli/commands/group/invite/_common.py
@@ -21,10 +21,10 @@ else:
 
 def get_invite_formatter(
     case: Literal["accept", "decline"]
-) -> Callable[["globus_sdk.GlobusHTTPResponse"], None]:
+) -> Callable[[globus_sdk.GlobusHTTPResponse], None]:
     action_word = "Accepted" if case == "accept" else "Declined"
 
-    def formatter(data: "globus_sdk.GlobusHTTPResponse") -> None:
+    def formatter(data: globus_sdk.GlobusHTTPResponse) -> None:
         values = [f"{x['identity_id']} ({x['username']})" for x in data[case]]
         if len(values) == 1:
             click.echo(f"{action_word} invitation as {values[0]}")
@@ -37,8 +37,8 @@ def get_invite_formatter(
 
 
 def build_invite_actions(
-    auth_client: "CustomAuthClient",
-    groups_client: "globus_sdk.GroupsClient",
+    auth_client: CustomAuthClient,
+    groups_client: globus_sdk.GroupsClient,
     action: Literal["accept", "decline"],
     group_id: uuid.UUID,
     identity: ParsedIdentity | None,

--- a/src/globus_cli/commands/group/invite/_common.py
+++ b/src/globus_cli/commands/group/invite/_common.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import sys
 import uuid
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import click
-import globus_sdk
 
 from globus_cli.parsing import ParsedIdentity
-from globus_cli.services.auth import CustomAuthClient
+
+if TYPE_CHECKING:
+    import globus_sdk
+
+    from globus_cli.services.auth import CustomAuthClient
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -18,10 +21,10 @@ else:
 
 def get_invite_formatter(
     case: Literal["accept", "decline"]
-) -> Callable[[globus_sdk.GlobusHTTPResponse], None]:
+) -> Callable[["globus_sdk.GlobusHTTPResponse"], None]:
     action_word = "Accepted" if case == "accept" else "Declined"
 
-    def formatter(data: globus_sdk.GlobusHTTPResponse) -> None:
+    def formatter(data: "globus_sdk.GlobusHTTPResponse") -> None:
         values = [f"{x['identity_id']} ({x['username']})" for x in data[case]]
         if len(values) == 1:
             click.echo(f"{action_word} invitation as {values[0]}")
@@ -34,8 +37,8 @@ def get_invite_formatter(
 
 
 def build_invite_actions(
-    auth_client: CustomAuthClient,
-    groups_client: globus_sdk.GroupsClient,
+    auth_client: "CustomAuthClient",
+    groups_client: "globus_sdk.GroupsClient",
     action: Literal["accept", "decline"],
     group_id: uuid.UUID,
     identity: ParsedIdentity | None,

--- a/src/globus_cli/commands/group/leave.py
+++ b/src/globus_cli/commands/group/leave.py
@@ -10,7 +10,7 @@ from globus_cli.parsing import IdentityType, ParsedIdentity, command
 from globus_cli.termio import formatted_print
 
 
-def group_leave_formatter(data: "globus_sdk.GlobusHTTPResponse") -> None:
+def group_leave_formatter(data: globus_sdk.GlobusHTTPResponse) -> None:
     if "errors" in data:
         click.echo("Encountered errors leaving group, partial success")
         for error_doc in data.get("errors", {}).get("leave", []):

--- a/src/globus_cli/commands/group/leave.py
+++ b/src/globus_cli/commands/group/leave.py
@@ -10,7 +10,7 @@ from globus_cli.parsing import IdentityType, ParsedIdentity, command
 from globus_cli.termio import formatted_print
 
 
-def group_leave_formatter(data: globus_sdk.GlobusHTTPResponse) -> None:
+def group_leave_formatter(data: "globus_sdk.GlobusHTTPResponse") -> None:
     if "errors" in data:
         click.echo("Encountered errors leaving group, partial success")
         for error_doc in data.get("errors", {}).get("leave", []):

--- a/src/globus_cli/commands/logout.py
+++ b/src/globus_cli/commands/logout.py
@@ -1,6 +1,5 @@
 import click
 import globus_sdk
-from globus_sdk import AuthAPIError
 
 from globus_cli.login_manager import (
     LoginManager,
@@ -79,7 +78,7 @@ def logout_command(*, login_manager: LoginManager, ignore_errors):
         username = login_manager.get_auth_client().oauth2_userinfo()[
             "preferred_username"
         ]
-    except AuthAPIError:
+    except globus_sdk.AuthAPIError:
         warnecho(
             "Unable to lookup username. You may not be logged in. "
             "Attempting logout anyway...\n"
@@ -98,7 +97,7 @@ def logout_command(*, login_manager: LoginManager, ignore_errors):
     if not is_client_login():
         try:
             delete_templated_client()
-        except AuthAPIError:
+        except globus_sdk.AuthAPIError:
             if not ignore_errors:
                 warnecho(
                     "Failure while deleting internal client. "

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -3,15 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 import click
-from globus_sdk.services.transfer.response import IterableTransferResponse
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_OPTPATH, command
-from globus_cli.services.transfer import (
-    RecursiveLsResponse,
-    autoactivate,
-    iterable_response_to_dict,
-)
 from globus_cli.termio import formatted_print, is_verbose, outformat_is_text
 
 
@@ -160,6 +154,14 @@ def ls_command(
 
     {AUTOMATIC_ACTIVATION}
     """
+    from globus_sdk.services.transfer.response import IterableTransferResponse
+
+    from globus_cli.services.transfer import (
+        RecursiveLsResponse,
+        autoactivate,
+        iterable_response_to_dict,
+    )
+
     endpoint_id, path = endpoint_plus_path
 
     # do autoactivation before the `ls` call so that recursive invocations

--- a/src/globus_cli/commands/mkdir.py
+++ b/src/globus_cli/commands/mkdir.py
@@ -2,7 +2,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command
-from globus_cli.services.transfer import autoactivate
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -25,6 +24,8 @@ def mkdir_command(*, login_manager: LoginManager, endpoint_plus_path):
 
     {AUTOMATIC_ACTIVATION}
     """
+    from globus_cli.services.transfer import autoactivate
+
     endpoint_id, path = endpoint_plus_path
 
     transfer_client = login_manager.get_transfer_client()

--- a/src/globus_cli/commands/rename.py
+++ b/src/globus_cli/commands/rename.py
@@ -2,7 +2,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
-from globus_cli.services.transfer import autoactivate
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
 
@@ -31,6 +30,8 @@ def rename_command(*, login_manager: LoginManager, endpoint_id, source, destinat
     The new path does not have to be in the same directory as the old path, but
     most endpoints will require it to stay on the same filesystem.
     """
+    from globus_cli.services.transfer import autoactivate
+
     transfer_client = login_manager.get_transfer_client()
     autoactivate(transfer_client, endpoint_id, if_expires_in=60)
 

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -1,5 +1,5 @@
 import click
-from globus_sdk import DeleteData
+import globus_sdk
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
@@ -9,7 +9,6 @@ from globus_cli.parsing import (
     synchronous_task_wait_options,
     task_submission_options,
 )
-from globus_cli.services.transfer import autoactivate
 from globus_cli.termio import err_is_terminal, formatted_print, term_is_interactive
 
 from ._common import transfer_task_wait_with_io
@@ -71,6 +70,8 @@ def rm_command(
 
     {AUTOMATIC_ACTIVATION}
     """
+    from globus_cli.services.transfer import autoactivate
+
     endpoint_id, path = endpoint_plus_path
 
     transfer_client = login_manager.get_transfer_client()
@@ -79,7 +80,7 @@ def rm_command(
     if not skip_activation_check:
         autoactivate(transfer_client, endpoint_id, if_expires_in=60)
 
-    delete_data = DeleteData(
+    delete_data = globus_sdk.DeleteData(
         transfer_client,
         endpoint_id,
         label=label,

--- a/src/globus_cli/commands/search/subject/show.py
+++ b/src/globus_cli/commands/search/subject/show.py
@@ -11,7 +11,7 @@ from globus_cli.termio import formatted_print
 from .._common import index_id_arg
 
 
-def _print_subject(subject_doc: globus_sdk.GlobusHTTPResponse):
+def _print_subject(subject_doc: "globus_sdk.GlobusHTTPResponse"):
     entries = subject_doc["entries"]
     if len(entries) == 1:
         click.echo(json.dumps(entries[0], indent=2, separators=(",", ": ")))

--- a/src/globus_cli/commands/task/event_list.py
+++ b/src/globus_cli/commands/task/event_list.py
@@ -5,7 +5,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import iterable_response_to_dict
 from globus_cli.termio import formatted_print
 from globus_cli.utils import PagingWrapper
 
@@ -65,6 +64,8 @@ def task_event_list(
     NOTE: Tasks older than one month may no longer have event log history. In this
     case, no events will be shown.
     """
+    from globus_cli.services.transfer import iterable_response_to_dict
+
     transfer_client = login_manager.get_transfer_client()
 
     # cannot filter by both errors and non errors

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -2,7 +2,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import iterable_response_to_dict
 from globus_cli.termio import formatted_print
 from globus_cli.utils import PagingWrapper
 
@@ -165,6 +164,7 @@ def task_list(
     This lists your most recent tasks. The tasks displayed may be filtered by a number
     of attributes, each with a separate commandline option.
     """
+    from globus_cli.services.transfer import iterable_response_to_dict
 
     def _process_filterval(prefix, value, default=None):
         if value:

--- a/src/globus_cli/commands/task/show.py
+++ b/src/globus_cli/commands/task/show.py
@@ -2,7 +2,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, mutex_option_group
-from globus_cli.services.transfer import iterable_response_to_dict
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 from ._common import task_id_arg
@@ -58,6 +57,8 @@ SKIPPED_PATHS_FIELDS = [
 
 
 def print_successful_transfers(client, task_id):
+    from globus_cli.services.transfer import iterable_response_to_dict
+
     res = client.paginated.task_successful_transfers(task_id).items()
     formatted_print(
         res,
@@ -67,6 +68,8 @@ def print_successful_transfers(client, task_id):
 
 
 def print_skipped_errors(client, task_id):
+    from globus_cli.services.transfer import iterable_response_to_dict
+
     res = client.paginated.task_skipped_errors(task_id).items()
     formatted_print(
         res,

--- a/src/globus_cli/commands/task/update.py
+++ b/src/globus_cli/commands/task/update.py
@@ -2,7 +2,6 @@ import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.services.transfer import assemble_generic_doc
 from globus_cli.termio import formatted_print
 
 from ._common import task_id_arg
@@ -34,6 +33,8 @@ def update_task(*, login_manager: LoginManager, deadline, label, task_id):
 
     If a Task has completed, these attributes may no longer be updated.
     """
+    from globus_cli.services.transfer import assemble_generic_doc
+
     transfer_client = login_manager.get_transfer_client()
 
     task_doc = assemble_generic_doc("task", label=label, deadline=deadline)

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import click
-from globus_sdk import TransferData
+import globus_sdk
 
 from globus_cli import utils
 from globus_cli.login_manager import LoginManager
@@ -12,7 +12,6 @@ from globus_cli.parsing import (
     mutex_option_group,
     task_submission_options,
 )
-from globus_cli.services.transfer import autoactivate
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 
@@ -315,6 +314,8 @@ def transfer_command(
 
     {AUTOMATIC_ACTIVATION}
     """
+    from globus_cli.services.transfer import autoactivate
+
     source_endpoint, cmd_source_path = source
     dest_endpoint, cmd_dest_path = destination
 
@@ -357,7 +358,7 @@ def transfer_command(
         filter_rules = None
 
     transfer_client = login_manager.get_transfer_client()
-    transfer_data = TransferData(
+    transfer_data = globus_sdk.TransferData(
         transfer_client,
         source_endpoint,
         dest_endpoint,

--- a/src/globus_cli/commands/update.py
+++ b/src/globus_cli/commands/update.py
@@ -1,6 +1,5 @@
 import atexit
 import os
-import pathlib
 import site
 import subprocess
 import sys
@@ -29,6 +28,8 @@ def _is_user_install() -> bool:
 # pipx home discovery extracted from pipx itself. see:
 #   https://github.com/pypa/pipx/blob/878f03504417fa4cc9a6676b1bc24aef2ba3e491/src/pipx/constants.py#L8
 def _is_pipx_install() -> bool:
+    import pathlib
+
     _DEFAULT_PIPX_HOME = pathlib.Path.home() / ".local/pipx"
     _PIPX_HOME = pathlib.Path(os.getenv("PIPX_HOME", _DEFAULT_PIPX_HOME)).resolve()
     return __file__.startswith(str(_PIPX_HOME))

--- a/src/globus_cli/commands/whoami.py
+++ b/src/globus_cli/commands/whoami.py
@@ -1,5 +1,5 @@
 import click
-from globus_sdk import AuthAPIError
+import globus_sdk
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
@@ -64,7 +64,7 @@ def whoami_command(*, login_manager, linked_identities):
     # if we get back an error the user likely needs to log in again
     try:
         res = auth_client.oauth2_userinfo()
-    except AuthAPIError:
+    except globus_sdk.AuthAPIError:
         click.echo(
             "Unable to get user information. Please try logging in again.", err=True
         )

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -20,11 +20,11 @@ def _pretty_json(data: dict, compact=False) -> str:
 
 
 @error_handler(
-    error_class=globus_sdk.GlobusAPIError,
+    error_class="GlobusAPIError",
     condition=lambda err: err.info.authorization_parameters,
     exit_status=4,
 )
-def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
+def session_hook(exception: "globus_sdk.GlobusAPIError") -> None:
     """
     Expects an exception with a valid authorization_paramaters info field
     """
@@ -57,11 +57,11 @@ def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
 
 
 @error_handler(
-    error_class=globus_sdk.GlobusAPIError,
+    error_class="GlobusAPIError",
     condition=lambda err: err.info.consent_required,
     exit_status=4,
 )
-def consent_required_hook(exception: globus_sdk.GlobusAPIError) -> None:
+def consent_required_hook(exception: "globus_sdk.GlobusAPIError") -> None:
     """
     Expects an exception with a required_scopes field in its raw_json
     """
@@ -121,8 +121,8 @@ def authentication_hook(
     )
 
 
-@error_handler(error_class=globus_sdk.TransferAPIError)
-def transferapi_hook(exception: globus_sdk.TransferAPIError) -> None:
+@error_handler(error_class="TransferAPIError")
+def transferapi_hook(exception: "globus_sdk.TransferAPIError") -> None:
     write_error_info(
         "Transfer API Error",
         [
@@ -135,10 +135,10 @@ def transferapi_hook(exception: globus_sdk.TransferAPIError) -> None:
 
 
 @error_handler(
-    error_class=globus_sdk.SearchAPIError,
+    error_class="SearchAPIError",
     condition=lambda err: err.code == "BadRequest.ValidationError",
 )
-def searchapi_validationerror_hook(exception: globus_sdk.SearchAPIError) -> None:
+def searchapi_validationerror_hook(exception: "globus_sdk.SearchAPIError") -> None:
     fields = [
         PrintableErrorField("HTTP status", exception.http_status),
         # FIXME: raw_json because SDK is not exposing `request_id` as an attribute
@@ -165,8 +165,8 @@ def searchapi_validationerror_hook(exception: globus_sdk.SearchAPIError) -> None
     write_error_info("Search API Error", fields)
 
 
-@error_handler(error_class=globus_sdk.SearchAPIError)
-def searchapi_hook(exception: globus_sdk.SearchAPIError) -> None:
+@error_handler(error_class="SearchAPIError")
+def searchapi_hook(exception: "globus_sdk.SearchAPIError") -> None:
     fields = [
         PrintableErrorField("HTTP status", exception.http_status),
         # FIXME: raw_json because SDK is not exposing `request_id` as an attribute
@@ -186,10 +186,10 @@ def searchapi_hook(exception: globus_sdk.SearchAPIError) -> None:
 
 
 @error_handler(
-    error_class=globus_sdk.AuthAPIError,
+    error_class="AuthAPIError",
     condition=lambda err: err.message == "invalid_grant",
 )
-def invalidrefresh_hook(exception: globus_sdk.AuthAPIError) -> None:
+def invalidrefresh_hook(exception: "globus_sdk.AuthAPIError") -> None:
     write_error_info(
         "Invalid Refresh Token",
         [
@@ -204,8 +204,8 @@ def invalidrefresh_hook(exception: globus_sdk.AuthAPIError) -> None:
     )
 
 
-@error_handler(error_class=globus_sdk.AuthAPIError)
-def authapi_hook(exception: globus_sdk.AuthAPIError) -> None:
+@error_handler(error_class="AuthAPIError")
+def authapi_hook(exception: "globus_sdk.AuthAPIError") -> None:
     write_error_info(
         "Auth API Error",
         [
@@ -216,8 +216,8 @@ def authapi_hook(exception: globus_sdk.AuthAPIError) -> None:
     )
 
 
-@error_handler(error_class=globus_sdk.GlobusAPIError)  # catch-all
-def globusapi_hook(exception: globus_sdk.GlobusAPIError) -> None:
+@error_handler(error_class="GlobusAPIError")  # catch-all
+def globusapi_hook(exception: "globus_sdk.GlobusAPIError") -> None:
     write_error_info(
         "Globus API Error",
         [
@@ -228,8 +228,8 @@ def globusapi_hook(exception: globus_sdk.GlobusAPIError) -> None:
     )
 
 
-@error_handler(error_class=globus_sdk.GlobusError)
-def globus_error_hook(exception: globus_sdk.GlobusError) -> None:
+@error_handler(error_class="GlobusError")
+def globus_error_hook(exception: "globus_sdk.GlobusError") -> None:
     write_error_info(
         "Globus Error",
         [

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -24,7 +24,7 @@ def _pretty_json(data: dict, compact=False) -> str:
     condition=lambda err: err.info.authorization_parameters,
     exit_status=4,
 )
-def session_hook(exception: "globus_sdk.GlobusAPIError") -> None:
+def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
     """
     Expects an exception with a valid authorization_paramaters info field
     """
@@ -61,7 +61,7 @@ def session_hook(exception: "globus_sdk.GlobusAPIError") -> None:
     condition=lambda err: err.info.consent_required,
     exit_status=4,
 )
-def consent_required_hook(exception: "globus_sdk.GlobusAPIError") -> None:
+def consent_required_hook(exception: globus_sdk.GlobusAPIError) -> None:
     """
     Expects an exception with a required_scopes field in its raw_json
     """
@@ -122,7 +122,7 @@ def authentication_hook(
 
 
 @error_handler(error_class="TransferAPIError")
-def transferapi_hook(exception: "globus_sdk.TransferAPIError") -> None:
+def transferapi_hook(exception: globus_sdk.TransferAPIError) -> None:
     write_error_info(
         "Transfer API Error",
         [
@@ -138,7 +138,7 @@ def transferapi_hook(exception: "globus_sdk.TransferAPIError") -> None:
     error_class="SearchAPIError",
     condition=lambda err: err.code == "BadRequest.ValidationError",
 )
-def searchapi_validationerror_hook(exception: "globus_sdk.SearchAPIError") -> None:
+def searchapi_validationerror_hook(exception: globus_sdk.SearchAPIError) -> None:
     fields = [
         PrintableErrorField("HTTP status", exception.http_status),
         # FIXME: raw_json because SDK is not exposing `request_id` as an attribute
@@ -166,7 +166,7 @@ def searchapi_validationerror_hook(exception: "globus_sdk.SearchAPIError") -> No
 
 
 @error_handler(error_class="SearchAPIError")
-def searchapi_hook(exception: "globus_sdk.SearchAPIError") -> None:
+def searchapi_hook(exception: globus_sdk.SearchAPIError) -> None:
     fields = [
         PrintableErrorField("HTTP status", exception.http_status),
         # FIXME: raw_json because SDK is not exposing `request_id` as an attribute
@@ -189,7 +189,7 @@ def searchapi_hook(exception: "globus_sdk.SearchAPIError") -> None:
     error_class="AuthAPIError",
     condition=lambda err: err.message == "invalid_grant",
 )
-def invalidrefresh_hook(exception: "globus_sdk.AuthAPIError") -> None:
+def invalidrefresh_hook(exception: globus_sdk.AuthAPIError) -> None:
     write_error_info(
         "Invalid Refresh Token",
         [
@@ -205,7 +205,7 @@ def invalidrefresh_hook(exception: "globus_sdk.AuthAPIError") -> None:
 
 
 @error_handler(error_class="AuthAPIError")
-def authapi_hook(exception: "globus_sdk.AuthAPIError") -> None:
+def authapi_hook(exception: globus_sdk.AuthAPIError) -> None:
     write_error_info(
         "Auth API Error",
         [
@@ -217,7 +217,7 @@ def authapi_hook(exception: "globus_sdk.AuthAPIError") -> None:
 
 
 @error_handler(error_class="GlobusAPIError")  # catch-all
-def globusapi_hook(exception: "globus_sdk.GlobusAPIError") -> None:
+def globusapi_hook(exception: globus_sdk.GlobusAPIError) -> None:
     write_error_info(
         "Globus API Error",
         [
@@ -229,7 +229,7 @@ def globusapi_hook(exception: "globus_sdk.GlobusAPIError") -> None:
 
 
 @error_handler(error_class="GlobusError")
-def globus_error_hook(exception: "globus_sdk.GlobusError") -> None:
+def globus_error_hook(exception: globus_sdk.GlobusError) -> None:
     write_error_info(
         "Globus Error",
         [

--- a/src/globus_cli/exception_handling/registry.py
+++ b/src/globus_cli/exception_handling/registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Callable, List, NoReturn, Tuple, Type, TypeVar, cast
+from typing import Callable, List, NoReturn, Tuple, Type, TypeVar, Union, cast
 
 import click
 import globus_sdk
@@ -16,7 +16,7 @@ _HOOK_SRC_TYPE = Callable[[E], None]
 CONDITION_TYPE = Callable[[E], bool]
 
 # must cast the registry to avoid type errors around List[<nothing>]
-_HOOKLIST_TYPE = List[Tuple[HOOK_TYPE, Type[Exception], CONDITION_TYPE]]
+_HOOKLIST_TYPE = List[Tuple[HOOK_TYPE, Union[str, Type[Exception]], CONDITION_TYPE]]
 _REGISTERED_HOOKS: _HOOKLIST_TYPE = cast(_HOOKLIST_TYPE, [])
 
 
@@ -50,7 +50,13 @@ def error_handler(
 
 def find_handler(exception: Exception) -> HOOK_TYPE | None:
     for handler, error_class, condition in _REGISTERED_HOOKS:
-        if error_class is not None and not isinstance(exception, error_class):
+        if isinstance(error_class, str):
+            error_class_: Type[Exception] = getattr(globus_sdk, error_class)
+            assert issubclass(error_class_, Exception)
+        else:
+            error_class_ = error_class
+
+        if error_class_ is not None and not isinstance(exception, error_class_):
             continue
         if condition is not None and not condition(exception):
             continue

--- a/src/globus_cli/exception_handling/registry.py
+++ b/src/globus_cli/exception_handling/registry.py
@@ -51,7 +51,7 @@ def error_handler(
 def find_handler(exception: Exception) -> HOOK_TYPE | None:
     for handler, error_class, condition in _REGISTERED_HOOKS:
         if isinstance(error_class, str):
-            error_class_: Type[Exception] = getattr(globus_sdk, error_class)
+            error_class_: type[Exception] = getattr(globus_sdk, error_class)
             assert issubclass(error_class_, Exception)
         else:
             error_class_ = error_class

--- a/src/globus_cli/globus_cli_flake8.py
+++ b/src/globus_cli/globus_cli_flake8.py
@@ -1,0 +1,43 @@
+# type: ignore
+"""
+A Flake8 Plugin for use in globus-cli
+"""
+
+import ast
+
+CODEMAP = {
+    "CLI001": "CLI001 import from globus_sdk module, defeats lazy importer",
+}
+
+
+class Plugin:
+    name = "globus-cli-flake8"
+    version = "0.0.1"
+
+    # args to init determine plugin behavior. see:
+    # https://flake8.pycqa.org/en/latest/internal/utils.html#flake8.utils.parameters_for
+    def __init__(self, tree):
+        self.tree = tree
+
+    # Plugin.run() is how checks will run. For detail, see implementation of:
+    # https://flake8.pycqa.org/en/latest/internal/checker.html#flake8.checker.FileChecker.run_ast_checks
+    def run(self):
+        visitor = ImportVisitor()
+        visitor.visit(self.tree)
+        for lineno, col, code in visitor.collect:
+            yield lineno, col, CODEMAP[code], type(self)
+
+
+class ErrorRecordingVisitor(ast.NodeVisitor):
+    def __init__(self):
+        super().__init__()
+        self.collect = []
+
+    def _record(self, node, code):
+        self.collect.append((node.lineno, node.col_offset, code))
+
+
+class ImportVisitor(ErrorRecordingVisitor):
+    def visit_ImportFrom(self, node):  # a `from globus_sdk import ...` clause
+        if node.module == "globus_sdk":
+            self._record(node, "CLI001")

--- a/src/globus_cli/login_manager/__init__.py
+++ b/src/globus_cli/login_manager/__init__.py
@@ -1,6 +1,5 @@
 from .client_login import get_client_login, is_client_login
 from .errors import MissingLoginError
-from .local_server import is_remote_session
 from .manager import LoginManager
 from .tokenstore import (
     delete_templated_client,
@@ -8,6 +7,7 @@ from .tokenstore import (
     internal_native_client,
     token_storage_adapter,
 )
+from .utils import is_remote_session
 
 __all__ = [
     "MissingLoginError",

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -1,8 +1,5 @@
-import webbrowser
-
 import click
 
-from .local_server import LocalServerError, start_local_server
 from .tokenstore import internal_auth_client, token_storage_adapter
 
 _STORE_CONFIG_USERINFO = "auth_user_data"
@@ -50,6 +47,10 @@ def do_local_server_auth_flow(scopes, *, session_params=None):
     Starts a local http server, opens a browser to have the user authenticate,
     and gets the code redirected to the server (no copy and pasting required)
     """
+    import webbrowser
+
+    from .local_server import LocalServerError, start_local_server
+
     session_params = session_params or {}
 
     # start local server and create matching redirect_uri

--- a/src/globus_cli/login_manager/client_login.py
+++ b/src/globus_cli/login_manager/client_login.py
@@ -32,7 +32,7 @@ def is_client_login() -> bool:
         return bool(client_id) and bool(client_secret)
 
 
-def get_client_login() -> "globus_sdk.ConfidentialAppAuthClient":
+def get_client_login() -> globus_sdk.ConfidentialAppAuthClient:
     """
     Return the ConfidentialAppAuthClient for the client identity
     logged into the CLI

--- a/src/globus_cli/login_manager/client_login.py
+++ b/src/globus_cli/login_manager/client_login.py
@@ -32,7 +32,7 @@ def is_client_login() -> bool:
         return bool(client_id) and bool(client_secret)
 
 
-def get_client_login() -> globus_sdk.ConfidentialAppAuthClient:
+def get_client_login() -> "globus_sdk.ConfidentialAppAuthClient":
     """
     Return the ConfidentialAppAuthClient for the client identity
     logged into the CLI

--- a/src/globus_cli/login_manager/local_server.py
+++ b/src/globus_cli/login_manager/local_server.py
@@ -1,6 +1,5 @@
 import http.client
 import logging
-import os
 import queue
 import sys
 import threading
@@ -24,10 +23,6 @@ def enable_requests_logging():
     requests_log = logging.getLogger("requests.packages.urllib3")
     requests_log.setLevel(logging.DEBUG)
     requests_log.propagate = True
-
-
-def is_remote_session():
-    return os.environ.get("SSH_TTY", os.environ.get("SSH_CONNECTION"))
 
 
 class RedirectHandler(BaseHTTPRequestHandler):

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -254,23 +254,23 @@ class LoginManager:
                 on_refresh=self._token_storage.on_refresh,
             )
 
-    def get_transfer_client(self) -> "CustomTransferClient":
+    def get_transfer_client(self) -> CustomTransferClient:
         from ..services.transfer import CustomTransferClient
 
         authorizer = self._get_client_authorizer(TransferScopes.resource_server)
         return CustomTransferClient(authorizer=authorizer, app_name=version.app_name)
 
-    def get_auth_client(self) -> "CustomAuthClient":
+    def get_auth_client(self) -> CustomAuthClient:
         from ..services.auth import CustomAuthClient
 
         authorizer = self._get_client_authorizer(AuthScopes.resource_server)
         return CustomAuthClient(authorizer=authorizer, app_name=version.app_name)
 
-    def get_groups_client(self) -> "globus_sdk.GroupsClient":
+    def get_groups_client(self) -> globus_sdk.GroupsClient:
         authorizer = self._get_client_authorizer(GroupsScopes.resource_server)
         return globus_sdk.GroupsClient(authorizer=authorizer, app_name=version.app_name)
 
-    def get_search_client(self) -> "globus_sdk.SearchClient":
+    def get_search_client(self) -> globus_sdk.SearchClient:
         authorizer = self._get_client_authorizer(SearchScopes.resource_server)
         return globus_sdk.SearchClient(authorizer=authorizer, app_name=version.app_name)
 
@@ -305,7 +305,7 @@ class LoginManager:
         *,
         collection_id: uuid.UUID | None = None,
         endpoint_id: uuid.UUID | None = None,
-    ) -> "CustomGCSClient":
+    ) -> CustomGCSClient:
         from ..services.gcs import CustomGCSClient
 
         gcs_id, epish = self._get_gcs_info(

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import uuid
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 import click
 import globus_sdk
@@ -18,14 +18,16 @@ from globus_sdk.scopes import (
 from globus_cli.endpointish import Endpointish, EndpointType
 
 from .. import version
-from ..services.auth import CustomAuthClient
-from ..services.gcs import CustomGCSClient
-from ..services.transfer import CustomTransferClient
 from .auth_flows import do_link_auth_flow, do_local_server_auth_flow
 from .client_login import get_client_login, is_client_login
 from .errors import MissingLoginError
 from .tokenstore import internal_auth_client, token_storage_adapter
 from .utils import is_remote_session
+
+if TYPE_CHECKING:
+    from ..services.auth import CustomAuthClient
+    from ..services.gcs import CustomGCSClient
+    from ..services.transfer import CustomTransferClient
 
 
 class LoginManager:
@@ -252,19 +254,23 @@ class LoginManager:
                 on_refresh=self._token_storage.on_refresh,
             )
 
-    def get_transfer_client(self) -> CustomTransferClient:
+    def get_transfer_client(self) -> "CustomTransferClient":
+        from ..services.transfer import CustomTransferClient
+
         authorizer = self._get_client_authorizer(TransferScopes.resource_server)
         return CustomTransferClient(authorizer=authorizer, app_name=version.app_name)
 
-    def get_auth_client(self) -> CustomAuthClient:
+    def get_auth_client(self) -> "CustomAuthClient":
+        from ..services.auth import CustomAuthClient
+
         authorizer = self._get_client_authorizer(AuthScopes.resource_server)
         return CustomAuthClient(authorizer=authorizer, app_name=version.app_name)
 
-    def get_groups_client(self) -> globus_sdk.GroupsClient:
+    def get_groups_client(self) -> "globus_sdk.GroupsClient":
         authorizer = self._get_client_authorizer(GroupsScopes.resource_server)
         return globus_sdk.GroupsClient(authorizer=authorizer, app_name=version.app_name)
 
-    def get_search_client(self) -> globus_sdk.SearchClient:
+    def get_search_client(self) -> "globus_sdk.SearchClient":
         authorizer = self._get_client_authorizer(SearchScopes.resource_server)
         return globus_sdk.SearchClient(authorizer=authorizer, app_name=version.app_name)
 
@@ -299,7 +305,9 @@ class LoginManager:
         *,
         collection_id: uuid.UUID | None = None,
         endpoint_id: uuid.UUID | None = None,
-    ) -> CustomGCSClient:
+    ) -> "CustomGCSClient":
+        from ..services.gcs import CustomGCSClient
+
         gcs_id, epish = self._get_gcs_info(
             collection_id=collection_id, endpoint_id=endpoint_id
         )

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -24,8 +24,8 @@ from ..services.transfer import CustomTransferClient
 from .auth_flows import do_link_auth_flow, do_local_server_auth_flow
 from .client_login import get_client_login, is_client_login
 from .errors import MissingLoginError
-from .local_server import is_remote_session
 from .tokenstore import internal_auth_client, token_storage_adapter
+from .utils import is_remote_session
 
 
 class LoginManager:

--- a/src/globus_cli/login_manager/tokenstore.py
+++ b/src/globus_cli/login_manager/tokenstore.py
@@ -5,7 +5,6 @@ from typing import cast
 import globus_sdk
 from globus_sdk.tokenstorage import SQLiteAdapter
 
-from ._old_config import invalidate_old_config
 from .client_login import get_client_login, is_client_login
 
 # internal constants
@@ -111,6 +110,8 @@ def token_storage_adapter() -> SQLiteAdapter:
         # if it does not, then use this as a flag to clean the old config
         fname = _get_storage_filename()
         if not os.path.exists(fname):
+            from ._old_config import invalidate_old_config
+
             invalidate_old_config(internal_native_client())
         # namespace is equal to the current environment
         as_proto._instance = SQLiteAdapter(fname, namespace=_resolve_namespace())

--- a/src/globus_cli/login_manager/tokenstore.py
+++ b/src/globus_cli/login_manager/tokenstore.py
@@ -1,9 +1,11 @@
 import os
 import sys
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import globus_sdk
-from globus_sdk.tokenstorage import SQLiteAdapter
+
+if TYPE_CHECKING:
+    from globus_sdk.tokenstorage import SQLiteAdapter
 
 from .client_login import get_client_login, is_client_login
 
@@ -16,7 +18,7 @@ GLOBUS_ENV = os.environ.get("GLOBUS_SDK_ENVIRONMENT")
 
 # stub to allow type casting of a function to an object with an attribute
 class _TokenStoreFuncProto:
-    _instance: SQLiteAdapter
+    _instance: "SQLiteAdapter"
 
 
 def _template_client_id():
@@ -103,7 +105,9 @@ def _resolve_namespace():
         return "userprofile/" + env + (f"/{profile}" if profile else "")
 
 
-def token_storage_adapter() -> SQLiteAdapter:
+def token_storage_adapter() -> "SQLiteAdapter":
+    from globus_sdk.tokenstorage import SQLiteAdapter
+
     as_proto = cast(_TokenStoreFuncProto, token_storage_adapter)
     if not hasattr(as_proto, "_instance"):
         # when initializing the token storage adapter, check if the storage file exists

--- a/src/globus_cli/login_manager/utils.py
+++ b/src/globus_cli/login_manager/utils.py
@@ -1,0 +1,5 @@
+import os
+
+
+def is_remote_session():
+    return os.environ.get("SSH_TTY", os.environ.get("SSH_CONNECTION"))

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -3,7 +3,6 @@ import warnings
 from typing import Callable
 
 import click
-import jmespath
 
 # Format Enum for output formatting
 # could use a namedtuple, but that's overkill
@@ -81,6 +80,8 @@ def format_option(f: Callable) -> Callable:
     def jmespath_callback(ctx, param, value):
         if value is None:
             return
+
+        import jmespath
 
         state = ctx.ensure_object(CommandState)
         state.jmespath_expr = jmespath.compile(value)

--- a/src/globus_cli/principal_resolver.py
+++ b/src/globus_cli/principal_resolver.py
@@ -62,7 +62,7 @@ class PrincipalResolver:
         self._idmap: globus_sdk.IdentityMap | None = None
 
     @property
-    def idmap(self) -> "globus_sdk.IdentityMap":
+    def idmap(self) -> globus_sdk.IdentityMap:
         if not self._idmap:
             self._idmap = globus_sdk.IdentityMap(LoginManager().get_auth_client())
         return self._idmap

--- a/src/globus_cli/principal_resolver.py
+++ b/src/globus_cli/principal_resolver.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Iterable, cast
 
-from globus_sdk import IdentityMap
+import globus_sdk
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.types import DATA_CONTAINER_T
@@ -59,12 +59,12 @@ class PrincipalResolver:
     def __init__(self, key: str, use_urns: bool = True) -> None:
         self.key = key
         self.use_urns = use_urns
-        self._idmap: IdentityMap | None = None
+        self._idmap: globus_sdk.IdentityMap | None = None
 
     @property
-    def idmap(self) -> IdentityMap:
+    def idmap(self) -> "globus_sdk.IdentityMap":
         if not self._idmap:
-            self._idmap = IdentityMap(LoginManager().get_auth_client())
+            self._idmap = globus_sdk.IdentityMap(LoginManager().get_auth_client())
         return self._idmap
 
     def _raw_id_from_object(self, obj: DATA_CONTAINER_T) -> tuple[str, str]:

--- a/src/globus_cli/services/auth.py
+++ b/src/globus_cli/services/auth.py
@@ -1,6 +1,6 @@
 import uuid
 
-from globus_sdk import AuthClient
+import globus_sdk
 
 
 def _is_uuid(s):
@@ -11,7 +11,7 @@ def _is_uuid(s):
         return False
 
 
-class CustomAuthClient(AuthClient):
+class CustomAuthClient(globus_sdk.AuthClient):
     def _lookup_identity_field(
         self, id_name=None, id_id=None, field="id", provision=False
     ):

--- a/src/globus_cli/services/gcs.py
+++ b/src/globus_cli/services/gcs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from globus_sdk import GCSClient
+import globus_sdk
 
 CONNECTOR_INFO: list[dict[str, str]] = [
     {
@@ -72,7 +72,7 @@ def connector_id_to_display_name(connector_id: str) -> str:
     return display_name
 
 
-class CustomGCSClient(GCSClient):
+class CustomGCSClient(globus_sdk.GCSClient):
     def __init__(self, *args, source_epish=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.source_epish = source_epish

--- a/src/globus_cli/services/transfer/client.py
+++ b/src/globus_cli/services/transfer/client.py
@@ -6,7 +6,7 @@ import uuid
 from typing import Any
 
 import click
-from globus_sdk import GlobusHTTPResponse, TransferClient
+import globus_sdk
 from globus_sdk.transport import (
     RetryCheckFlags,
     RetryCheckResult,
@@ -43,7 +43,7 @@ def _retry_client_consent(ctx: RetryContext) -> RetryCheckResult:
     return RetryCheckResult.no_decision
 
 
-class CustomTransferClient(TransferClient):
+class CustomTransferClient(globus_sdk.TransferClient):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.transport.register_retry_check(_retry_client_consent)
@@ -79,7 +79,7 @@ class CustomTransferClient(TransferClient):
 
     def get_endpoint_w_server_list(
         self, endpoint_id
-    ) -> tuple[GlobusHTTPResponse, str | GlobusHTTPResponse]:
+    ) -> tuple[globus_sdk.GlobusHTTPResponse, str | globus_sdk.GlobusHTTPResponse]:
         """
         A helper for handling endpoint server list lookups correctly accounting
         for various endpoint types.

--- a/src/globus_cli/services/transfer/delegate_proxy.py
+++ b/src/globus_cli/services/transfer/delegate_proxy.py
@@ -3,10 +3,6 @@ import os
 import re
 import struct
 
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes, serialization
-
 
 def fill_delegate_proxy_activation_requirements(
     requirements_data, cred_file, lifetime_hours=12
@@ -54,6 +50,10 @@ def create_proxy_credentials(issuer_cred, public_key, lifetime_hours):
     proxy lifetime, returns credentials as a unicode string in PEM format
     containing a new proxy certificate and an extended proxy chain.
     """
+
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+
     # parse the issuer credential
     loaded_cert, loaded_private_key, issuer_chain = parse_issuer_cred(issuer_cred)
 
@@ -94,6 +94,10 @@ def parse_issuer_cred(issuer_cred):
     Returns the issuer cert and private key as loaded cryptography objects
     and the proxy chain as a potentially empty string.
     """
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+
     # get each section of the PEM file
     sections = re.findall(
         "-----BEGIN.*?-----.*?-----END.*?-----", issuer_cred, flags=re.DOTALL
@@ -143,6 +147,10 @@ def create_proxy_cert(
     a private_key, and an int for lifetime in hours, creates a proxy
     cert from the issuer and public key signed by the private key.
     """
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import hashes
+
     builder = x509.CertificateBuilder()
 
     # create a serial number for the new proxy
@@ -204,6 +212,8 @@ def confirm_not_old_proxy(loaded_cert):
     Given a cryptography object for the issuer cert, checks if the cert is
     an "old proxy" and raise an error if so.
     """
+    from cryptography import x509
+
     # Examine the last CommonName to see if it looks like an old proxy.
     last_cn = loaded_cert.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[
         -1
@@ -221,6 +231,8 @@ def validate_key_usage(loaded_cert):
     the keyUsage extension is being used that the digital signature
     bit has been asserted. (As specified in RFC 3820 section 3.1.)
     """
+    from cryptography import x509
+
     try:
         key_usage = loaded_cert.extensions.get_extension_for_oid(
             x509.oid.ExtensionOID.KEY_USAGE

--- a/src/globus_cli/services/transfer/recursive_ls.py
+++ b/src/globus_cli/services/transfer/recursive_ls.py
@@ -7,7 +7,7 @@ import time
 from collections import deque
 from typing import Any, Deque, Dict, Iterator, Optional, Tuple, cast
 
-from globus_sdk import TransferClient
+import globus_sdk
 
 log = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class RecursiveLsResponse:
 
     def __init__(
         self,
-        client: TransferClient,
+        client: globus_sdk.TransferClient,
         endpoint_id: str,
         ls_params: dict[str, Any],
         *,

--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import sys
-from distutils.util import strtobool
 
 import click
 
@@ -76,6 +75,8 @@ def env_interactive() -> bool | None:
     Check the `GLOBUS_CLI_INTERACTIVE` environment variable for a boolean, and *let*
     `strtobool` raise a `ValueError` if it doesn't parse.
     """
+    from distutils.util import strtobool
+
     explicit_val = os.getenv("GLOBUS_CLI_INTERACTIVE")
     if explicit_val is None:
         return None

--- a/src/globus_cli/termio/output_formatter.py
+++ b/src/globus_cli/termio/output_formatter.py
@@ -2,7 +2,7 @@ import json
 import textwrap
 
 import click
-from globus_sdk import GlobusHTTPResponse
+import globus_sdk
 
 from globus_cli.utils import CLIStubResponse
 
@@ -81,7 +81,7 @@ def _key_to_keyfunc(k):
 def _jmespath_preprocess(res):
     jmespath_expr = get_jmespath_expression()
 
-    if isinstance(res, (CLIStubResponse, GlobusHTTPResponse)):
+    if isinstance(res, (CLIStubResponse, globus_sdk.GlobusHTTPResponse)):
         res = res.data
 
     if not isinstance(res, str):

--- a/src/globus_cli/types.py
+++ b/src/globus_cli/types.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Tuple, Union
 
-from globus_sdk import GlobusHTTPResponse
-
 # all imports from globus_cli modules done here are done under TYPE_CHECKING
 # in order to ensure that the use of type annotations never introduces circular
 # imports at runtime
 if TYPE_CHECKING:
+    import globus_sdk
+
     from globus_cli.termio import FormatField
     from globus_cli.utils import CLIStubResponse
 
@@ -26,4 +26,8 @@ FIELD_T = Union[
 
 FIELD_LIST_T = List[FIELD_T]
 
-DATA_CONTAINER_T = Union[Mapping[str, Any], GlobusHTTPResponse, "CLIStubResponse"]
+DATA_CONTAINER_T = Union[
+    Mapping[str, Any],
+    "globus_sdk.GlobusHTTPResponse",
+    "CLIStubResponse",
+]

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import inspect
 import json
-import shlex
 from typing import Any, Callable, Iterable, Iterator, TextIO, cast
 
 import click
@@ -20,6 +18,8 @@ def get_current_option_help(*, filter_names: Iterable[str] | None = None) -> lis
 
 
 def supported_parameters(c: Callable) -> list[str]:
+    import inspect
+
     sig = inspect.signature(c)
     return list(sig.parameters.keys())
 
@@ -170,6 +170,8 @@ def shlex_process_stream(process_command: click.Command, stream: TextIO) -> None
     processing single lines of input. helptext is prepended to the standard
     message printed to interactive sessions.
     """
+    import shlex
+
     # use readlines() rather than implicit file read line looping to force
     # python to properly capture EOF (otherwise, EOF acts as a flush and
     # things get weird)

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from distutils.version import LooseVersion
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from distutils.version import LooseVersion
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
@@ -21,6 +24,8 @@ def get_versions() -> tuple[LooseVersion | None, LooseVersion]:
     # import in the func (rather than top-level scope) so that at setup time,
     # `requests` isn't required -- otherwise, setuptools will fail to run
     # because it isn't installed yet.
+    from distutils.version import LooseVersion
+
     import requests
 
     try:

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -2,7 +2,6 @@ import uuid
 from unittest import mock
 
 import globus_sdk
-from globus_sdk import NativeAppAuthClient
 from globus_sdk._testing import load_response_set
 
 from globus_cli.login_manager import LoginManager
@@ -64,7 +63,7 @@ def test_login_gcs_different_identity(
     test_token_storage.store_config(
         _STORE_CONFIG_USERINFO, {"sub": str(uuid.UUID(int=0))}
     )
-    mock_auth_client = mock.MagicMock(spec=NativeAppAuthClient)
+    mock_auth_client = mock.MagicMock(spec=globus_sdk.NativeAppAuthClient)
     mock_auth_client.oauth2_exchange_code_for_tokens = lambda _: MockToken()
     mock_local_server_flow.side_effect = (
         lambda *args, **kwargs: exchange_code_and_store(mock_auth_client, "bogus_code")

--- a/tests/functional/timer/test_job_operations.py
+++ b/tests/functional/timer/test_job_operations.py
@@ -1,8 +1,8 @@
 import json
 import re
 
+import globus_sdk
 import pytest
-from globus_sdk import TimerClient
 from globus_sdk._testing import RegisteredResponse, load_response, load_response_set
 
 from globus_cli.commands.timer._common import JOB_FORMAT_FIELDS
@@ -63,7 +63,7 @@ DELETE_RESPONSE = RegisteredResponse(
 
 
 def test_show_job(run_line):
-    meta = load_response_set(TimerClient.get_job).metadata
+    meta = load_response_set(globus_sdk.TimerClient.get_job).metadata
     assert meta
     result = run_line(["globus", "timer", "show", meta["job_id"]])
     assert result.exit_code == 0
@@ -73,7 +73,7 @@ def test_show_job(run_line):
 
 
 def test_list_jobs(run_line):
-    meta = load_response_set(TimerClient.list_jobs).metadata
+    meta = load_response_set(globus_sdk.TimerClient.list_jobs).metadata
     assert meta
     result = run_line(["globus", "timer", "list"])
     assert result.exit_code == 0

--- a/tests/unit/test_bookmark_helpers.py
+++ b/tests/unit/test_bookmark_helpers.py
@@ -1,8 +1,8 @@
 import uuid
 from unittest import mock
 
+import globus_sdk
 import pytest
-from globus_sdk import TransferAPIError
 
 from globus_cli.commands.bookmark._common import resolve_id_or_name
 
@@ -18,7 +18,7 @@ def test_resolve_bookmarkid_not_found_does_name_match():
     err_res.headers = {"Content-Type": "application/json"}
 
     client = mock.MagicMock()
-    client.get_bookmark.side_effect = TransferAPIError(err_res)
+    client.get_bookmark.side_effect = globus_sdk.TransferAPIError(err_res)
 
     bookmarkid = str(uuid.uuid1())
     magic_result = {"name": bookmarkid, "_sentinel": object()}
@@ -36,11 +36,11 @@ def test_resolve_bookmarkid_any_other_error_reraise(status, code):
     err_res.headers = {"Content-Type": "application/json"}
 
     client = mock.MagicMock()
-    client.get_bookmark.side_effect = TransferAPIError(err_res)
+    client.get_bookmark.side_effect = globus_sdk.TransferAPIError(err_res)
 
     bookmarkid = str(uuid.uuid1())
 
-    with pytest.raises(TransferAPIError):
+    with pytest.raises(globus_sdk.TransferAPIError):
         resolve_id_or_name(client, bookmarkid)
 
 

--- a/tests/unit/test_lazy_sdk_import.py
+++ b/tests/unit/test_lazy_sdk_import.py
@@ -1,0 +1,63 @@
+"""
+        ***************
+        * PLEASE READ *
+        ***************
+
+If these tests fail, it probably means you broke a delicate but important feature of the
+CLI. Read this full docstring before changing these tests.
+
+
+It's important to test the behavior of importing the globus_cli command tree to ensure
+that it does not import the main globus_sdk components.
+
+This is a performance enhancement which avoids paying the cost for expensive import-time
+logic done in globus_sdk, requests, and urllib3 when the CLI is running a command like
+  globus ls --help
+or tab completion.
+
+It is *very* easy to accidentally undo this performance improvement. For example, a new
+module with an innocuous annotation:
+
+    import globus_sdk
+
+    def foo(client: globus_sdk.TransferClient) -> None: pass
+
+The annotation should be deferred (default behavior on py3.10+) but because it isn't
+quoted or guarded with `from __future__ import annotations`, it will evaluate at
+runtime.
+
+Because the overhead of `import requests` alone (let alone all of the SDK imports) is
+about 100ms, it eats a significant chunk of our time budget for completions and other
+very latency-sensitive usages. We need to ensure that doesn't get done when the CLI does
+its (almost entirely eager) imports.
+"""
+import subprocess
+import sys
+
+import globus_sdk
+import pytest
+
+
+@pytest.mark.skipif(
+    not hasattr(globus_sdk, "_force_eager_imports"),
+    reason="globus_sdk lazy imports not supported on this version",
+)
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="lazy imports require py3.7+")
+def test_importing_cli_doesnt_import_requests():
+    to_run = "; ".join(
+        [
+            "import sys",
+            "from globus_cli import main",
+            "assert 'requests' not in sys.modules",
+        ]
+    )
+    proc = subprocess.Popen(
+        f'{sys.executable} -c "{to_run}"',
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    status = proc.wait()
+    assert status == 0, str(proc.communicate())
+    proc.stdout.close()
+    proc.stderr.close()


### PR DESCRIPTION
This builds off of #638 , but expands the work to do the lazy-loading of `globus_sdk` which we want.

This is marked as a draft until the next SDK release, so that we can bump the SDK version used and "turn this on".

Commit messages here have a great deal of useful detail.