### PR TITLE
Remove support for python3.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         # we do not want a large number of windows and macos builds, so
         # enumerate them explicitly
         include:
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.6"
+          python-version: "3.7"
       - name: install tox
         run: python -m pip install -U tox
       - name: test
@@ -87,7 +87,7 @@ jobs:
   test-sdk-main:
     strategy:
       matrix:
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.7", "3.10"]
     runs-on: ubuntu-latest
     name: "sdk-main"
     steps:
@@ -100,13 +100,13 @@ jobs:
 
   # use the oldest python version we support for this build
   test-ancient-virtualenv:
-    name: "test on py3.6, using old virtualenv"
+    name: "test on py3.7, using old virtualenv"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: "3.7"
       - name: Install Requirements
         run: python -m pip install -U pip setuptools tox
       - name: Downgrade Virtualenv

--- a/changelog.d/20220607_195242_sirosen_drop_py36.md
+++ b/changelog.d/20220607_195242_sirosen_drop_py36.md
@@ -1,0 +1,4 @@
+### Other
+
+* Remove support for python3.6 . Users on python3.6 should still be able to
+  install `globus-cli` but will not be able to update to the latest version.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     version=parse_version(),
     packages=find_packages("src"),
     package_dir={"": "src"},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "globus-sdk==3.9.0",
         "click>=8.0.0,<9",
@@ -65,7 +65,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     cov-clean
     cov-report
-    py{310,39,38,37,36}
-    py36-mindeps
+    py{310,39,38,37}
+    py37-mindeps
 skip_missing_interpreters = true
 minversion = 3.0.0
 
@@ -25,13 +25,13 @@ deps =
 #
 # usage examples:
 #   GLOBUS_SDK_PATH=../globus-sdk tox -e py310-localsdk
-#   GLOBUS_SDK_PATH=../globus-sdk tox -e 'py{37,38,39,310}-localsdk
+#   GLOBUS_SDK_PATH=../globus-sdk tox -e 'py{37,38,39,310}-localsdk'
 commands =
     localsdk: python -c 'import os, subprocess, sys; subprocess.run([sys.executable, "-m", "pip", "install", "-e", os.environ["GLOBUS_SDK_PATH"]])'
     pytest --cov-append --cov-report= {posargs}
 depends =
-    {py36-mindeps,py36,py37,py38,py39}: cov-clean
-    cov-report: py36-mindeps,py36,py37,py38,py39
+    py{37,38,39,310}{,-mindeps}: cov-clean
+    cov-report: py{37,38,39,310}{,-mindeps}
 
 [testenv:cov-clean]
 deps = coverage


### PR DESCRIPTION
- Remove from tox and CI
- Update python_requires in setup.py
- Adjust several builds to use py3.7 as our new "minimum version"

---

The plan here is that we drop 3.6, we do a release with this and the other minor tweaks that are in `main`, and we assess impact. That puts us in a position to start working with 3.7+ features, but without doing any major refactoring that we'd have to unwind if we get (unexpected) blowback from dropping this EOL version.