### PR TITLE
Add Search index deletion comand

### DIFF
--- a/changelog.d/20220624_133604_sirosen_delete_search_index.md
+++ b/changelog.d/20220624_133604_sirosen_delete_search_index.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add `globus search index delete` command

--- a/src/globus_cli/commands/search/index/__init__.py
+++ b/src/globus_cli/commands/search/index/__init__.py
@@ -1,6 +1,7 @@
 from globus_cli.parsing import group
 
 from .create import create_command
+from .delete import delete_command
 from .list import list_command
 from .role import role_command
 from .show import show_command
@@ -12,6 +13,7 @@ def index_command():
 
 
 index_command.add_command(create_command)
+index_command.add_command(delete_command)
 index_command.add_command(list_command)
 index_command.add_command(show_command)
 index_command.add_command(role_command)

--- a/src/globus_cli/commands/search/index/delete.py
+++ b/src/globus_cli/commands/search/index/delete.py
@@ -1,0 +1,18 @@
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import formatted_print
+
+
+@command("delete")
+@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@click.argument("INDEX_ID")
+def delete_command(*, login_manager: LoginManager, index_id: str):
+    """(BETA) Delete a Search Index"""
+    search_client = login_manager.get_search_client()
+    formatted_print(
+        search_client.delete(f"/beta/index/{index_id}"),
+        simple_text=f"Index {index_id} is now marked for deletion.\n"
+        "It will be fully deleted after cleanup steps complete.",
+    )

--- a/tests/files/api_fixtures/search.yaml
+++ b/tests/files/api_fixtures/search.yaml
@@ -354,6 +354,13 @@ search:
         "status": "open",
         "subscription_id": null
       }
+  - path: /beta/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f
+    method: DELETE
+    json:
+      {
+        "acknowledged": true,
+        "index_id": "6f831ac8-4c41-4812-b383-6fb04f8b9f9f"
+      }
   - path: /v1/index_list
     json:
       {

--- a/tests/functional/search/test_index.py
+++ b/tests/functional/search/test_index.py
@@ -43,3 +43,11 @@ def test_index_create(run_line):
         matcher=True,
     )
     matcher.check(r"^Index ID:\s+([\w-]+)$", groups=[index_id])
+
+
+def test_index_delete(run_line):
+    meta = load_response_set("cli.search").metadata
+    index_id = meta["index_id"]
+
+    result = run_line(f"globus search index delete {index_id}")
+    assert f"Index {index_id} is now marked for deletion." in result.output


### PR DESCRIPTION
Like the creation command, this uses a (currently) beta API and therefore is labeled as beta in the helptext.

The intention is for Search to eventually move to a non-`/beta/` endpoint for this API, at which point the ClI can update to use that endpoint and drop "BETA" from the helptext.