### PR TITLE
Implement 'globus timer delete' (hidden)

### DIFF
--- a/src/globus_cli/commands/timer/__init__.py
+++ b/src/globus_cli/commands/timer/__init__.py
@@ -1,5 +1,6 @@
 from globus_cli.parsing import group
 
+from .delete import delete_command
 from .list import list_command
 from .show import show_command
 
@@ -11,3 +12,4 @@ def timer_command():
 
 timer_command.add_command(list_command)
 timer_command.add_command(show_command)
+timer_command.add_command(delete_command)

--- a/src/globus_cli/commands/timer/_common.py
+++ b/src/globus_cli/commands/timer/_common.py
@@ -69,9 +69,20 @@ JOB_FORMAT_FIELDS = [
     ("Last Run", lambda data: isoformat_to_local(data["last_ran_at"])),
     ("Next Run", lambda data: isoformat_to_local(data["next_run"])),
     ("Stop After Date", _get_stop_date),
-    ("Stop After N. Runs", _get_stop_n_runs),
-    ("N. Runs", lambda data: data["n_runs"]),
-    ("N. Timer Errors", lambda data: data["n_errors"]),
+    ("Stop After Number of Runs", _get_stop_n_runs),
+    ("Number of Runs", lambda data: data["n_runs"]),
+    ("Number of Timer Errors", lambda data: data["n_errors"]),
+]
+
+DELETED_JOB_FORMAT_FIELDS = [
+    ("Job ID", "job_id"),
+    ("Name", "name"),
+    ("Type", _get_action_type),
+    ("Submitted At", lambda data: isoformat_to_local(data["submitted_at"])),
+    ("Start", lambda data: isoformat_to_local(data["start"])),
+    ("Interval", _get_interval),
+    ("Stop After Date", _get_stop_date),
+    ("Stop After Number of Runs", _get_stop_n_runs),
 ]
 
 START_HELP = """

--- a/src/globus_cli/commands/timer/delete.py
+++ b/src/globus_cli/commands/timer/delete.py
@@ -1,0 +1,27 @@
+import uuid
+
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+
+from ._common import DELETED_JOB_FORMAT_FIELDS
+
+
+@command("delete", short_help="Delete a timer job", hidden=True)
+@click.argument("JOB_ID", type=uuid.UUID)
+@LoginManager.requires_login(LoginManager.TIMER_RS)
+def delete_command(login_manager: LoginManager, job_id: uuid.UUID):
+    """
+    Delete a Timer job.
+
+    The contents of the deleted job is printed afterwards.
+    """
+    timer_client = login_manager.get_timer_client()
+    deleted = timer_client.delete_job(job_id)
+    formatted_print(
+        deleted,
+        text_format=FORMAT_TEXT_RECORD,
+        fields=DELETED_JOB_FORMAT_FIELDS,
+    )

--- a/tests/functional/timer/test_job_operations.py
+++ b/tests/functional/timer/test_job_operations.py
@@ -1,7 +1,65 @@
+import json
+import re
+
+import pytest
 from globus_sdk import TimerClient
-from globus_sdk._testing import load_response_set
+from globus_sdk._testing import RegisteredResponse, load_response, load_response_set
 
 from globus_cli.commands.timer._common import JOB_FORMAT_FIELDS
+
+# NOTE: this is not quite the same as the "normal" job responses from
+# create/update—definitely something to consider revisiting on the Timer API.
+_job_id = "e304f241-b77a-4e75-89f6-c431ddafe497"
+DELETE_RESPONSE = RegisteredResponse(
+    metadata={"job_id": _job_id},
+    service="timer",
+    path=f"/jobs/{_job_id}",
+    method="DELETE",
+    json={
+        "callback_body": {
+            "body": {
+                "DATA": [
+                    {
+                        "DATA_TYPE": "transfer_item",
+                        "checksum_algorithm": None,
+                        "destination_path": "/~/file1.txt",
+                        "external_checksum": None,
+                        "recursive": False,
+                        "source_path": "/share/godata/file1.txt",
+                    }
+                ],
+                "DATA_TYPE": "transfer",
+                "delete_destination_extra": False,
+                "destination_endpoint": "ddb59af0-6d04-11e5-ba46-22000b92c6ec",
+                "encrypt_data": False,
+                "fail_on_quota_errors": False,
+                "notify_on_failed": True,
+                "notify_on_inactive": True,
+                "notify_on_succeeded": True,
+                "preserve_timestamp": False,
+                "recursive_symlinks": "ignore",
+                "skip_source_errors": False,
+                "source_endpoint": "ddb59aef-6d04-11e5-ba46-22000b92c6ec",
+                "submission_id": "548ec2d3-b4fd-11ec-b87f-3912f602f346",
+                "verify_checksum": False,
+            }
+        },
+        "callback_url": "https://actions.automate.globus.org/transfer/transfer/run",
+        "interval": None,
+        "job_id": _job_id,
+        "n_tries": 1,
+        "name": "example-timer-job",
+        "owner": "5276fa05-eedf-46c5-919f-ad2d0160d1a9",
+        "refresh_token": None,
+        "results": [],
+        "start": "2022-04-05T16:27:48",
+        "status": "deleted",
+        "stop_after": None,
+        "stop_after_n": 1,
+        "submitted_at": "2022-04-05T16:27:48.805427",
+        "update_pending": True,
+    },
+)
 
 
 def test_show_job(run_line):
@@ -22,3 +80,20 @@ def test_list_jobs(run_line):
     assert all(job_id in result.output for job_id in meta["job_ids"])
     for field_name, _ in JOB_FORMAT_FIELDS:
         assert field_name in result.output
+
+
+@pytest.mark.parametrize("out_format", ["text", "json"])
+def test_delete_job(run_line, out_format):
+    meta = load_response(DELETE_RESPONSE).metadata
+    add_args = []
+    if out_format == "json":
+        add_args = ["-F", "json"]
+    result = run_line(["globus", "timer", "delete", meta["job_id"]] + add_args)
+    assert result.exit_code == 0
+    if out_format == "json":
+        assert json.loads(result.output) == DELETE_RESPONSE.json
+    else:
+        pattern = re.compile(
+            r"^Job ID:\s+" + re.escape(meta["job_id"]) + "$", flags=re.MULTILINE
+        )
+        assert pattern.search(result.output) is not None


### PR DESCRIPTION
This adds a new command for timer job deletion, extracted from #659

Some minor changes and adjustments are included. Most notably, this is an opportunity to rename the `"N. Runs"` fields in output to `"Number of Runs"`, where appropriate.

Co-authored-by: Rudyard Richter <rudyardrichter@users.noreply.github.com>

---

This part of the original PR was good to merge in my book. I'm breaking it up to allow for simpler review cycles.

I included the delete data -- with the note comment -- from the original. I'm not quite sure what it means that the format mismatch with other APIs should be revisited, but I'll take this up with the Automate team at _some point_. Not in the near term, however.