### PR TITLE
Add 'api timer' command

### DIFF
--- a/changelog.d/20220808_181413_sirosen_add_timer_api_command.md
+++ b/changelog.d/20220808_181413_sirosen_add_timer_api_command.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Add the `globus api timer` command for direct interactions with the Globus
+  Timer service

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -104,6 +104,7 @@ _SERVICE_MAP = {
     "groups": LoginManager.GROUPS_RS,
     "search": LoginManager.SEARCH_RS,
     "transfer": LoginManager.TRANSFER_RS,
+    "timer": LoginManager.TIMER_RS,
 }
 
 
@@ -118,6 +119,8 @@ def _get_client(
         return login_manager.get_search_client()
     elif service_name == "transfer":
         return login_manager.get_transfer_client()
+    elif service_name == "timer":
+        return login_manager.get_timer_client()
     else:
         raise NotImplementedError(f"unrecognized service: {service_name}")
 
@@ -128,6 +131,7 @@ def _get_url(service_name: str) -> str:
         "groups": "https://groups.api.globus.org/v2/",
         "search": "https://search.api.globus.org/",
         "transfer": "https://transfer.api.globus.org/v0.10/",
+        "timer": "https://timer.automate.globus.org/",
     }[service_name]
 
 

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -2,7 +2,9 @@ import pytest
 from globus_sdk._testing import RegisteredResponse, load_response
 
 
-@pytest.mark.parametrize("service_name", ["auth", "transfer", "groups", "search"])
+@pytest.mark.parametrize(
+    "service_name", ["auth", "transfer", "groups", "search", "timer"]
+)
 @pytest.mark.parametrize("is_error_response", (False, True))
 def test_api_command_get(run_line, service_name, is_error_response):
     load_response(


### PR DESCRIPTION
This was intended for the last release but I forgot how explicit the `api` command code is. The test case is updated to ensure that it's all "wired up correctly".