### PR TITLE
Implement lazy subcommand loading

### DIFF
--- a/changelog.d/20220831_164625_sirosen_lazy_subcommands.md
+++ b/changelog.d/20220831_164625_sirosen_lazy_subcommands.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Implement lazy subcommand loading, making many CLI usages significantly
+  faster. Speed improvements are as dramatic as 2x for some commands.

--- a/src/globus_cli/commands/__init__.py
+++ b/src/globus_cli/commands/__init__.py
@@ -1,31 +1,33 @@
-from globus_cli.commands.bookmark import bookmark_command
-from globus_cli.commands.cli_profile_list import cli_profile_list
-from globus_cli.commands.collection import collection_command
-from globus_cli.commands.delete import delete_command
-from globus_cli.commands.endpoint import endpoint_command
-from globus_cli.commands.get_identities import get_identities_command
-from globus_cli.commands.group import group_command
-from globus_cli.commands.list_commands import list_commands
-from globus_cli.commands.login import login_command
-from globus_cli.commands.logout import logout_command
-from globus_cli.commands.ls import ls_command
-from globus_cli.commands.mkdir import mkdir_command
-from globus_cli.commands.rename import rename_command
-from globus_cli.commands.rm import rm_command
-from globus_cli.commands.search import search_command
-from globus_cli.commands.session import session_command
-from globus_cli.commands.task import task_command
-from globus_cli.commands.timer import timer_command
-from globus_cli.commands.transfer import transfer_command
-from globus_cli.commands.update import update_command
-from globus_cli.commands.version import version_command
-from globus_cli.commands.whoami import whoami_command
 from globus_cli.parsing import main_group
 
-from .api import api_command
 
-
-@main_group
+@main_group(
+    lazy_subcommands={
+        "api": ("api", "api_command"),
+        "bookmark": ("bookmark", "bookmark_command"),
+        "cli-profile-list": ("cli_profile_list", "cli_profile_list"),
+        "collection": ("collection", "collection_command"),
+        "delete": ("delete", "delete_command"),
+        "endpoint": ("endpoint", "endpoint_command"),
+        "get-identities": ("get_identities", "get_identities_command"),
+        "group": ("group", "group_command"),
+        "list-commands": ("list_commands", "list_commands"),
+        "login": ("login", "login_command"),
+        "logout": ("logout", "logout_command"),
+        "ls": ("ls", "ls_command"),
+        "mkdir": ("mkdir", "mkdir_command"),
+        "rename": ("rename", "rename_command"),
+        "rm": ("rm", "rm_command"),
+        "search": ("search", "search_command"),
+        "session": ("session", "session_command"),
+        "task": ("task", "task_command"),
+        "timer": ("timer", "timer_command"),
+        "transfer": ("transfer", "transfer_command"),
+        "update": ("update", "update_command"),
+        "version": ("version", "version_command"),
+        "whoami": ("whoami", "whoami_command"),
+    }
+)
 def main() -> None:
     """
     Interact with Globus from the command line
@@ -36,34 +38,3 @@ def main() -> None:
 
     The documentation is also online at https://docs.globus.org/cli/
     """
-
-
-main.add_command(list_commands)
-main.add_command(cli_profile_list)
-main.add_command(version_command)
-main.add_command(update_command)
-
-main.add_command(login_command)
-main.add_command(logout_command)
-main.add_command(whoami_command)
-main.add_command(api_command)
-
-main.add_command(get_identities_command)
-main.add_command(ls_command)
-main.add_command(mkdir_command)
-main.add_command(rename_command)
-main.add_command(delete_command)
-main.add_command(rm_command)
-main.add_command(transfer_command)
-
-main.add_command(endpoint_command)
-main.add_command(collection_command)
-main.add_command(bookmark_command)
-main.add_command(task_command)
-main.add_command(session_command)
-
-main.add_command(group_command)
-
-main.add_command(search_command)
-
-main.add_command(timer_command)

--- a/src/globus_cli/commands/bookmark/__init__.py
+++ b/src/globus_cli/commands/bookmark/__init__.py
@@ -1,18 +1,15 @@
-from globus_cli.commands.bookmark.create import bookmark_create
-from globus_cli.commands.bookmark.delete import bookmark_delete
-from globus_cli.commands.bookmark.list import bookmark_list
-from globus_cli.commands.bookmark.rename import bookmark_rename
-from globus_cli.commands.bookmark.show import bookmark_show
 from globus_cli.parsing import group
 
 
-@group("bookmark")
+@group(
+    "bookmark",
+    lazy_subcommands={
+        "create": (".create", "bookmark_create"),
+        "delete": (".delete", "bookmark_delete"),
+        "list": (".list", "bookmark_list"),
+        "rename": (".rename", "bookmark_rename"),
+        "show": (".show", "bookmark_show"),
+    },
+)
 def bookmark_command() -> None:
     """Manage endpoint bookmarks"""
-
-
-bookmark_command.add_command(bookmark_list)
-bookmark_command.add_command(bookmark_create)
-bookmark_command.add_command(bookmark_delete)
-bookmark_command.add_command(bookmark_rename)
-bookmark_command.add_command(bookmark_show)

--- a/src/globus_cli/commands/collection/__init__.py
+++ b/src/globus_cli/commands/collection/__init__.py
@@ -1,18 +1,14 @@
 from globus_cli.parsing import group
 
-from .delete import collection_delete
-from .list import collection_list
-from .show import collection_show
-from .update import collection_update
 
-
-@group("collection")
+@group(
+    "collection",
+    lazy_subcommands={
+        "delete": (".delete", "collection_delete"),
+        "list": (".list", "collection_list"),
+        "show": (".show", "collection_show"),
+        "update": (".update", "collection_update"),
+    },
+)
 def collection_command() -> None:
     """Manage your Collections"""
-
-
-# commands
-collection_command.add_command(collection_delete)
-collection_command.add_command(collection_list)
-collection_command.add_command(collection_show)
-collection_command.add_command(collection_update)

--- a/src/globus_cli/commands/endpoint/__init__.py
+++ b/src/globus_cli/commands/endpoint/__init__.py
@@ -1,43 +1,27 @@
-from globus_cli.commands.endpoint.activate import endpoint_activate
-from globus_cli.commands.endpoint.create import endpoint_create
-from globus_cli.commands.endpoint.deactivate import endpoint_deactivate
-from globus_cli.commands.endpoint.delete import endpoint_delete
-from globus_cli.commands.endpoint.is_activated import endpoint_is_activated
-from globus_cli.commands.endpoint.local_id import local_id
-from globus_cli.commands.endpoint.my_shared_endpoint_list import my_shared_endpoint_list
-from globus_cli.commands.endpoint.permission import permission_command
-from globus_cli.commands.endpoint.role import role_command
-from globus_cli.commands.endpoint.search import endpoint_search
-from globus_cli.commands.endpoint.server import server_command
-from globus_cli.commands.endpoint.set_subscription_id import (
-    set_endpoint_subscription_id,
-)
-from globus_cli.commands.endpoint.show import endpoint_show
-from globus_cli.commands.endpoint.update import endpoint_update
 from globus_cli.parsing import group
 
 
-@group("endpoint")
+@group(
+    "endpoint",
+    lazy_subcommands={
+        "activate": (".activate", "endpoint_activate"),
+        "create": (".create", "endpoint_create"),
+        "deactivate": (".deactivate", "endpoint_deactivate"),
+        "delete": (".delete", "endpoint_delete"),
+        "is-activated": (".is_activated", "endpoint_is_activated"),
+        "local-id": (".local_id", "local_id"),
+        "my-shared-endpoint-list": (
+            ".my_shared_endpoint_list",
+            "my_shared_endpoint_list",
+        ),
+        "permission": (".permission", "permission_command"),
+        "role": (".role", "role_command"),
+        "search": (".search", "endpoint_search"),
+        "server": (".server", "server_command"),
+        "set-subscription-id": (".set_subscription_id", "set_endpoint_subscription_id"),
+        "show": (".show", "endpoint_show"),
+        "update": (".update", "endpoint_update"),
+    },
+)
 def endpoint_command() -> None:
     """Manage Globus endpoint definitions"""
-
-
-# groups
-endpoint_command.add_command(permission_command)
-endpoint_command.add_command(role_command)
-endpoint_command.add_command(server_command)
-
-# commands
-endpoint_command.add_command(endpoint_search)
-endpoint_command.add_command(endpoint_show)
-endpoint_command.add_command(endpoint_create)
-endpoint_command.add_command(endpoint_update)
-endpoint_command.add_command(endpoint_delete)
-endpoint_command.add_command(set_endpoint_subscription_id)
-
-endpoint_command.add_command(endpoint_activate)
-endpoint_command.add_command(endpoint_is_activated)
-endpoint_command.add_command(endpoint_deactivate)
-
-endpoint_command.add_command(my_shared_endpoint_list)
-endpoint_command.add_command(local_id)

--- a/src/globus_cli/commands/endpoint/permission/__init__.py
+++ b/src/globus_cli/commands/endpoint/permission/__init__.py
@@ -1,18 +1,15 @@
-from globus_cli.commands.endpoint.permission.create import create_command
-from globus_cli.commands.endpoint.permission.delete import delete_command
-from globus_cli.commands.endpoint.permission.list import list_command
-from globus_cli.commands.endpoint.permission.show import show_command
-from globus_cli.commands.endpoint.permission.update import update_command
 from globus_cli.parsing import group
 
 
-@group("permission")
+@group(
+    "permission",
+    lazy_subcommands={
+        "create": (".create", "create_command"),
+        "delete": (".delete", "delete_command"),
+        "list": (".list", "list_command"),
+        "show": (".show", "show_command"),
+        "udpate": (".update", "update_command"),
+    },
+)
 def permission_command() -> None:
     """Manage endpoint permissions (Access Control Lists)"""
-
-
-permission_command.add_command(list_command)
-permission_command.add_command(create_command)
-permission_command.add_command(show_command)
-permission_command.add_command(update_command)
-permission_command.add_command(delete_command)

--- a/src/globus_cli/commands/endpoint/role/__init__.py
+++ b/src/globus_cli/commands/endpoint/role/__init__.py
@@ -1,18 +1,14 @@
-from globus_cli.commands.endpoint.role.create import role_create
-from globus_cli.commands.endpoint.role.delete import role_delete
-from globus_cli.commands.endpoint.role.list import role_list
-from globus_cli.commands.endpoint.role.show import role_show
 from globus_cli.parsing import group
 
 
-@group("role")
+@group(
+    "role",
+    lazy_subcommands={
+        "create": (".create", "role_create"),
+        "delete": (".delete", "role_delete"),
+        "list": (".list", "role_list"),
+        "show": (".show", "role_show"),
+    },
+)
 def role_command() -> None:
     """Manage endpoint roles"""
-
-
-role_command.add_command(role_list)
-role_command.add_command(role_show)
-role_command.add_command(role_create)
-role_command.add_command(role_delete)
-
-__all__ = ["role_command"]

--- a/src/globus_cli/commands/endpoint/server/__init__.py
+++ b/src/globus_cli/commands/endpoint/server/__init__.py
@@ -1,12 +1,17 @@
-from globus_cli.commands.endpoint.server.add import server_add
-from globus_cli.commands.endpoint.server.delete import server_delete
-from globus_cli.commands.endpoint.server.list import server_list
-from globus_cli.commands.endpoint.server.show import server_show
-from globus_cli.commands.endpoint.server.update import server_update
 from globus_cli.parsing import group
 
 
-@group("server", short_help="Manage servers for a Globus endpoint")
+@group(
+    "server",
+    short_help="Manage servers for a Globus endpoint",
+    lazy_subcommands={
+        "add": (".add", "server_add"),
+        "delete": (".delete", "server_delete"),
+        "list": (".list", "server_list"),
+        "show": (".show", "server_show"),
+        "update": (".update", "server_update"),
+    },
+)
 def server_command() -> None:
     """
     Manage the servers which back a Globus endpoint
@@ -14,10 +19,3 @@ def server_command() -> None:
     This typically refers to a Globus Connect Server endpoint running on multiple
     servers. Each GridFTP server is registered as a server backing the endpoint.
     """
-
-
-server_command.add_command(server_list)
-server_command.add_command(server_show)
-server_command.add_command(server_add)
-server_command.add_command(server_update)
-server_command.add_command(server_delete)

--- a/src/globus_cli/commands/group/__init__.py
+++ b/src/globus_cli/commands/group/__init__.py
@@ -1,28 +1,20 @@
-from globus_cli.commands.group.create import group_create
-from globus_cli.commands.group.delete import group_delete
-from globus_cli.commands.group.invite import group_invite
-from globus_cli.commands.group.join import group_join
-from globus_cli.commands.group.leave import group_leave
-from globus_cli.commands.group.list import group_list
-from globus_cli.commands.group.member import group_member
-from globus_cli.commands.group.set_policies import group_set_policies
-from globus_cli.commands.group.show import group_show
-from globus_cli.commands.group.update import group_update
 from globus_cli.parsing import group
 
 
-@group("group")
+@group(
+    "group",
+    lazy_subcommands={
+        "create": (".create", "group_create"),
+        "delete": (".delete", "group_delete"),
+        "invite": (".invite", "group_invite"),
+        "join": (".join", "group_join"),
+        "leave": (".leave", "group_leave"),
+        "list": (".list", "group_list"),
+        "member": (".member", "group_member"),
+        "set-policies": (".set_policies", "group_set_policies"),
+        "show": (".show", "group_show"),
+        "update": (".update", "group_update"),
+    },
+)
 def group_command() -> None:
     """Manage Globus Groups"""
-
-
-group_command.add_command(group_list)
-group_command.add_command(group_show)
-group_command.add_command(group_create)
-group_command.add_command(group_update)
-group_command.add_command(group_delete)
-group_command.add_command(group_member)
-group_command.add_command(group_invite)
-group_command.add_command(group_join)
-group_command.add_command(group_leave)
-group_command.add_command(group_set_policies)

--- a/src/globus_cli/commands/group/invite/__init__.py
+++ b/src/globus_cli/commands/group/invite/__init__.py
@@ -1,13 +1,12 @@
 from globus_cli.parsing import group
 
-from .accept import invite_accept
-from .decline import invite_decline
 
-
-@group("invite")
+@group(
+    "invite",
+    lazy_subcommands={
+        "accept": (".accept", "invite_accept"),
+        "decline": (".decline", "invite_decline"),
+    },
+)
 def group_invite() -> None:
     """Manage invitations to a Globus Group"""
-
-
-group_invite.add_command(invite_accept)
-group_invite.add_command(invite_decline)

--- a/src/globus_cli/commands/group/member/__init__.py
+++ b/src/globus_cli/commands/group/member/__init__.py
@@ -1,21 +1,16 @@
 from globus_cli.parsing import group
 
-from .add import member_add
-from .approve import member_approve
-from .invite import member_invite
-from .list import member_list
-from .reject import member_reject
-from .remove import member_remove
 
-
-@group("member")
+@group(
+    "member",
+    lazy_subcommands={
+        "add": (".add", "member_add"),
+        "approve": (".approve", "member_approve"),
+        "invite": (".invite", "member_invite"),
+        "list": (".list", "member_list"),
+        "reject": (".reject", "member_reject"),
+        "remove": (".remove", "member_remove"),
+    },
+)
 def group_member() -> None:
     """Manage members in a Globus Group"""
-
-
-group_member.add_command(member_add)
-group_member.add_command(member_remove)
-group_member.add_command(member_list)
-group_member.add_command(member_approve)
-group_member.add_command(member_reject)
-group_member.add_command(member_invite)

--- a/src/globus_cli/commands/search/__init__.py
+++ b/src/globus_cli/commands/search/__init__.py
@@ -1,21 +1,16 @@
 from globus_cli.parsing import group
 
-from .delete_by_query import delete_by_query_command
-from .index import index_command
-from .ingest import ingest_command
-from .query import query_command
-from .subject import subject_command
-from .task import task_command
 
-
-@group("search")
+@group(
+    "search",
+    lazy_subcommands={
+        "delete-by-query": (".delete_by_query", "delete_by_query_command"),
+        "index": (".index", "index_command"),
+        "ingest": (".ingest", "ingest_command"),
+        "query": (".query", "query_command"),
+        "subject": (".subject", "subject_command"),
+        "task": (".task", "task_command"),
+    },
+)
 def search_command():
     """Use Globus Search to store and query for data"""
-
-
-search_command.add_command(ingest_command)
-search_command.add_command(index_command)
-search_command.add_command(query_command)
-search_command.add_command(delete_by_query_command)
-search_command.add_command(subject_command)
-search_command.add_command(task_command)

--- a/src/globus_cli/commands/search/index/__init__.py
+++ b/src/globus_cli/commands/search/index/__init__.py
@@ -1,19 +1,15 @@
 from globus_cli.parsing import group
 
-from .create import create_command
-from .delete import delete_command
-from .list import list_command
-from .role import role_command
-from .show import show_command
 
-
-@group("index")
+@group(
+    "index",
+    lazy_subcommands={
+        "create": (".create", "create_command"),
+        "delete": (".delete", "delete_command"),
+        "list": (".list", "list_command"),
+        "role": (".role", "role_command"),
+        "show": (".show", "show_command"),
+    },
+)
 def index_command():
     """View and manage indices"""
-
-
-index_command.add_command(create_command)
-index_command.add_command(delete_command)
-index_command.add_command(list_command)
-index_command.add_command(show_command)
-index_command.add_command(role_command)

--- a/src/globus_cli/commands/search/index/role/__init__.py
+++ b/src/globus_cli/commands/search/index/role/__init__.py
@@ -1,15 +1,13 @@
 from globus_cli.parsing import group
 
-from .create import create_command
-from .delete import delete_command
-from .list import list_command
 
-
-@group("role")
+@group(
+    "role",
+    lazy_subcommands={
+        "create": (".create", "create_command"),
+        "delete": (".delete", "delete_command"),
+        "list": (".list", "list_command"),
+    },
+)
 def role_command():
     """View and manage index roles"""
-
-
-role_command.add_command(create_command)
-role_command.add_command(delete_command)
-role_command.add_command(list_command)

--- a/src/globus_cli/commands/search/subject/__init__.py
+++ b/src/globus_cli/commands/search/subject/__init__.py
@@ -1,13 +1,13 @@
 from globus_cli.parsing import group
 
-from .delete import delete_command
-from .show import show_command
 
-
-@group("subject", short_help="Manage data by subject")
+@group(
+    "subject",
+    short_help="Manage data by subject",
+    lazy_subcommands={
+        "delete": (".delete", "delete_command"),
+        "show": (".show", "show_command"),
+    },
+)
 def subject_command() -> None:
     """View and manage individual documents in an index by subject"""
-
-
-subject_command.add_command(delete_command)
-subject_command.add_command(show_command)

--- a/src/globus_cli/commands/search/task/__init__.py
+++ b/src/globus_cli/commands/search/task/__init__.py
@@ -1,13 +1,12 @@
 from globus_cli.parsing import group
 
-from .list import list_command
-from .show import show_command
 
-
-@group("task")
+@group(
+    "task",
+    lazy_subcommands={
+        "list": (".list", "list_command"),
+        "show": (".show", "show_command"),
+    },
+)
 def task_command():
     """View Task documents"""
-
-
-task_command.add_command(show_command)
-task_command.add_command(list_command)

--- a/src/globus_cli/commands/session/__init__.py
+++ b/src/globus_cli/commands/session/__init__.py
@@ -1,15 +1,13 @@
-from globus_cli.commands.session.consent import session_consent
-from globus_cli.commands.session.show import session_show
-from globus_cli.commands.session.update import session_update
 from globus_cli.parsing import group
 
 
-@group("session")
+@group(
+    "session",
+    lazy_subcommands={
+        "consent": (".consent", "session_consent"),
+        "show": (".show", "session_show"),
+        "update": (".update", "session_update"),
+    },
+)
 def session_command() -> None:
     """Manage your CLI auth session"""
-
-
-# commands
-session_command.add_command(session_update)
-session_command.add_command(session_show)
-session_command.add_command(session_consent)

--- a/src/globus_cli/commands/task/__init__.py
+++ b/src/globus_cli/commands/task/__init__.py
@@ -1,24 +1,18 @@
-from globus_cli.commands.task.cancel import cancel_task
-from globus_cli.commands.task.event_list import task_event_list
-from globus_cli.commands.task.generate_submission_id import generate_submission_id
-from globus_cli.commands.task.list import task_list
-from globus_cli.commands.task.pause_info import task_pause_info
-from globus_cli.commands.task.show import show_task
-from globus_cli.commands.task.update import update_task
-from globus_cli.commands.task.wait import task_wait
 from globus_cli.parsing import group
 
 
-@group("task")
+@group(
+    "task",
+    lazy_subcommands={
+        "cancel": (".cancel", "cancel_task"),
+        "event-list": (".event_list", "task_event_list"),
+        "generate-submission-id": (".generate_submission_id", "generate_submission_id"),
+        "list": (".list", "task_list"),
+        "pause-info": (".pause_info", "task_pause_info"),
+        "show": (".show", "show_task"),
+        "update": (".update", "update_task"),
+        "wait": (".wait", "task_wait"),
+    },
+)
 def task_command() -> None:
     """Manage asynchronous tasks"""
-
-
-task_command.add_command(task_list)
-task_command.add_command(show_task)
-task_command.add_command(update_task)
-task_command.add_command(cancel_task)
-task_command.add_command(task_event_list)
-task_command.add_command(task_pause_info)
-task_command.add_command(task_wait)
-task_command.add_command(generate_submission_id)

--- a/src/globus_cli/commands/timer/__init__.py
+++ b/src/globus_cli/commands/timer/__init__.py
@@ -1,15 +1,13 @@
 from globus_cli.parsing import group
 
-from .delete import delete_command
-from .list import list_command
-from .show import show_command
 
-
-@group("timer")
+@group(
+    "timer",
+    lazy_subcommands={
+        "delete": (".delete", "delete_command"),
+        "list": (".list", "list_command"),
+        "show": (".show", "show_command"),
+    },
+)
 def timer_command():
     """Schedule and manage jobs in Globus Timer"""
-
-
-timer_command.add_command(list_command)
-timer_command.add_command(show_command)
-timer_command.add_command(delete_command)


### PR DESCRIPTION
All command-to-group attachments are now done lazily, via a dict named `lazy_subcommands` attached to Group Command objects. The dict records a name->(config) mapping that allows for lazy loading.

This improves the speed of almost all commands. All tests pass with no changes.

In the case of a group helptext, the lazy loading will be triggered in order to fetch command objects (and their short_help attributes), but it won't cascade down to the second-order children of groups found in that pass. In the case of completion, only `list_commands` should be needed, meaning there's no subcommand loading at all because names are available from the lazy loading mapping.

This also operates in a beneficial way *outside* of the helptext and completion scenarios: a command like `globus group list` will not need to parse and load all of the modules for Endpoint ACL management, Search roles, Timers, or any other non-Groups-related commands.