### PR TITLE
Bump mindeps for 'cryptography' to 3.3.1 + add typing.overload to coverage ignores

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,3 +16,7 @@ exclude_lines =
     if TYPE_CHECKING:
     if typing.TYPE_CHECKING:
     if t.TYPE_CHECKING:
+    # don't check typing overloads
+    @overload
+    @typing.overload
+    @t.overload

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     mindeps: click==8.0.0
     mindeps: requests==2.19.1
     mindeps: pyjwt==2.0.0
-    mindeps: cryptography==2.0
+    mindeps: cryptography==3.3.1
     sdkmain: https://github.com/globus/globus-sdk-python/archive/main.tar.gz
 # the 'localsdk' factor allows CLI tests to be run against a local repo copy of globus-sdk
 # it requires that the GLOBUS_SDK_PATH env var is set and uses subprocess and os to pass it as


### PR DESCRIPTION
3.3.1 is still an old release of `cryptography`, but the even older one we were testing has started to be a problem to install/build on some workstations due to the newer openssl versions shipped with newer Linux distros.

3.3.1 is actually declared in the setup.py dependencies, so we should attempt to match that in our testing.

Also, add typing overloads to the coverage exemptions, so that we don't get false coverage misses on the overload bodies (which cannot ever execute).