### PR TITLE
Bugfix to `transfer --dry-run` text output

### DIFF
--- a/changelog.d/20220914_214457_sirosen_fix_xfer_dryrun.md
+++ b/changelog.d/20220914_214457_sirosen_fix_xfer_dryrun.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Fix a bug in text output for `globus transfer --dry-run` which crashed with a
+  `KeyError` if `--external-checksum` was omitted

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -360,7 +360,7 @@ def transfer_command(
                 ("Source Path", "source_path"),
                 ("Dest Path", "destination_path"),
                 ("Recursive", "recursive"),
-                ("External Checksum", "external_checksum"),
+                ("External Checksum", lambda x: x.get("external_checksum")),
             ),
         )
         # exit safely


### PR DESCRIPTION
When `external_checksum` is omitted, the SDK now omits it from the payload instead of filling with `None`. This causes a failure in the CLI text formatting code which expects that any string key it's given is present.

To fix:
- add a test which runs `--dry-run` with text formatted output
- switch from a string key to a lambda which calls `x.get(...)`

This effectively emulates the previous behavior, in which the value was `None` as well.