### PR TITLE
Add `globus gcp create` commands for creating mapped and guest collections

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,7 @@ exclude_lines =
     pragma: no cover
     # don't complain if tests don't hit unimplemented methods/modes
     raise NotImplementedError
+    assert_never()
     # don't check on executable components of importable modules
     if __name__ == .__main__.:
     # don't check 'TYPE_CHECKING' blocks

--- a/changelog.d/20220916_134333_sirosen_gcp_commands.md
+++ b/changelog.d/20220916_134333_sirosen_gcp_commands.md
@@ -1,0 +1,21 @@
+### Enhancements
+
+* New commands for creating Globus Connect Personal endpoints and collections
+** `globus gcp create mapped` creates a GCP Mapped Collection
+** `globus gcp create guest` creates a GCP Guest Collection
+
+In GCP, the Mapped Collection and Endpoint are synonymous. Therefore,
+`globus gcp create mapped` replaces the functionality previously only available
+via `globus endpoint create --personal`.
+
+NOTE: Neither of the `globus gcp create` commands automatically installs Globus
+Connect Personal on the local machine. These commands complement and interact with
+an existing installation.
+
+### Other
+
+* `globus endpoint create` is now documented as deprecated. Users are
+  encouraged to use `globus gcp create` for Globus Connect Personal,
+  and the Globus Connect Server CLI for Globus Connect Server
+* `globus endpoint create` no longer accepts `--no-default-directory` as an
+  option. It previously did nothing when used.

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ setup(
         # declare them here in case the underlying lib ever changes
         "requests>=2.19.1,<3.0.0",
         "cryptography>=3.3.1,<37",
+        # depend on the latest version of typing-extensions on python versions which do
+        # not have all of the typing features we use
+        'typing_extensions>=4.0;python_version<"3.11"',
     ],
     extras_require={"development": DEV_REQUIREMENTS},
     entry_points={"console_scripts": ["globus = globus_cli:main"]},

--- a/src/globus_cli/commands/__init__.py
+++ b/src/globus_cli/commands/__init__.py
@@ -9,6 +9,7 @@ from globus_cli.parsing import main_group
         "collection": ("collection", "collection_command"),
         "delete": ("delete", "delete_command"),
         "endpoint": ("endpoint", "endpoint_command"),
+        "gcp": ("gcp", "gcp_command"),
         "get-identities": ("get_identities", "get_identities_command"),
         "group": ("group", "group_command"),
         "list-commands": ("list_commands", "list_commands"),

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -84,7 +84,10 @@ def endpoint_create(
     **kwargs: Any,
 ) -> None:
     """
-    Create a new endpoint.
+    Create a new endpoint. (deprecated)
+
+    This command is deprecated. Either `globus gcp create` or the Globus Connect Server
+    CLI should be used instead for most cases.
 
     Requires a display name and exactly one of --personal, --server, or --shared to make
     a Globus Connect Personal, Globus Connect Server, or Shared endpoint respectively.

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -6,15 +6,13 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
     ENDPOINT_PLUS_REQPATH,
     command,
+    endpointish_create_and_update_params,
     mutex_option_group,
     one_use_option,
 )
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
-from ._common import (
-    endpoint_create_and_update_params,
-    validate_endpoint_create_and_update_params,
-)
+from ._common import endpoint_create_params, validate_endpoint_create_and_update_params
 
 COMMON_FIELDS = [("Message", "message"), ("Endpoint ID", "id")]
 
@@ -47,7 +45,8 @@ $ globus endpoint create --shared host_ep:~/ my_shared_endpoint
 ----
 """,
 )
-@endpoint_create_and_update_params(create=True)
+@endpointish_create_and_update_params("create")
+@endpoint_create_params
 @one_use_option(
     "--personal",
     is_flag=True,

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -1,17 +1,19 @@
 from globus_cli.endpointish import Endpointish
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import command, endpoint_id_arg
+from globus_cli.parsing import (
+    command,
+    endpoint_id_arg,
+    endpointish_create_and_update_params,
+)
 from globus_cli.termio import FORMAT_TEXT_RAW, formatted_print
 
-from ._common import (
-    endpoint_create_and_update_params,
-    validate_endpoint_create_and_update_params,
-)
+from ._common import endpoint_update_params, validate_endpoint_create_and_update_params
 
 
 @command("update")
 @endpoint_id_arg
-@endpoint_create_and_update_params(create=False)
+@endpoint_update_params
+@endpointish_create_and_update_params("update")
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def endpoint_update(*, login_manager: LoginManager, **kwargs):
     """Update attributes of an endpoint"""

--- a/src/globus_cli/commands/gcp/__init__.py
+++ b/src/globus_cli/commands/gcp/__init__.py
@@ -1,0 +1,11 @@
+from globus_cli.parsing import group
+
+
+@group(
+    "gcp",
+    lazy_subcommands={
+        "create": (".create", "create_command"),
+    },
+)
+def gcp_command():
+    """Manage Globus Connect Personal endpoints"""

--- a/src/globus_cli/commands/gcp/create/__init__.py
+++ b/src/globus_cli/commands/gcp/create/__init__.py
@@ -1,0 +1,12 @@
+from globus_cli.parsing import group
+
+
+@group(
+    "create",
+    lazy_subcommands={
+        "mapped": (".mapped", "mapped_command"),
+        "guest": (".guest", "guest_command"),
+    },
+)
+def create_command():
+    """Create Globus Connect Personal collections"""

--- a/src/globus_cli/commands/gcp/create/guest.py
+++ b/src/globus_cli/commands/gcp/create/guest.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import (
+    ENDPOINT_PLUS_REQPATH,
+    command,
+    endpointish_create_options,
+)
+from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+
+
+@command("guest", short_help="Create a new Guest Collection on GCP")
+@click.argument("DISPLAY_NAME")
+@click.argument("HOST_GCP_PATH", type=ENDPOINT_PLUS_REQPATH)
+@endpointish_create_options(name="collection")
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+def guest_command(
+    *,
+    login_manager: LoginManager,
+    display_name: str,
+    host_gcp_path: tuple[str, str],
+    description: str | None,
+    info_link: str | None,
+    contact_info: str | None,
+    contact_email: str | None,
+    organization: str | None,
+    department: str | None,
+    keywords: str | None,
+    default_directory: str | None,
+    force_encryption: bool | None,
+    disable_verify: bool | None,
+) -> None:
+    """
+    Create a new Guest Collection on a Globus Connect Personal Endpoint
+
+    The host ID and a path to the root for the Guest Collection are required.
+    """
+    from globus_cli.services.transfer import assemble_generic_doc, autoactivate
+
+    transfer_client = login_manager.get_transfer_client()
+
+    # build the endpoint document to submit
+    host_endpoint_id, host_path = host_gcp_path
+    ep_doc = assemble_generic_doc(
+        "shared_endpoint",
+        host_endpoint=host_endpoint_id,
+        host_path=host_path,
+        display_name=display_name,
+        description=description,
+        info_link=info_link,
+        contact_info=contact_info,
+        contact_email=contact_email,
+        organization=organization,
+        department=department,
+        keywords=keywords,
+        default_directory=default_directory,
+        force_encryption=force_encryption,
+        disable_verify=disable_verify,
+    )
+
+    autoactivate(transfer_client, host_endpoint_id, if_expires_in=60)
+    res = transfer_client.create_shared_endpoint(ep_doc)
+
+    # output
+    formatted_print(
+        res,
+        fields=[("Message", "message"), ("Collection ID", "id")],
+        text_format=FORMAT_TEXT_RECORD,
+    )

--- a/src/globus_cli/commands/gcp/create/guest.py
+++ b/src/globus_cli/commands/gcp/create/guest.py
@@ -6,15 +6,14 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
     ENDPOINT_PLUS_REQPATH,
     command,
-    endpointish_create_options,
+    endpointish_create_and_update_params,
 )
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 
 @command("guest", short_help="Create a new Guest Collection on GCP")
-@click.argument("DISPLAY_NAME")
+@endpointish_create_and_update_params("create", "collection")
 @click.argument("HOST_GCP_PATH", type=ENDPOINT_PLUS_REQPATH)
-@endpointish_create_options(name="collection")
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
 def guest_command(
     *,

--- a/src/globus_cli/commands/gcp/create/mapped.py
+++ b/src/globus_cli/commands/gcp/create/mapped.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import click
 
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import command, endpointish_create_options
+from globus_cli.parsing import command, endpointish_create_and_update_params
 from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 
 
 @command("mapped", short_help="Create a new GCP Mapped Collection")
-@click.argument("DISPLAY_NAME")
-@endpointish_create_options(name="collection")
+@endpointish_create_and_update_params("create", "collection")
 @click.option(
     "--subscription-id",
     help="Set the endpoint as a managed endpoint with the given subscription ID",

--- a/src/globus_cli/commands/gcp/create/mapped.py
+++ b/src/globus_cli/commands/gcp/create/mapped.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command, endpointish_create_options
+from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
+
+
+@command("mapped", short_help="Create a new GCP Mapped Collection")
+@click.argument("DISPLAY_NAME")
+@endpointish_create_options(name="collection")
+@click.option(
+    "--subscription-id",
+    help="Set the endpoint as a managed endpoint with the given subscription ID",
+)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+def mapped_command(
+    *,
+    login_manager: LoginManager,
+    display_name: str,
+    description: str | None,
+    info_link: str | None,
+    contact_info: str | None,
+    contact_email: str | None,
+    organization: str | None,
+    department: str | None,
+    keywords: str | None,
+    default_directory: str | None,
+    force_encryption: bool | None,
+    disable_verify: bool | None,
+    subscription_id: str | None,
+) -> None:
+    """
+    Create a new Globus Connect Personal Mapped Collection.
+
+    In GCP, the Mapped Collection and Endpoint are synonymous.
+
+    NOTE: This command does not install or start a local installation of Globus Connect
+    Personal. It performs the registration step with the Globus service and prints out a
+    setup-key which can be used to configure an installed Globus Connect Personal to use
+    that registration.
+    """
+    from globus_cli.services.transfer import assemble_generic_doc
+
+    transfer_client = login_manager.get_transfer_client()
+
+    # build the endpoint document to submit
+    ep_doc = assemble_generic_doc(
+        "endpoint",
+        is_globus_connect=True,
+        display_name=display_name,
+        description=description,
+        info_link=info_link,
+        contact_info=contact_info,
+        contact_email=contact_email,
+        organization=organization,
+        department=department,
+        keywords=keywords,
+        default_directory=default_directory,
+        force_encryption=force_encryption,
+        disable_verify=disable_verify,
+        subscription_id=subscription_id,
+    )
+
+    res = transfer_client.create_endpoint(ep_doc)
+
+    # output
+    formatted_print(
+        res,
+        fields=[
+            ("Message", "message"),
+            ("Collection ID", "id"),
+            ("Setup Key", "globus_connect_setup_key"),
+        ],
+        text_format=FORMAT_TEXT_RECORD,
+    )

--- a/src/globus_cli/parsing/__init__.py
+++ b/src/globus_cli/parsing/__init__.py
@@ -25,7 +25,9 @@ from .shared_options import (
     task_notify_option,
     task_submission_options,
 )
-from .shared_options.endpoint_create_and_update import endpointish_create_options
+from .shared_options.endpoint_create_and_update import (
+    endpointish_create_and_update_params,
+)
 from .shared_options.transfer_task_options import (
     encrypt_data_option,
     fail_on_quota_errors_option,
@@ -76,5 +78,5 @@ __all__ = [
     "preserve_timestamp_option",
     "skip_source_errors_option",
     "verify_checksum_option",
-    "endpointish_create_options",
+    "endpointish_create_and_update_params",
 ]

--- a/src/globus_cli/parsing/__init__.py
+++ b/src/globus_cli/parsing/__init__.py
@@ -25,6 +25,7 @@ from .shared_options import (
     task_notify_option,
     task_submission_options,
 )
+from .shared_options.endpoint_create_and_update import endpointish_create_options
 from .shared_options.transfer_task_options import (
     encrypt_data_option,
     fail_on_quota_errors_option,
@@ -75,4 +76,5 @@ __all__ = [
     "preserve_timestamp_option",
     "skip_source_errors_option",
     "verify_checksum_option",
+    "endpointish_create_options",
 ]

--- a/src/globus_cli/parsing/shared_options/endpoint_create_and_update.py
+++ b/src/globus_cli/parsing/shared_options/endpoint_create_and_update.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import functools
+from typing import Callable, TypeVar, Union, cast, overload
+
+import click
+
+C = TypeVar("C", bound=Union[Callable, click.Command])
+
+
+@overload
+def endpointish_create_options(f: C) -> C:
+    ...
+
+
+@overload
+def endpointish_create_options(*, name: str) -> Callable[[C], C]:
+    ...
+
+
+def endpointish_create_options(
+    f: C | None = None, *, name: str = "endpoint"
+) -> Callable[[C], C] | C:
+    if f is None:
+        return cast(
+            Callable[[C], C], functools.partial(endpointish_create_options, name=name)
+        )
+    f = click.option("--description", help=f"Description for the {name}")(f)
+    f = click.option("--info-link", help=f"Link for Info about the {name}")(f)
+    f = click.option("--contact-info", help=f"Contact Info for the {name}")(f)
+    f = click.option("--contact-email", help=f"Contact Email for the {name}")(f)
+    f = click.option("--organization", help=f"Organization for the {name}")(f)
+    f = click.option("--department", help=f"Department which operates the {name}")(f)
+    f = click.option(
+        "--keywords",
+        help=f"Comma separated list of keywords to help searches for the {name}",
+    )(f)
+
+    f = click.option("--default-directory", help="Set the default directory")(f)
+
+    f = click.option(
+        "--force-encryption/--no-force-encryption",
+        default=None,
+        help=f"Force the {name} to encrypt transfers",
+    )(f)
+    f = click.option(
+        "--disable-verify/--no-disable-verify",
+        default=None,
+        is_flag=True,
+        help=f"Set the {name} to ignore checksum verification",
+    )(f)
+
+    return f

--- a/tests/functional/endpoint/test_endpoint_create.py
+++ b/tests/functional/endpoint/test_endpoint_create.py
@@ -209,16 +209,3 @@ def test_invalid_managed_only_options(run_line):
             assert_exit_code=2,
         )
         assert "managed endpoints" in result.stderr
-
-
-def test_mutex_options(run_line):
-    options = [
-        "--default-directory /foo/ --no-default-directory",
-        "--subscription-id aa3ccabf-d0dc-4ea8-b6aa-6c9b4ae9b0d3 --no-managed",
-    ]
-    for opts in options:
-        result = run_line(
-            f"globus endpoint create withbadopts --server {opts}",
-            assert_exit_code=2,
-        )
-        assert "mutually exclusive" in result.stderr

--- a/tests/functional/endpoint/test_endpoint_update.py
+++ b/tests/functional/endpoint/test_endpoint_update.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 
 import pytest
 import responses
@@ -131,3 +132,18 @@ def test_invalid_managed_only_options(run_line):
             assert_exit_code=2,
         )
         assert "managed endpoints" in result.stderr
+
+
+def test_mutex_options(run_line):
+    subid = str(uuid.uuid1())
+    epid = str(uuid.uuid1())
+    options = [
+        "--default-directory /foo/ --no-default-directory",
+        f"--subscription-id {subid} --no-managed",
+    ]
+    for opts in options:
+        result = run_line(
+            f"globus endpoint update {epid} {opts}",
+            assert_exit_code=2,
+        )
+        assert "mutually exclusive" in result.stderr

--- a/tests/functional/test_gcp.py
+++ b/tests/functional/test_gcp.py
@@ -1,0 +1,25 @@
+import json
+
+from globus_sdk._testing import load_response_set
+
+
+def test_gcp_create_mapped(run_line):
+    load_response_set("cli.gcp_create")
+    result = run_line("globus gcp create mapped mygcp -F json")
+    res = json.loads(result.output)
+    assert res["DATA_TYPE"] == "endpoint_create_result"
+    assert res["code"] == "Created"
+    assert "id" in res
+
+
+def test_gcp_create_share(run_line):
+    load_response_set("cli.endpoint_operations")
+    meta = load_response_set("cli.transfer_activate_success").metadata
+    epid = meta["endpoint_id"]
+
+    result = run_line(f"globus gcp create guest myshare -F json {epid}:/~/")
+    res = json.loads(result.output)
+    assert res["DATA_TYPE"] == "endpoint_create_result"
+    assert res["code"] == "Created"
+    assert "Shared endpoint" in res["message"]
+    assert "id" in res

--- a/tests/functional/test_gcp.py
+++ b/tests/functional/test_gcp.py
@@ -1,25 +1,92 @@
 import json
+import uuid
 
-from globus_sdk._testing import load_response_set
-
-
-def test_gcp_create_mapped(run_line):
-    load_response_set("cli.gcp_create")
-    result = run_line("globus gcp create mapped mygcp -F json")
-    res = json.loads(result.output)
-    assert res["DATA_TYPE"] == "endpoint_create_result"
-    assert res["code"] == "Created"
-    assert "id" in res
+import pytest
+from globus_sdk._testing import load_response_set, register_response_set
 
 
-def test_gcp_create_share(run_line):
-    load_response_set("cli.endpoint_operations")
-    meta = load_response_set("cli.transfer_activate_success").metadata
-    epid = meta["endpoint_id"]
+@pytest.fixture(scope="session", autouse=True)
+def _create_mapped_responses():
+    ep_id = str(uuid.uuid1())
+    setup_key = str(uuid.uuid1())
+    register_response_set(
+        "gcp_create_mapped",
+        {
+            "default": {
+                "service": "transfer",
+                "path": "/endpoint",
+                "method": "POST",
+                "json": {
+                    "DATA_TYPE": "endpoint_create_result",
+                    "code": "Created",
+                    "message": "Endpoint created",
+                    "globus_connect_setup_key": setup_key,
+                    "id": ep_id,
+                    "request_id": "ABCdef789",
+                },
+            },
+        },
+        metadata={"ep_id": ep_id, "setup_key": setup_key},
+    )
 
-    result = run_line(f"globus gcp create guest myshare -F json {epid}:/~/")
-    res = json.loads(result.output)
-    assert res["DATA_TYPE"] == "endpoint_create_result"
-    assert res["code"] == "Created"
-    assert "Shared endpoint" in res["message"]
-    assert "id" in res
+
+@pytest.fixture(scope="session", autouse=True)
+def _create_guest_responses():
+    host_id = str(uuid.uuid1())
+    share_id = str(uuid.uuid1())
+    register_response_set(
+        "gcp_create_guest",
+        {
+            "activate_host": {
+                "service": "transfer",
+                "path": f"/endpoint/{host_id}/autoactivate",
+                "method": "POST",
+                "json": {"code": "AutoActivated.BogusCode"},
+            },
+            "share_create": {
+                "service": "transfer",
+                "path": "/shared_endpoint",
+                "method": "POST",
+                "json": {
+                    "DATA_TYPE": "endpoint_create_result",
+                    "code": "Created",
+                    "message": "Shared endpoint created",
+                    "id": share_id,
+                    "request_id": "ABCdef789",
+                },
+            },
+        },
+        metadata={"host_id": host_id, "share_id": share_id},
+    )
+
+
+@pytest.mark.parametrize("output_format", ["json", "text"])
+def test_gcp_create_mapped(run_line, output_format):
+    meta = load_response_set("gcp_create_mapped").metadata
+    result = run_line(f"globus gcp create mapped mygcp -F {output_format}")
+    if output_format == "json":
+        res = json.loads(result.output)
+        assert res["DATA_TYPE"] == "endpoint_create_result"
+        assert res["code"] == "Created"
+        assert res["id"] == meta["ep_id"]
+    else:
+        assert meta["ep_id"] in result.output
+        assert meta["setup_key"] in result.output
+
+
+@pytest.mark.parametrize("output_format", ["json", "text"])
+def test_gcp_create_share(run_line, output_format):
+    meta = load_response_set("gcp_create_guest").metadata
+    host_id = meta["host_id"]
+
+    result = run_line(
+        f"globus gcp create guest myshare -F {output_format} {host_id}:/~/"
+    )
+    if output_format == "json":
+        res = json.loads(result.output)
+        assert res["DATA_TYPE"] == "endpoint_create_result"
+        assert res["code"] == "Created"
+        assert "Shared endpoint" in res["message"]
+        assert res["id"] == meta["share_id"]
+    else:
+        assert meta["share_id"] in result.output


### PR DESCRIPTION
This introduces `globus gcp create mapped` and `globus gcp create guest` to create a GCP Endpoint a.k.a. Mapped Collection or a Shared Endpoint on GCP a.k.a. Guest Collection, respectively.
It is the first in a long series of steps towards replacing `globus endpoint create` with more GCSv5-compatible commands.

These commands needed _some_ but not all of the options which were previously shared between `globus endpoint create|update`, which necessitated a bit of work on shared option refactoring in the parsing subpackage. Specifically, a new decorator has been introduced with usage as follows:
```python
@endpointish_create_and_update_params("create", "collection")
def gcp_create_guest(...): ...

@endpointish_create_and_update_params("create", "collection")
def gcp_create_mapped(...): ...

@endpointish_create_and_update_params("create")
def endpoint_create(...): ...

@endpointish_create_and_update_params("update")
def endpoint_update(...): ...
```

The first parameter to `endpointish_create_and_update_params` is checked with `typing.Literal["create", "update"]`, so a variety of potential typos are rendered impossible. (Read: `typing.Literal` makes it safer and easier to define string-based internal APIs.)
Because the Literal usage is type-checked with `assert_never()`, `typing_extensions` is added to requirements data to support python < 3.11.

The `globus endpoint create` command is now documented as deprecated, but no runtime warning or other change is made.
After checking with our PM team, I've confirmed some of the helptext and changelog details, so we're okay to ship this text in a release without worrying about the phrasing.

The command implementations themselves look very similar to two of the branching paths of `globus endpoint create`. For `create mapped`, a single endpoint creation call is performed, and for `create guest`, the host is checked for activation, and then the shared endpoint creation call is performed. In both cases, the text output fields are similar to `globus endpoint create` outputs: `Message, Collection ID` and `Message, Collection ID, Setup Key`.

One related subtle change is included here to `globus endpoint create`. As part of the parameter refactor, `endpoint_create_and_update_params` was split into two decorators, `endpoint_create_params` and `endpoint_update_params`. Since `globus endpoint create --no-default-directory` doesn't make sense as a usage, `--no-default-directory` is only applied in the `endpoint_update_params` (along with the associated mutex info).

New tests are modeled fairly closely on the existing `globus endpoint create` tests, and a test-case for `--no-default-directory` needed to switch from `create` to `update`.