### PR TITLE
Update to mypy==0.982 and add update script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     - id: pyupgrade
       args: ["--py36-plus"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.971
+  rev: v0.982
   hooks:
     - id: mypy
       additional_dependencies:

--- a/scripts/update_mypy.py
+++ b/scripts/update_mypy.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import urllib.request
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+
+class Abort(RuntimeError):
+    pass
+
+
+def get_mypy_latest() -> str:
+    with urllib.request.urlopen("https://pypi.python.org/pypi/mypy/json") as conn:
+        version_data = json.load(conn)
+    return str(version_data["info"]["version"])
+
+
+def bump_mypy_version_on_file(path: pathlib.Path, new_version: str) -> None:
+    print(f"updating mypy in {path.relative_to(REPO_ROOT)} ... ", end="")
+    with open(path) as fp:
+        content = fp.read()
+    match = re.search(r"mypy==(\d+\.\d+)", content)
+    if not match:
+        raise Abort(f"{path} did not contain mypy version pattern")
+
+    old_version = match.group(1)
+    old_str = f"mypy=={old_version}"
+    new_str = f"mypy=={new_version}"
+    content = content.replace(old_str, new_str)
+    with open(path, "w") as fp:
+        fp.write(content)
+    print("ok")
+
+
+def bump_mypy_version_in_precommit(path: pathlib.Path, new_version: str) -> None:
+    print(f"updating mypy in {path.relative_to(REPO_ROOT)} ... ", end="")
+    with open(path) as fp:
+        content = fp.readlines()
+    found_line = -1
+    for lineno, line in enumerate(content):
+        if line.strip() == "- repo: https://github.com/pre-commit/mirrors-mypy":
+            found_line = lineno
+            break
+    if found_line == -1:
+        raise Abort(f"{path} did not contain mypy repo line")
+
+    target_line = found_line + 1
+    if target_line >= len(content):
+        raise Abort(f"{path} had mypy repo line as last line (needs rev line next)")
+
+    match = re.search(r"\s+rev:\sv(\d+\.\d+)", content[target_line])
+    if not match:
+        raise Abort(f"{path} did not have rev line after repo line")
+
+    old_version = match.group(1)
+    content[target_line] = content[target_line].replace(old_version, new_version)
+    with open(path, "w") as fp:
+        fp.write("".join(content))
+    print("ok")
+
+
+def bump_mypy_version() -> None:
+    new_version = get_mypy_latest()
+    bump_mypy_version_on_file(REPO_ROOT / "tox.ini", new_version)
+    bump_mypy_version_in_precommit(REPO_ROOT / ".pre-commit-config.yaml", new_version)
+
+
+def main() -> None:
+    bump_mypy_version()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/globus_cli/parsing/mutex_group.py
+++ b/src/globus_cli/parsing/mutex_group.py
@@ -7,8 +7,7 @@ import click
 
 from ..utils import format_list_of_words
 
-RT = TypeVar("RT")
-C = TypeVar("C", bound=Callable[..., RT])
+C = TypeVar("C", bound=Callable)
 
 
 class MutexInfo:
@@ -62,7 +61,7 @@ def mutex_option_group(*options: str | MutexInfo) -> Callable[[C], C]:
 
     def decorator(func: C) -> C:
         @functools.wraps(func)
-        def wrapped(*args: Any, **kwargs: Any) -> RT:
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
             found_opts = []
             for opt in opt_infos:
                 if opt.is_present(kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ commands = pre-commit run --all-files
 
 [testenv:mypy]
 deps =
-    mypy==0.971
+    mypy==0.982
     types-jwt
     types-requests
     types-jmespath


### PR DESCRIPTION
1. Copy the SDK version bump script and use it to write a mypy update script which tweaks tox.ini and .pre-commit-config.yaml
2. Apply the script update (latest mypy version is now in use)
3. Adjust one annotation to pass under the new mypy

Regarding (3), the failure stems from an annotation being more specific than is really needed. An extra type variable is being used and bound as a parameter to another type variable -- probably this should be supported by mypy, but perhaps there's a reason that it should not. In any case, the typevar is not really needed since the entire value in question is being passed through a `cast` call after the usage site. Therefore, the wayward type variable can be safely replaced with Any.

Regarding (1), this may be an unnecessary script being added. However, it's a nice and low-key way of exploring the potential space for an auto-update process which ensures the mypy version stays consistent. Next step: should we hook this script in to generate automatic PRs which bump `mypy` in both locations?