### PR TITLE
Remove mypy from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,16 +28,6 @@ repos:
   hooks:
     - id: pyupgrade
       args: ["--py36-plus"]
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.982
-  hooks:
-    - id: mypy
-      additional_dependencies:
-        - types-setuptools
-        - types-requests
-        - types-jmespath
-        - click
-        - 'globus-sdk==3.11.0'
 - repo: local
   hooks:
     - id: fix-changelog


### PR DESCRIPTION
mypy is run under `tox -e mypy` already, in a more reproducible way. Under `pre-commit`, we run into issues because the same dependency graph as the real package must be installed, but `additional_dependencies` does not support this cleanly.

A similar change and range of issues is explained in greater depth in the globus-sdk, under
  https://github.com/globus/globus-sdk-python/pull/620

Similarly here, the changes allow for local and CI runs on mypy to continue, but remove it from pre-commit config.