### PR TITLE
Timer create data_access handling part 1

### DIFF
--- a/src/globus_cli/endpointish/endpointish.py
+++ b/src/globus_cli/endpointish/endpointish.py
@@ -77,3 +77,10 @@ class Endpointish:
     def get_gcs_address(self) -> str:
         self.assert_ep_type(EndpointType.gcsv5_types())
         return cast(str, self.data["DATA"][0]["hostname"])
+
+    @property
+    def requires_data_access_scope(self) -> bool:
+        if self.ep_type is EndpointType.MAPPED_COLLECTION:
+            if self.data.get("high_assurance") is False:
+                return True
+        return False


### PR DESCRIPTION
Enable detection of endpoints which *will* require use of the data_access scope, and reject them when used with the `globus timer create transfer` command.

This checks for non-HA Mapped Collections and rejects them with a usage error.