### PR TITLE
Update flake8-typing-as-t, remove TYT03 ignores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     - id: flake8
       additional_dependencies:
         - 'flake8-bugbear==22.7.1'
-        - 'flake8-typing-as-t==0.0.1'
+        - 'flake8-typing-as-t==0.0.2'
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:

--- a/src/globus_cli/commands/group/invite/_common.py
+++ b/src/globus_cli/commands/group/invite/_common.py
@@ -14,7 +14,7 @@ if t.TYPE_CHECKING:
     from globus_cli.services.auth import CustomAuthClient
 
 if sys.version_info >= (3, 8):
-    from typing import Literal  # noqa: TYT03
+    from typing import Literal
 else:
     from typing_extensions import Literal
 

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -29,7 +29,7 @@ from globus_cli.termio import FORMAT_TEXT_RECORD, formatted_print
 from .._common import DATETIME_FORMATS, JOB_FORMAT_FIELDS
 
 if sys.version_info >= (3, 8):
-    from typing import Literal  # noqa: TYT03
+    from typing import Literal
 else:
     from typing_extensions import Literal
 

--- a/src/globus_cli/parsing/shared_options/endpoint_create_and_update.py
+++ b/src/globus_cli/parsing/shared_options/endpoint_create_and_update.py
@@ -4,11 +4,11 @@ import sys
 import typing as t
 
 if sys.version_info >= (3, 8):
-    from typing import Literal  # noqa: TYT03
+    from typing import Literal
 else:
     from typing_extensions import Literal
 if sys.version_info >= (3, 11):
-    from typing import assert_never  # noqa: TYT03
+    from typing import assert_never
 else:
     from typing_extensions import assert_never
 


### PR DESCRIPTION
flake8-typing-as-t now understands version_info inspection, so it is not necessary to ignore conditional 'from typing import ...' usage.

---

This is basically a copy of https://github.com/globus/globus-sdk-python/pull/625

@kurtmckee, sorry for picking you as the only reviewer for these PRs, but you were the one who flagged this earlier and I thought you might like seeing that it was fixed! 😄 