### PR TITLE
Add `globus flows delete` to delete flow by ID

### DIFF
--- a/changelog.d/20221102_023238_sirosen_add_delete_flow.md
+++ b/changelog.d/20221102_023238_sirosen_add_delete_flow.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add `globus flows delete` to delete a flow by ID

--- a/src/globus_cli/commands/flows/__init__.py
+++ b/src/globus_cli/commands/flows/__init__.py
@@ -5,6 +5,7 @@ from globus_cli.parsing import group
     "flows",
     lazy_subcommands={
         "list": (".list", "list_command"),
+        "delete": (".delete", "delete_command"),
     },
 )
 def flows_command():

--- a/src/globus_cli/commands/flows/delete.py
+++ b/src/globus_cli/commands/flows/delete.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import uuid
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command, flow_id_arg
+from globus_cli.termio import Field, TextMode, display, formatters
+
+
+@command("delete", short_help="Delete a flow")
+@flow_id_arg
+@LoginManager.requires_login(LoginManager.FLOWS_RS)
+def delete_command(login_manager: LoginManager, flow_id: uuid.UUID):
+    """
+    Delete a flow
+    """
+    flows_client = login_manager.get_flows_client()
+
+    fields = [
+        Field("Deleted", "DELETED", formatter=formatters.Bool),
+        Field("Flow ID", "id"),
+        Field("Title", "title"),
+        Field(
+            "Owner",
+            "flow_owner",
+            formatter=formatters.auth.PrincipalURNFormatter(
+                login_manager.get_auth_client()
+            ),
+        ),
+        Field("Created At", "created_at", formatter=formatters.Date),
+        Field("Updated At", "updated_at", formatter=formatters.Date),
+    ]
+
+    res = flows_client.delete_flow(flow_id)
+    display(res, fields=fields, text_mode=TextMode.text_record)

--- a/src/globus_cli/parsing/__init__.py
+++ b/src/globus_cli/parsing/__init__.py
@@ -16,9 +16,7 @@ from .param_types import (
     nullable_multi_callback,
 )
 from .shared_options import (
-    collection_id_arg,
     delete_and_rm_options,
-    endpoint_id_arg,
     no_local_server_option,
     security_principal_opts,
     synchronous_task_wait_options,
@@ -28,6 +26,7 @@ from .shared_options import (
 from .shared_options.endpoint_create_and_update import (
     endpointish_create_and_update_params,
 )
+from .shared_options.id_args import collection_id_arg, endpoint_id_arg, flow_id_arg
 from .shared_options.transfer_task_options import (
     encrypt_data_option,
     fail_on_quota_errors_option,
@@ -61,9 +60,10 @@ __all__ = [
     "mutex_option_group",
     "nullable_multi_callback",
     "one_use_option",
-    # Transfer options
+    # shared options
     "collection_id_arg",
     "endpoint_id_arg",
+    "flow_id_arg",
     "task_submission_options",
     "delete_and_rm_options",
     "synchronous_task_wait_options",

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -57,37 +57,6 @@ def common_options(
     return f
 
 
-def collection_id_arg(f: t.Callable | None = None, *, metavar: str = "COLLECTION_ID"):
-    if f is None:
-        return functools.partial(collection_id_arg, metavar=metavar)
-    return click.argument("collection_id", metavar=metavar, type=click.UUID)(f)
-
-
-def endpoint_id_arg(f: t.Callable | None = None, *, metavar: str = "ENDPOINT_ID"):
-    """
-    This is the `ENDPOINT_ID` argument consumed by many Transfer and GCS
-    endpoint related operations. It accepts alternate metavars for cases
-    when another name is desirable (e.x. `SHARE_ID`, `HOST_ENDPOINT_ID`), but
-    can also be applied as a direct decorator if no specialized metavar is
-    being passed.
-
-    Usage:
-
-    >>> @endpoint_id_arg
-    >>> def command_func(endpoint_id):
-    >>>     ...
-
-    or
-
-    >>> @endpoint_id_arg(metavar='HOST_ENDPOINT_ID')
-    >>> def command_func(endpoint_id):
-    >>>     ...
-    """
-    if f is None:
-        return functools.partial(endpoint_id_arg, metavar=metavar)
-    return click.argument("endpoint_id", metavar=metavar, type=click.UUID)(f)
-
-
 def task_notify_option(f: C) -> C:
     def notify_opt_callback(ctx, param, value):
         """

--- a/src/globus_cli/parsing/shared_options/id_args.py
+++ b/src/globus_cli/parsing/shared_options/id_args.py
@@ -1,0 +1,39 @@
+"""
+These are semi-standard arg names with overridable metavars.
+
+Basic usage:
+
+>>> @endpoint_id_arg
+>>> def command_func(endpoint_id: uuid.UUID):
+>>>     ...
+
+Override metavar (note that argname is unchanged):
+
+>>> @endpoint_id_arg(metavar='HOST_ENDPOINT_ID')
+>>> def command_func(endpoint_id: uuid.UUID):
+>>>     ...
+"""
+from __future__ import annotations
+
+import functools
+import typing as t
+
+import click
+
+
+def collection_id_arg(f: t.Callable | None = None, *, metavar: str = "COLLECTION_ID"):
+    if f is None:
+        return functools.partial(collection_id_arg, metavar=metavar)
+    return click.argument("collection_id", metavar=metavar, type=click.UUID)(f)
+
+
+def endpoint_id_arg(f: t.Callable | None = None, *, metavar: str = "ENDPOINT_ID"):
+    if f is None:
+        return functools.partial(endpoint_id_arg, metavar=metavar)
+    return click.argument("endpoint_id", metavar=metavar, type=click.UUID)(f)
+
+
+def flow_id_arg(f: t.Callable | None = None, *, metavar: str = "FLOW_ID"):
+    if f is None:
+        return functools.partial(flow_id_arg, metavar=metavar)
+    return click.argument("flow_id", metavar=metavar, type=click.UUID)(f)

--- a/tests/functional/flows/test_delete_flow.py
+++ b/tests/functional/flows/test_delete_flow.py
@@ -1,0 +1,43 @@
+import re
+
+from globus_sdk._testing import RegisteredResponse, load_response
+
+
+def test_delete_flow_text_output(run_line):
+    delete_response = load_response("flows.delete_flow")
+    flow_id = delete_response.metadata["flow_id"]
+    load_response(
+        RegisteredResponse(
+            service="auth",
+            path="/v2/api/identities",
+            json={
+                "identities": [
+                    {
+                        "username": "legolas@rivendell.middleearth",
+                        "name": "Orlando Bloom",
+                        "id": delete_response.json["flow_owner"].split(":")[-1],
+                        "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+                        "organization": "Fellowship of the Ring",
+                        "status": "used",
+                        "email": "legolas@thewoodlandrealm.middleearth",
+                    }
+                ]
+            },
+        )
+    )
+
+    result = run_line(f"globus flows delete {flow_id}")
+    # all fields present
+    for fieldname in (
+        "Deleted",
+        "Flow ID",
+        "Title",
+        "Owner",
+        "Created At",
+        "Updated At",
+    ):
+        assert fieldname in result.output
+    # owner was resolved to a username
+    assert "legolas@rivendell.middleearth" in result.output
+    # bool formatter worked as expected
+    assert re.search(r"Deleted:\s+True", result.output) is not None


### PR DESCRIPTION
In addition to the core change here, a new command, some of the parsing code is slightly rearranged. `endpoint_id_arg` and `collection_id_arg` helpers are moved into a dedicated module where they are joined by `flow_id_arg`. The goal of this adjustment is not to make major changes, but to better make room for `flow_id_arg`.

The test case relies on globus_sdk._testing data as well as an explicit mock.