### PR TITLE
Add `globus flows show` to display a flow by ID

### DIFF
--- a/changelog.d/20221102_031847_sirosen_add_show_flow.md
+++ b/changelog.d/20221102_031847_sirosen_add_show_flow.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Add a new command, `globus flows show` which displays information about a
+  single flow

--- a/src/globus_cli/commands/flows/__init__.py
+++ b/src/globus_cli/commands/flows/__init__.py
@@ -6,6 +6,7 @@ from globus_cli.parsing import group
     lazy_subcommands={
         "list": (".list", "list_command"),
         "delete": (".delete", "delete_command"),
+        "show": (".show", "show_command"),
     },
 )
 def flows_command():

--- a/src/globus_cli/commands/flows/show.py
+++ b/src/globus_cli/commands/flows/show.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import uuid
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command, flow_id_arg
+from globus_cli.termio import Field, TextMode, display, formatters
+
+
+@command("show")
+@flow_id_arg
+@LoginManager.requires_login(LoginManager.FLOWS_RS)
+def show_command(login_manager: LoginManager, flow_id: uuid.UUID):
+    """
+    Show a flow
+    """
+    flows_client = login_manager.get_flows_client()
+    auth_client = login_manager.get_auth_client()
+
+    res = flows_client.get_flow(flow_id)
+
+    principal_formatter = formatters.auth.PrincipalURNFormatter(auth_client)
+    for principal_set_name in ("flow_administrators", "flow_viewers", "flow_starters"):
+        for value in res.get(principal_set_name, ()):
+            principal_formatter.add_item(value)
+    principal_formatter.add_item(res.get("flow_owner"))
+
+    fields = [
+        Field("Flow ID", "id"),
+        Field("Title", "title"),
+        Field("Keywords", "keywords", formatter=formatters.ArrayFormatter()),
+        Field("Owner", "flow_owner", formatter=principal_formatter),
+        Field("Created At", "created_at", formatter=formatters.Date),
+        Field("Updated At", "updated_at", formatter=formatters.Date),
+        Field(
+            "Administrators",
+            "flow_administrators",
+            formatter=formatters.ArrayFormatter(element_formatter=principal_formatter),
+        ),
+        Field(
+            "Viewers",
+            "flow_viewers",
+            formatter=formatters.ArrayFormatter(element_formatter=principal_formatter),
+        ),
+        Field(
+            "Starters",
+            "flow_starters",
+            formatter=formatters.ArrayFormatter(element_formatter=principal_formatter),
+        ),
+    ]
+
+    display(res, fields=fields, text_mode=TextMode.text_record)

--- a/tests/functional/flows/test_show_flow.py
+++ b/tests/functional/flows/test_show_flow.py
@@ -1,0 +1,63 @@
+import re
+
+from globus_sdk._testing import RegisteredResponse, load_response
+
+
+def test_show_flow_text_output(run_line):
+    get_response = load_response("flows.get_flow")
+    flow_id = get_response.metadata["flow_id"]
+    keywords = get_response.json["keywords"]
+    load_response(
+        RegisteredResponse(
+            service="auth",
+            path="/v2/api/identities",
+            json={
+                "identities": [
+                    {
+                        "username": "legolas@rivendell.middleearth",
+                        "name": "Orlando Bloom",
+                        "id": get_response.json["flow_owner"].split(":")[-1],
+                        "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+                        "organization": "Fellowship of the Ring",
+                        "status": "used",
+                        "email": "legolas@thewoodlandrealm.middleearth",
+                    }
+                ]
+            },
+        )
+    )
+
+    result = run_line(f"globus flows show {flow_id}")
+    # all fields present
+    for fieldname in (
+        "Flow ID",
+        "Title",
+        "Keywords",
+        "Owner",
+        "Created At",
+        "Updated At",
+        "Administrators",
+        "Viewers",
+        "Starters",
+    ):
+        assert fieldname in result.output
+    # array formatters worked as expected
+    assert (
+        re.search(r"Keywords:\s+" + re.escape(",".join(keywords)), result.output)
+        is not None
+    )
+    assert (
+        re.search(r"Administrators:\s+legolas@rivendell\.middleearth", result.output)
+        is not None
+    )
+    assert (
+        re.search(r"Viewers:\s+public,legolas@rivendell\.middleearth", result.output)
+        is not None
+    )
+    assert (
+        re.search(
+            r"Starters:\s+all_authenticated_users,legolas@rivendell\.middleearth",
+            result.output,
+        )
+        is not None
+    )


### PR DESCRIPTION
This command demonstrates some novel use of the new field formatter system, converting lists of principal URNs to lists of usernames.

Like `globus flows delete`, testing mixes SDK-provided test data with explicit mock data.