### PR TITLE
Add support for timer create with data_access

### DIFF
--- a/changelog.d/20221102_223217_sirosen_timer_prompt.md
+++ b/changelog.d/20221102_223217_sirosen_timer_prompt.md
@@ -1,0 +1,9 @@
+### Enhancements
+
+* Add `globus timer create transfer` as a new command for creating new timers
+
+** The command prompts for login if data_access consents are detected as a
+   requirement
+
+* `globus session consent` now supports a `--timer-data-access` flag, specifically
+   to help support timer creation

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -42,7 +42,7 @@ def session_consent(
 
     if timer_data_access:
         scope_list.append(
-            str(compute_timer_scope(data_access_collection_ids=timer_data_access))
+            compute_timer_scope(data_access_collection_ids=timer_data_access)
         )
     if not scope_list:
         raise click.UsageError(

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -4,7 +4,7 @@ import click
 from globus_sdk.scopes import MutableScope
 
 from globus_cli import utils
-from globus_cli.login_manager import LoginManager
+from globus_cli.login_manager import LoginManager, compute_timer_scope
 from globus_cli.parsing import command, no_local_server_option
 
 
@@ -14,8 +14,21 @@ from globus_cli.parsing import command, no_local_server_option
     disable_options=["format", "map_http_status"],
 )
 @no_local_server_option
-@click.argument("SCOPES", nargs=-1, required=True)
-def session_consent(scopes: tuple[str], no_local_server: bool) -> None:
+@click.argument("SCOPES", nargs=-1)
+@click.option(
+    "--timer-data-access",
+    multiple=True,
+    help=(
+        "This is a shorthand for specifying a Globus Timer data_access scope, "
+        "a type of consent needed for a timer to access certain collections."
+    ),
+)
+def session_consent(
+    *,
+    scopes: tuple[str, ...],
+    timer_data_access: tuple[str, ...],
+    no_local_server: bool,
+) -> None:
     """
     Update your current CLI auth session by authenticating with a specific scope or set
     of scopes.
@@ -26,6 +39,16 @@ def session_consent(scopes: tuple[str], no_local_server: bool) -> None:
     scope_list: list[str | MutableScope] = [
         utils.unquote_cmdprompt_single_quotes(s) for s in scopes
     ]
+
+    if timer_data_access:
+        scope_list.append(
+            str(compute_timer_scope(data_access_collection_ids=timer_data_access))
+        )
+    if not scope_list:
+        raise click.UsageError(
+            "You must provide either SCOPES or at least one scope-defining option."
+        )
+
     manager = LoginManager()
 
     manager.run_login_flow(

--- a/src/globus_cli/commands/timer/create/__init__.py
+++ b/src/globus_cli/commands/timer/create/__init__.py
@@ -4,7 +4,6 @@ from globus_cli.parsing import group
 @group(
     "create",
     short_help="Submit a Timer job",
-    hidden=True,
     lazy_subcommands={"transfer": (".transfer", "transfer_command")},
 )
 def create_command() -> None:

--- a/src/globus_cli/login_manager/__init__.py
+++ b/src/globus_cli/login_manager/__init__.py
@@ -15,6 +15,7 @@ from .utils import is_remote_session
 
 __all__ = [
     "MissingLoginError",
+    "compute_timer_scope",
     "is_remote_session",
     "LoginManager",
     "delete_templated_client",

--- a/src/globus_cli/login_manager/__init__.py
+++ b/src/globus_cli/login_manager/__init__.py
@@ -15,7 +15,6 @@ from .utils import is_remote_session
 
 __all__ = [
     "MissingLoginError",
-    "compute_timer_scope",
     "is_remote_session",
     "LoginManager",
     "delete_templated_client",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,8 +80,14 @@ def mock_login_token_response():
     mock_token_res.by_resource_server = {
         "auth.globus.org": _mock_token_response_data(
             "auth.globus.org",
-            "openid profile email "
-            "urn:globus:auth:scope:auth.globus.org:view_identity_set",
+            " ".join(
+                [
+                    "openid",
+                    "profile",
+                    "email",
+                    "urn:globus:auth:scope:auth.globus.org:view_identity_set",
+                ]
+            ),
         ),
         "transfer.api.globus.org": _mock_token_response_data(
             "transfer.api.globus.org",
@@ -133,6 +139,12 @@ def test_token_storage(mock_login_token_response):
     mockstore.store_config(
         "auth_client_data",
         {"client_id": "fakeClientIDString", "client_secret": "fakeClientSecret"},
+    )
+    # NB: this carefully matches the ID provided by our "foo_user_info" data fixture
+    # in the future, this should be moved to a dedicated fixture providing the current
+    # user's identity ID
+    mockstore.store_config(
+        "auth_user_data", {"sub": "25de0aed-aa83-4600-a1be-a62a910af116"}
     )
     mockstore.store(mock_login_token_response)
     return mockstore


### PR DESCRIPTION
EDIT: revised 2023-02-17 after a significant overhaul to use the consents API.

There is at least one noted significant issue identified during final review.

---

Subsequent to the changes below, `globus timer create transfer` is no longer marked hidden and it is included in the changelog. This therefore marks the "release" of `globus timer create transfer` as a command.

In order to support this change, the `timer` scope handling, which also touches on the main login codepath, had to be reworked. There are two reasons for this:

1. This effort uncovered that the scope requested was not sufficient for new transfer timers. The needed scope is `timer[transfer_ap[transfer]]`, but we only requested `timer` previously.

2. It needs to be possible the parametrize the most nested one of these scopes (the `transfer` scope) with dependencies. So a scope-building helper was introduced, `compute_timer_scope`

`compute_timer_scope` encodes the construction of two variant scope strings: `timer[transfer_ap[transfer]]` and
`timer[transfer_ap[transfer[foo/data_access bar/data_access]]]`. One with and one without some set of data_access scopes. The first variant is baked into the LoginManager as the statically required Timer scope.

Client Credentials handling is not included in the data_access handling code for the time being. Therefore, if client credentials are used to run `globus timer create transfer` against a collection with `data_access`, an explicit usage error is thrown for now. In the future, it should be possible to use client creds to request a new token which has the required dependency, but this is set aside as future work.


---

## ⚠️ The remaining "consent gap" in `requires_login` (resolved! ✔️ )

Original text preserved below, but this problem was solved.

`requires_login` cannot -- even with our recent changes to detect needed scopes -- detect changes in scope dependencies. Therefore, it is possible that a user will have logged in in the past, have a timer token which does not have the dependent scope chain, and will *not* be prompted to login again.
We could simply recommend that anyone who finds that timer creation fails do a logout and login, but I find that unsatisfactory as a workaround. I'd rather figure out how we want to track the addition of scope dependencies.

I'm going to work on this now, but it may be better to flip the `hidden=True` flag back to `False` so that this could merge and we're not announcing support for something unfinished, while still getting the rest of this body of work merged.

---

## Post-rebase

I've rebased and, in order to have any kind of sensible messaging in the git log, squashed everything down to one commit.
We kept pulling bits and pieces out of this, so the rebase stopped really making sense when I was looking through the commits.

I'm going to self-review the results here at least once, and I think this would benefit from a final round of testing as well.