### PR TITLE
Separate test and dev deps, remove pytest-cov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 parallel = True
+include = src/*
 
 [report]
 show_missing = True
@@ -13,11 +14,7 @@ exclude_lines =
     assert_never()
     # don't check on executable components of importable modules
     if __name__ == .__main__.:
-    # don't check 'TYPE_CHECKING' blocks
-    if TYPE_CHECKING:
-    if typing.TYPE_CHECKING:
+    # don't check coverage on type checking conditionals
     if t.TYPE_CHECKING:
-    # don't check typing overloads
-    @overload
-    @typing.overload
+    # skip overloads
     @t.overload

--- a/changelog.d/20221110_101524_kurtmckee_support_python_3_11.md
+++ b/changelog.d/20221110_101524_kurtmckee_support_python_3_11.md
@@ -1,4 +1,3 @@
 ### Other
 
 * Support Python 3.11.
-* List scriv and tox as development dependencies.

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ paths = ./src/globus_cli/
 
 
 [tool:pytest]
-addopts = --cov=src --no-cov-on-fail --timeout 3
+addopts = --timeout 3
 filterwarnings =
     # warnings are errors, like -Werror
     error

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,17 @@ import re
 
 from setuptools import find_packages, setup
 
-DEV_REQUIREMENTS = [
-    # tests
-    "tox<4",
+TEST_REQUIREMENTS = [
+    "coverage<7",
     "pytest<7",
-    "pytest-cov<3",
     "pytest-xdist<3",
     "pytest-timeout<2",
     "responses==0.17.0",
     # loading test fixture data
     "ruamel.yaml==0.17.16",
-    # development
+]
+DEV_REQUIREMENTS = TEST_REQUIREMENTS + [
+    "tox<4",
     "scriv==0.17.0",
 ]
 
@@ -56,7 +56,7 @@ setup(
         # not have all of the typing features we use
         'typing_extensions>=4.0;python_version<"3.11"',
     ],
-    extras_require={"development": DEV_REQUIREMENTS},
+    extras_require={"test": TEST_REQUIREMENTS, "development": DEV_REQUIREMENTS},
     entry_points={"console_scripts": ["globus = globus_cli:main"]},
     # descriptive info, non-critical
     description="Globus CLI",

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ minversion = 3.0.0
 
 [testenv]
 usedevelop = true
-extras = development
+extras = test
 passenv = GLOBUS_SDK_PATH
 deps =
     mindeps: click==8.0.0
@@ -28,15 +28,21 @@ deps =
 #   GLOBUS_SDK_PATH=../globus-sdk tox -e 'py{37,38,39,310,311}-localsdk'
 commands =
     localsdk: python -c 'import os, subprocess, sys; subprocess.run([sys.executable, "-m", "pip", "install", "-e", os.environ["GLOBUS_SDK_PATH"]])'
-    pytest --cov-append --cov-report= {posargs}
+    coverage run -m pytest {posargs}
 depends =
     py{37,38,39,310,311}{,-mindeps}: cov-clean
-    cov-report: py{37,38,39,310,311}{,-mindeps}
+    cov-combine: py{37,38,39,310,311}{,-mindeps}
+    cov-report: cov-combine
 
 [testenv:cov-clean]
 deps = coverage
 skip_install = true
 commands = coverage erase
+
+[testenv:cov-combine]
+deps = coverage
+skip_install = true
+commands = coverage combine
 
 [testenv:cov-report]
 deps = coverage


### PR DESCRIPTION
Introducing a 'test' extra to make the two sets of dependencies independently installable.

Also changed
- make .coveragerc more uniform with globus-sdk .coveragerc
- remove mention of dev deps from the changelog (which is destined for user-facing documentation)