### PR TITLE
Update testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ include = src/*
 [report]
 show_missing = True
 skip_covered = True
+fail_under = 87
 
 exclude_lines =
     # the pragma to disable coverage

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.pyc
 /docs-source/_build/
 /.coverage
+/.coverage.*
 .idea
 
 #virtualenv

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -29,12 +29,10 @@ def get_versions() -> tuple[LooseVersion | None, LooseVersion]:
     import requests
 
     try:
-        version_data = requests.get(
-            "https://pypi.python.org/pypi/globus-cli/json"
-        ).json()
-        parsed_versions = [LooseVersion(v) for v in version_data["releases"]]
-        latest = max(parsed_versions)
-        return latest, LooseVersion(__version__)
+        response = requests.get("https://pypi.python.org/pypi/globus-cli/json")
     # if the fetch from pypi fails
     except requests.RequestException:
         return None, LooseVersion(__version__)
+    parsed_versions = [LooseVersion(v) for v in response.json()["releases"]]
+    latest = max(parsed_versions)
+    return latest, LooseVersion(__version__)

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,45 @@
+from distutils.version import LooseVersion
+
+import pytest
+import requests
+import responses
+
+import globus_cli.version
+
+
+@pytest.mark.parametrize(
+    "injected_version, expected",
+    (
+        ("0.0.0", globus_cli.version.__version__),
+        ("1000.1000.1000", "1000.1000.1000"),
+    ),
+)
+@pytest.mark.filterwarnings("ignore:distutils Version classes are deprecated")
+def test_get_versions_success(injected_version, expected):
+    # Only a portion of the PyPI response is needed.
+    pypi_json_response = {
+        "releases": {
+            injected_version: [],
+            globus_cli.version.__version__: [],
+        }
+    }
+    responses.add(
+        "GET", "https://pypi.python.org/pypi/globus-cli/json", json=pypi_json_response
+    )
+    assert globus_cli.version.get_versions() == (
+        LooseVersion(expected),
+        LooseVersion(globus_cli.version.__version__),
+    )
+
+
+@pytest.mark.filterwarnings("ignore:distutils Version classes are deprecated")
+def test_get_versions_failure():
+    responses.add(
+        "GET",
+        "https://pypi.python.org/pypi/globus-cli/json",
+        body=requests.RequestException(),
+    )
+    assert globus_cli.version.get_versions() == (
+        None,
+        LooseVersion(globus_cli.version.__version__),
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands = coverage combine
 [testenv:cov-report]
 deps = coverage
 skip_install = true
+commands_pre = coverage html --fail-under=0
 commands = coverage report
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands = coverage combine
 [testenv:cov-report]
 deps = coverage
 skip_install = true
-commands = coverage report --skip-covered
+commands = coverage report
 
 [testenv:lint]
 deps = pre-commit~=2.9.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
     cov-clean
-    cov-report
     py{311,310,39,38,37}
     py37-mindeps
+    cov-combine
+    cov-report
 skip_missing_interpreters = true
 minversion = 3.0.0
 


### PR DESCRIPTION
* git-ignore `.coverage.*` files
* Consistently run `coverage combine`
* Set a minimum bar for code coverage (currently at 87%)
* Remove a coverage CLI option that is redundant due to a configuration in `.coveragerc`
* Always write an HTML coverage report
* Test the version-gathering code that intacts with PyPI
* Refactor code in the version-gathering function that cannot raise `RequestException`.