### PR TITLE
Better behavior when doing recursive filtering

### DIFF
--- a/changelog.d/20221117_103859_aaschaer_recursive_filter.md
+++ b/changelog.d/20221117_103859_aaschaer_recursive_filter.md
@@ -1,4 +1,16 @@
 ### Enhancements
 
-* the `--filter` and `--recursive` options to `globus ls` now combine better
-  with directories that don't match the name filter being explored
+* `globus ls` has improved behavior when the `--filter` and `--recursive` options
+   are used in combination
+
+  * directory names are not matched against the filter, allowing the operation to
+    traverse directories regardless of their names
+
+  * the `--filter` is still applied to filenames in all directories traversed by
+    the `ls` operation
+
+  * directory names can be filtered out of the text output by eliminating
+    lines which end in `/`
+
+  * the behaviors of `globus ls` commands with `--recursive` or `--filter`, but not
+    both, are unchanged

--- a/changelog.d/20221117_103859_aaschaer_recursive_filter.md
+++ b/changelog.d/20221117_103859_aaschaer_recursive_filter.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* the `--filter` and `--recursive` options to `globus ls` now combine better
+  with directories that don't match the name filter being explored

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -180,29 +180,32 @@ def ls_command(
     ls_params: dict[str, t.Any] = {"show_hidden": int(show_hidden)}
     if path:
         ls_params["path"] = path
-    if filter_val:
-        # this char has special meaning in the LS API's filter clause
-        # can't be part of the pattern (but we don't support globbing across
-        # dir structures anyway)
-        if "/" in filter_val:
-            raise click.UsageError('--filter cannot contain "/"')
-        # format into a simple filter clause which operates on filenames
-        ls_params["filter"] = f"name:{filter_val}"
+
+    # this char has special meaning in the LS API's filter clause
+    # can't be part of the pattern (but we don't support globbing across
+    # dir structures anyway)
+    if filter_val and "/" in filter_val:
+        raise click.UsageError('--filter cannot contain "/"')
 
     # get the `ls` result
     if recursive:
-        # NOTE:
-        # --recursive and --filter have an interplay that some users may find
-        # surprising
-        # if we're asked to change or "improve" the behavior in the future, we
-        # could do so with "type:dir" or "type:file" filters added in, and
-        # potentially work out some viable behavior based on what people want
+
+        # if we are doing filtering we need to pass multiple filter params. The
+        # first allows all directories, as we need them for recursive
+        # expansion. The second then filters name by the filter_val
+        if filter_val:
+            ls_params["filter"] = ["type:dir", f"name:{filter_val}"]
+
         res: (
             IterableTransferResponse | RecursiveLsResponse
         ) = transfer_client.recursive_operation_ls(
             endpoint_id, ls_params, depth=recursive_depth_limit
         )
     else:
+        # format filter_val into a simple filter clause which operates on name
+        if filter_val:
+            ls_params["filter"] = f"name:{filter_val}"
+
         res = transfer_client.operation_ls(endpoint_id, **ls_params)
 
     # and then print it, per formatting rules

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -194,7 +194,7 @@ def ls_command(
         # first allows all directories, as we need them for recursive
         # expansion. The second then filters name by the filter_val
         if filter_val:
-            ls_params["filter"] = ["type:dir", f"name:{filter_val}"]
+            ls_params["filter"] = [{"type": "dir"}, {"name": filter_val}]
 
         res: (
             IterableTransferResponse | RecursiveLsResponse

--- a/src/globus_cli/services/transfer/recursive_ls.py
+++ b/src/globus_cli/services/transfer/recursive_ls.py
@@ -49,8 +49,6 @@ class RecursiveLsResponse:
     :param endpoint_id: The endpoint that will be recursively ls'ed.
     :param ls_params: Query params sent to operation_ls
     :param max_depth: The maximum depth the recursive ls will go into the filesys
-    :param filter_after_first: If True, any filter in ``ls_params`` will be applied
-        to all calls. If False, any filter will be removed after the first ls.
     """
 
     def __init__(
@@ -60,13 +58,11 @@ class RecursiveLsResponse:
         ls_params: dict[str, t.Any],
         *,
         max_depth: int = 3,
-        filter_after_first: bool = True,
     ) -> None:
         self._client = client
         self._endpoint_id = endpoint_id
         self._ls_params = ls_params
         self._max_depth = max_depth
-        self._filter_after_first = filter_after_first
 
         start_path = t.cast(t.Optional[str], ls_params.get("path"))
         log.info(
@@ -146,11 +142,6 @@ class RecursiveLsResponse:
                         if item["type"] == "dir"
                     ]
                 )
-
-            # if filter_after_first is False, stop filtering after the first
-            # ls call has been made
-            if not self._filter_after_first:
-                self._ls_params.pop("filter", None)
 
             # for each item in the response data update the item's name with
             # the relative path popped from the queue, and yield the item


### PR DESCRIPTION
For https://app.shortcut.com/globus/story/17393/update-globus-ls-recursive-filter-x-to-use-new-transfer-filter-behavior-to-include-dirs

Depends on https://github.com/globus/globus-sdk-python/pull/652, so I'm making this a draft for now.

Also want to make sure we're all on the same page about expected behavior. Some example output:

```
$ globus ls $EP1:/ --recursive --filter ~*1.txt
home/
mnt/
not shareable/
share/
home/aaschaer/
home/aaschaer/file1.txt
not shareable/godata/
not shareable/godata/file1.txt
share/godata/
share/godata/file1.txt
```
