### PR TITLE
Update globus-sdk and mypy versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "globus-sdk==3.14.0",
+        "globus-sdk==3.15.0",
         "click>=8.0.0,<9",
         "jmespath==0.10.0",
         # these are dependencies of the SDK, but they are used directly in the CLI

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ commands = pre-commit run --all-files
 
 [testenv:mypy]
 deps =
-    mypy==0.982
+    mypy==0.991
     types-jwt
     types-requests
     types-jmespath


### PR DESCRIPTION
Run `./scripts/update-dependencies.py`

I may look into a way of configuring `dependabot` to handle `globus-sdk` for us. That would be cool.
And I'd like to find a way to handle `tox.ini` (Dependabot doesn't support it). Maybe `upadup` needs to be extended to handle updates to `tox.ini`... 🤔 