### PR TITLE
Add mypy as a default tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py37-mindeps
     cov-combine
     cov-report
+    mypy
 skip_missing_interpreters = true
 minversion = 3.0.0
 


### PR DESCRIPTION
Noticed that mypy wasn't running by default, which resulted in avoidable failures in CI when publishing a PR.