### PR TITLE
More progress on disallow_untypted_defs

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -25,5 +25,8 @@ disallow_untyped_defs = true
 [mypy-globus_cli.constants]
 disallow_untyped_defs = true
 
+[mypy-globus_cli.termio.field]
+disallow_untyped_defs = true
+
 [mypy-globus_cli.termio.formatters.*]
 disallow_untyped_defs = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,6 +25,9 @@ disallow_untyped_defs = true
 [mypy-globus_cli.constants]
 disallow_untyped_defs = true
 
+[mypy-globus_cli.termio.context]
+disallow_untyped_defs = true
+
 [mypy-globus_cli.termio.field]
 disallow_untyped_defs = true
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,3 +24,6 @@ disallow_untyped_defs = true
 
 [mypy-globus_cli.constants]
 disallow_untyped_defs = true
+
+[mypy-globus_cli.termio.formatters.*]
+disallow_untyped_defs = true

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging.config
 import typing as t
 import warnings
@@ -39,28 +41,28 @@ def _setup_logging(level="DEBUG"):
 
 
 class CommandState:
-    def __init__(self):
+    def __init__(self) -> None:
         # default is TEXT
-        self.output_format = TEXT_FORMAT
+        self.output_format: str = TEXT_FORMAT
         # a jmespath expression to process on the json output
-        self.jmespath_expr = None
+        self.jmespath_expr: t.Any | None = None
         # default is always False
         self.debug = False
         # default is 0
         self.verbosity = 0
         # by default, empty dict
-        self.http_status_map = {}
+        self.http_status_map: dict[int, int] = {}
 
-    def outformat_is_text(self):
+    def outformat_is_text(self) -> bool:
         return self.output_format == TEXT_FORMAT
 
-    def outformat_is_json(self):
+    def outformat_is_json(self) -> bool:
         return self.output_format == JSON_FORMAT
 
-    def outformat_is_unix(self):
+    def outformat_is_unix(self) -> bool:
         return self.output_format == UNIX_FORMAT
 
-    def is_verbose(self):
+    def is_verbose(self) -> bool:
         return self.verbosity > 0
 
 

--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import os
 import sys
+import typing as t
 
 import click
 
 from globus_cli.parsing.command_state import CommandState
 
 
-def outformat_is_json():
+def outformat_is_json() -> bool:
     """
     Only safe to call within a click context.
     """
@@ -17,7 +18,7 @@ def outformat_is_json():
     return state.outformat_is_json()
 
 
-def outformat_is_unix():
+def outformat_is_unix() -> bool:
     """
     Only safe to call within a click context.
     """
@@ -26,7 +27,7 @@ def outformat_is_unix():
     return state.outformat_is_unix()
 
 
-def outformat_is_text():
+def outformat_is_text() -> bool:
     """
     Only safe to call within a click context.
     """
@@ -35,7 +36,7 @@ def outformat_is_text():
     return state.outformat_is_text()
 
 
-def get_jmespath_expression():
+def get_jmespath_expression() -> t.Any:
     """
     Only safe to call within a click context.
     """
@@ -44,7 +45,7 @@ def get_jmespath_expression():
     return state.jmespath_expr
 
 
-def verbosity():
+def verbosity() -> int:
     """
     Only safe to call within a click context.
     """
@@ -53,7 +54,7 @@ def verbosity():
     return state.verbosity
 
 
-def is_verbose():
+def is_verbose() -> bool:
     """
     Only safe to call within a click context.
     """
@@ -62,11 +63,11 @@ def is_verbose():
     return state.is_verbose()
 
 
-def out_is_terminal():
+def out_is_terminal() -> bool:
     return sys.stdout.isatty()
 
 
-def err_is_terminal():
+def err_is_terminal() -> bool:
     return sys.stderr.isatty()
 
 

--- a/src/globus_cli/termio/field.py
+++ b/src/globus_cli/termio/field.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing as t
+
 from . import formatters
 
 
@@ -26,13 +28,13 @@ class Field:
         self.wrap_enabled = wrap_enabled
         self.formatter = formatter
 
-    def get_value(self, data):
+    def get_value(self, data: t.Any) -> t.Any:
         import jmespath
 
         return jmespath.search(self.key, data)
 
-    def format(self, value):
+    def format(self, value: t.Any) -> str:
         return self.formatter.format(value)
 
-    def __call__(self, data):
+    def __call__(self, data: t.Any) -> str:
         return self.format(self.get_value(data))


### PR DESCRIPTION
This is the single most important setting for eventual `mypy --strict` behavior, and we've been gradually rolling it out across the codebase with `mypy.ini`. I've made another short push to ensure that the new formatter code is all annotated.