### PR TITLE
Invert the default for disallow_untyped_defs and enumerate non-compliant modules explicitly

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -56,7 +56,28 @@ disallow_untyped_defs = false
 [mypy-globus_cli.parsing.one_use_option]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.parsing.param_types.*]
+[mypy-globus_cli.parsing.param_types.comma_delimited]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.param_types.endpoint_plus_path]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.param_types.identity_type]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.param_types.location]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.param_types.nullable]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.param_types.prefix_mapper]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.param_types.task_path]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.param_types.timedelta]
 disallow_untyped_defs = false
 
 [mypy-globus_cli.parsing.shared_options.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -80,7 +80,16 @@ disallow_untyped_defs = false
 [mypy-globus_cli.parsing.param_types.timedelta]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.parsing.shared_options.*]
+[mypy-globus_cli.parsing.shared_options]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.shared_options.endpoint_create_and_update]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.shared_options.id_args]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.shared_options.transfer_task_options]
 disallow_untyped_defs = false
 
 [mypy-globus_cli.parsing.shell_completion]

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,9 +11,6 @@ warn_no_return = true
 no_implicit_optional = true
 disallow_untyped_defs = true
 
-[mypy-globus_cli.commands.*]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.exception_handling.hooks]
 disallow_untyped_defs = false
 
@@ -126,4 +123,337 @@ disallow_untyped_defs = false
 disallow_untyped_defs = false
 
 [mypy-globus_cli.termio.awscli_text]
+disallow_untyped_defs = false
+
+# command modules
+# listed separately to preserve the readability of the above config
+
+[mypy-globus_cli.commands._common]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.api]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.bookmark.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.bookmark.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.bookmark.rename]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.bookmark.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.collection.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.collection.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.collection.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.collection.update]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.is_activated]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.permission._common]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.permission.create]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.permission.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.permission.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.permission.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.permission.update]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.role._common]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.role.create]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.role.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.role.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.role.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.server._common]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.server.add]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.server.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.server.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.server.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.server.update]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.set_subscription_id]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.storage_gateway.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.update]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.user_credential._common]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.user_credential.create.from_json]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.user_credential.create.posix]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.user_credential.create.s3]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.user_credential.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.user_credential.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.user_credential.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.endpoint.user_credential.update.from_json]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.flows]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.flows.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.flows.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.flows.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.flows.start]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.gcp]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.gcp.create]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.get_identities]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group._common]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.create]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.invite.accept]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.invite.decline]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.join]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.leave]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.member.add]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.member.approve]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.member.invite]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.member.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.member.reject]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.member.remove]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.set_policies]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.group.update]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.login]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.logout]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.ls]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.mkdir]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.rename]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.rm]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.delete_by_query]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.index]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.index.create]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.index.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.index.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.index.role]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.index.role.create]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.index.role.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.index.role.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.index.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.ingest]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.query]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.subject.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.subject.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.task]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.task.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.search.task.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.session.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.session.update]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.task._common]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.task.cancel]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.task.event_list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.task.generate_submission_id]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.task.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.task.pause_info]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.task.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.task.update]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.task.wait]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.timer]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.timer.create]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.timer.create.transfer]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.timer.delete]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.timer.list]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.timer.show]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.transfer]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.update]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.version]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.commands.whoami]
 disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,27 +9,55 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_no_return = true
 no_implicit_optional = true
-
-[mypy-globus_cli.endpointish.*]
 disallow_untyped_defs = true
 
-[mypy-globus_cli.utils]
-disallow_untyped_defs = true
+[mypy-globus_cli.commands.*]
+disallow_untyped_defs = false
 
-[mypy-globus_cli.types]
-disallow_untyped_defs = true
+[mypy-globus_cli.exception_handling.*]
+disallow_untyped_defs = false
 
-[mypy-globus_cli.version]
-disallow_untyped_defs = true
+[mypy-globus_cli.login_manager.*]
+disallow_untyped_defs = false
 
-[mypy-globus_cli.constants]
-disallow_untyped_defs = true
+[mypy-globus_cli.parsing.command_state]
+disallow_untyped_defs = false
 
-[mypy-globus_cli.termio.context]
-disallow_untyped_defs = true
+[mypy-globus_cli.parsing.commands]
+disallow_untyped_defs = false
 
-[mypy-globus_cli.termio.field]
-disallow_untyped_defs = true
+[mypy-globus_cli.parsing.mutex_group]
+disallow_untyped_defs = false
 
-[mypy-globus_cli.termio.formatters.*]
-disallow_untyped_defs = true
+[mypy-globus_cli.parsing.one_use_option]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.param_types.*]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.shared_options.*]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.parsing.shell_completion]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.services.auth]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.services.gcs]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.services.transfer.*]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.termio]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.termio.printer]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.termio.errors]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.termio.awscli_text]
+disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -101,7 +101,19 @@ disallow_untyped_defs = false
 [mypy-globus_cli.services.gcs]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.services.transfer.*]
+[mypy-globus_cli.services.transfer.activation]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.services.transfer.client]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.services.transfer.data]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.services.transfer.delegate_proxy]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.services.transfer.recursive_ls]
 disallow_untyped_defs = false
 
 [mypy-globus_cli.termio]

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,7 +20,28 @@ disallow_untyped_defs = false
 [mypy-globus_cli.exception_handling.registry]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.login_manager.*]
+[mypy-globus_cli.login_manager._old_config]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.login_manager.auth_flows]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.login_manager.client_login]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.login_manager.errors]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.login_manager.local_server]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.login_manager.manager]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.login_manager.tokenstore]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.login_manager.utils]
 disallow_untyped_defs = false
 
 [mypy-globus_cli.parsing.command_state]

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,7 +14,10 @@ disallow_untyped_defs = true
 [mypy-globus_cli.commands.*]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.exception_handling.*]
+[mypy-globus_cli.exception_handling.hooks]
+disallow_untyped_defs = false
+
+[mypy-globus_cli.exception_handling.registry]
 disallow_untyped_defs = false
 
 [mypy-globus_cli.login_manager.*]

--- a/src/globus_cli/exception_handling/__init__.py
+++ b/src/globus_cli/exception_handling/__init__.py
@@ -7,7 +7,11 @@ format an exception.
 Define an except hook per exception type that we want to treat specially,
 generally types of SDK errors, and dispatch onto tht set of hooks.
 """
+from __future__ import annotations
+
 import sys
+import types
+import typing as t
 
 import click
 import click.exceptions
@@ -20,7 +24,9 @@ from .registry import find_handler
 register_all_hooks()
 
 
-def custom_except_hook(exc_info):
+def custom_except_hook(
+    exc_info: tuple[type[Exception], Exception, types.TracebackType]
+) -> t.NoReturn:
     """
     A custom excepthook to present python errors produced by the CLI.
     We don't want to show end users big scary stacktraces if they aren't python


### PR DESCRIPTION
The prior default in our mypy config was `disallow_untyped_defs = false`, and we set this to true on various modules. This PR makes two changes to help us conquer our mountain of missing annotations:

1. `disallow_untyped_defs = true` is now our config default
2. Rules for `disallow_untyped_defs = false` are added _module by module_ to make it easy to identify and fix non-compliant code and avoid `*` semantics

Most of the work was small enough that it could be done manually. The part that turned out to be too big was handling the removal of `globus_cli.commands.*`. I ended up writing a little bash loop to generate the config I wanted and then appending that to `mypy.ini`.

During the changes, I added annotations to one module (the effort of adding it to config was approximately equivalent to the effort of adding the annotations), but I generally tried to resist the temptation to make changes in `src/`.