### PR TITLE
Update jmespath dependency to latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         "globus-sdk==3.15.0",
         "click>=8.0.0,<9",
-        "jmespath==0.10.0",
+        "jmespath==1.0.1",
         # these are dependencies of the SDK, but they are used directly in the CLI
         # declare them here in case the underlying lib ever changes
         "requests>=2.19.1,<3.0.0",


### PR DESCRIPTION
I saw warnings in a recent test build which were not related to those changes.
I believe the best/fastest resolution is to update `jmespath`, as the warnings appeared to originate from there and are fixed in a more recent release. However, it's not clear why the errors appeared now (perhaps a change in GitHub actions), so we will need to watch this build to see if it resolves the issue.

---

The changes made in jmespath in this version jump are:
- add py3.11 support
- remove python < 3.7 support
- fix warnings raised by 3.8+ and 3.9+

We originally delayed updating because we supported 3.6 in the CLI at the time that python2 and python3.6 support was removed from `jmespath`. Now this is valuable because it will fix warnings which appeared during test runs.