### PR TITLE
Type annotate the whoami command

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -454,6 +454,3 @@ disallow_untyped_defs = false
 
 [mypy-globus_cli.commands.version]
 disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.whoami]
-disallow_untyped_defs = false

--- a/src/globus_cli/commands/whoami.py
+++ b/src/globus_cli/commands/whoami.py
@@ -49,7 +49,7 @@ $ globus whoami --linked-identities
     help="Also show identities linked to the currently logged-in primary identity.",
 )
 @LoginManager.requires_login(LoginManager.AUTH_RS)
-def whoami_command(*, login_manager: LoginManager, linked_identities: bool):
+def whoami_command(*, login_manager: LoginManager, linked_identities: bool) -> None:
     """
     Display information for the currently logged-in user.
     """


### PR DESCRIPTION
Remove it from `mypy`'s list of `disallow_untyped_defs = false`, then fix that check. It needs a return type (None).