### PR TITLE
remove timezone unaware call in test_session_show_text

### DIFF
--- a/tests/functional/test_session_show.py
+++ b/tests/functional/test_session_show.py
@@ -84,7 +84,11 @@ def create_introspect_data(user_attrs):
                     "acr": None,
                     "amr": None,
                     "idp": user_attrs["idp_id"],
-                    "auth_time": 613217460,
+                    "auth_time": datetime.datetime.strptime(
+                        user_attrs["auth_time"], "%Y-%m-%d %H:%M %Z"
+                    )
+                    .replace(tzinfo=datetime.timezone.utc)
+                    .timestamp(),
                     "custom_claims": {},
                 }
             },

--- a/tests/functional/test_session_show.py
+++ b/tests/functional/test_session_show.py
@@ -1,5 +1,4 @@
 import datetime
-import time
 import uuid
 
 import pytest
@@ -85,11 +84,7 @@ def create_introspect_data(user_attrs):
                     "acr": None,
                     "amr": None,
                     "idp": user_attrs["idp_id"],
-                    "auth_time": int(
-                        time.mktime(
-                            time.strptime(user_attrs["auth_time"], "%Y-%m-%d %H:%M %Z")
-                        )
-                    ),
+                    "auth_time": 613217460,
                     "custom_claims": {},
                 }
             },


### PR DESCRIPTION
This test was failing for me locally, I believe because mktime can only handle time_structs that are in local time.

Skimming the python time and datetime docs I didn't see an obvious way to fix this, and hardcoding a test value to match another hardcoded test value seemed a reasonable-ish solution. Any other ideas would be welcome though.