### PR TITLE
Fix builds for tox v4 and any other changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,8 +107,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-      - name: Install Requirements
-        run: python -m pip install -U pip setuptools tox
+      # use tox v3 to support the old virtualenv version
+      - run: python -m pip install -U pip setuptools 'tox<4'
       - name: Downgrade Virtualenv
         run: python -m pip install 'virtualenv==16.7.12'
       - name: Run Tests

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ deps =
 commands = mypy src/
 
 [testenv:reference]
-whitelist_externals = find
+allowlist_externals = find
 commands_pre = find reference/ -name "*.adoc" -type f -delete
 commands = python ./reference/_generate.py {posargs}
 
@@ -75,7 +75,7 @@ skip_install = true
 deps =
     build
     twine
-whitelist_externals = rm
+allowlist_externals = rm
 commands_pre = rm -rf dist/
 # check that twine validating package data works
 commands =
@@ -95,7 +95,7 @@ deps =
     build
     twine
 # clean the build dir before rebuilding
-whitelist_externals = rm
+allowlist_externals = rm
 commands_pre = rm -rf dist/
 commands =
     python -m build


### PR DESCRIPTION
I suspect it won't just be tox again, but I'm starting with the allowlist_externals tweak.

---

Changes ended up being:
- allowlist_externals
- use tox v3 when testing a very old version of `virtualenv` (there is a story behind this test)