### PR TITLE
handle session_required_policies errors

### DIFF
--- a/changelog.d/20221206_163612_aaschaer_auth_policy.md
+++ b/changelog.d/20221206_163612_aaschaer_auth_policy.md
@@ -1,0 +1,7 @@
+### Enhancements
+
+* Add `--policy` option to `globus session update` which takes a Globus
+  Auth policy uuid and starts an auth flow to meet the session's policies.
+
+* Whenever an error is hit due to not meeting a Globus Auth policy, helptext
+  is displayed with a `globus session update` command to resolve the error.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "globus-sdk==3.15.0",
+        "globus-sdk==3.15.1",
         "click>=8.0.0,<9",
         "jmespath==1.0.1",
         # these are dependencies of the SDK, but they are used directly in the CLI

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -39,6 +39,8 @@ def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
 
     identities = exception.info.authorization_parameters.session_required_identities
     domains = exception.info.authorization_parameters.session_required_single_domain
+    policy = exception.info.authorization_parameters.session_required_policies
+
     if identities or domains:
         # cast: mypy can't deduce that `domains` is not None if `identities` is None
         update_target = (
@@ -49,6 +51,12 @@ def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
         click.echo(
             "Please run\n\n"
             f"    globus session update {update_target}\n\n"
+            "to re-authenticate with the required identities"
+        )
+    elif policy:
+        click.echo(
+            "Please run\n\n"
+            f"    globus session update --policy {policy}\n\n"
             "to re-authenticate with the required identities"
         )
     else:

--- a/tests/functional/test_exception_hooks.py
+++ b/tests/functional/test_exception_hooks.py
@@ -5,8 +5,8 @@ from globus_sdk._testing import RegisteredResponse, load_response, load_response
 
 def test_session_required_policies(run_line):
     """
-    ls on hits a 403 with session_required_policies set
-    confirms correct globus session update command in helptext
+    confirms a correct `globus session update` command is shown in helptext
+    after hitting a 403 with session_required_policies set
     """
     meta = load_response_set("cli.transfer_activate_success").metadata
     ep_id = meta["endpoint_id"]

--- a/tests/functional/test_exception_hooks.py
+++ b/tests/functional/test_exception_hooks.py
@@ -1,0 +1,34 @@
+import uuid
+
+from globus_sdk._testing import RegisteredResponse, load_response, load_response_set
+
+
+def test_session_required_policies(run_line):
+    """
+    ls on hits a 403 with session_required_policies set
+    confirms correct globus session update command in helptext
+    """
+    meta = load_response_set("cli.transfer_activate_success").metadata
+    ep_id = meta["endpoint_id"]
+    policy_id = str(uuid.uuid4())
+
+    load_response(
+        RegisteredResponse(
+            service="transfer",
+            path=f"/operation/endpoint/{ep_id}/ls",
+            status=403,
+            json={
+                "authorization_parameters": {
+                    "session_message": "Failing collection authentication policy",
+                    "session_required_policies": policy_id,
+                },
+                "code": "AuthPolicyFailed",
+                "message": "Failing collection authentication policy",
+                "request_id": "MSbPbMR9n",
+                "resource": f"/operation/endpoint/{ep_id}/ls",
+            },
+        )
+    )
+    result = run_line(f"globus ls {ep_id}:/", assert_exit_code=4)
+
+    assert f"globus session update --policy {policy_id}" in result.output


### PR DESCRIPTION
For https://app.shortcut.com/globus/story/18757/sdk-and-cli-support-for-session-required-policies

Opening as a draft as this depends on https://github.com/globus/globus-sdk-python/pull/658 and tests will fail without it.

As of yesterday Transfer released the fixed `session_required_policies` field name to all envs, and Auth support should also be on all envs now, so I think this is stable enough to at least open the PR. No rush to release until GCS support is live though, as that is where the UI (and docs?) will be.

I've tested end-to-end on sandbox, and can help with the needed `globus api` calls if anyone else wants to try it out.