### PR TITLE
Add type annotations to 'transfer' command

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -427,6 +427,3 @@ disallow_untyped_defs = false
 
 [mypy-globus_cli.commands.timer.show]
 disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.transfer]
-disallow_untyped_defs = false


### PR DESCRIPTION
Most of these annotations are routine changes to fill out details. A couple of them have interesting nuances.

`sync_level` is delcared as a Literal so that it will type-check against the TransferData signature. It is a "choice" option in the CLI, so the literal selection matches the available choices.

Several of the arguments to TransferData have been moved from additional_fields now that they are supported as top-level args.

Internal exclude rule helpers are replaced with `add_filter_rule`, which has been added to TransferData since the initial version of support was added to this command.

The TransferData usage now does not pass a client on init. This means that the submission_id will only be fetched at the end of the command, when the submit call is made.

The requirement for src and dst paths when `--batch` is not used is now enforced close to where the options are evaluated. In concert with the change to avoid passing a client to `TransferData.__init__`, this means that there is no change in the command's behaviors, but it enables `mypy` to understand that these values have been checked to be not-None.