### PR TITLE
Check type annotations on bookmark commands

### DIFF
--- a/src/globus_cli/commands/bookmark/create.py
+++ b/src/globus_cli/commands/bookmark/create.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 import click
 
 from globus_cli.login_manager import LoginManager
@@ -38,7 +40,7 @@ $ globus bookmark create \
 def bookmark_create(
     *,
     login_manager: LoginManager,
-    endpoint_plus_path: tuple[str, str],
+    endpoint_plus_path: tuple[uuid.UUID, str],
     bookmark_name: str,
 ) -> None:
     """

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -10,6 +10,11 @@ from tests.click_types import check_has_correct_annotations_for_click_args
 @pytest.mark.parametrize(
     "modname, command_name",
     (
+        ("bookmark.create", "bookmark_create"),
+        ("bookmark.delete", "bookmark_delete"),
+        ("bookmark.list", "bookmark_list"),
+        ("bookmark.rename", "bookmark_rename"),
+        ("bookmark.show", "bookmark_show"),
         ("cli_profile_list", "cli_profile_list"),
         ("transfer", "transfer_command"),
         ("update", "update_command"),


### PR DESCRIPTION
Run the click type checker on these commands.

It succeeds except for a minor error with `bookmark_create`, where `tuple[str, str]` was used for an EndpointPlusPath param, rather than `tuple[UUID, str]`.