### PR TITLE
Enhance click type checker to show all errors

### DIFF
--- a/tests/unit/param_types/test_click_param_types_checker.py
+++ b/tests/unit/param_types/test_click_param_types_checker.py
@@ -12,6 +12,7 @@ from globus_cli.constants import ExplicitNullType
 from globus_cli.parsing.param_types import JSONStringOrFile, StringOrNull
 from globus_cli.types import JsonValue
 from tests.click_types import (
+    BadAnnotationError,
     check_has_correct_annotations_for_click_args,
     deduce_type_from_parameter,
 )
@@ -69,7 +70,7 @@ def test_check_annotations_fails_on_missing_arg():
         pass
 
     with pytest.raises(
-        ValueError, match="expected parameter 'foo' was not in type hints"
+        BadAnnotationError, match="expected parameter 'foo' was not in type hints"
     ):
         check_has_correct_annotations_for_click_args(mycmd)
 
@@ -81,6 +82,6 @@ def test_check_annotations_fails_on_bad_arg_type():
         pass
 
     with pytest.raises(
-        ValueError, match="parameter 'foo' has unexpected parameter type"
+        BadAnnotationError, match="parameter 'foo' has unexpected parameter type"
     ):
         check_has_correct_annotations_for_click_args(mycmd)


### PR DESCRIPTION
Collect errors into a list and then report them all together. The previous "fail fast" behavior only showed one of the many errors underlying a mismatch.

Also define a custom subclass of ValueError for annotation mismatch errors, which helps clarify tests capturing those errors.

---

This is a minor change to the error output which I wanted while doing other work based on the checker.
As an example of the new output (from within a pytest run):
```
tests.click_types.BadAnnotationError:
  parameter 'verify' has unexpected parameter type 'dict[str, bool]' rather than 'typing.Optional[typing.Literal['force', 'disable', 'default']]'
  parameter 'sharing_users_deny' has unexpected parameter type 'list[str] | None | globus_cli.constants.ExplicitNullType' rather than 'tuple[str, ...]'
  parameter 'sharing_users_allow' has unexpected parameter type 'list[str] | None | globus_cli.constants.ExplicitNullType' rather than 'tuple[str, ...]'
  parameter 'sharing_restrict_paths' has unexpected parameter type 'typing.Any | None' rather than 'globus_cli.types.JsonValue'
  parameter 'public' has unexpected parameter type '<class 'bool'>' rather than 'typing.Optional[bool]'
```