### PR TITLE
Add testing for 'endpoint is-activated'

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -143,9 +143,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.delete]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.endpoint.is_activated]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.permission._common]
 disallow_untyped_defs = false
 

--- a/tests/functional/endpoint/test_is_activated.py
+++ b/tests/functional/endpoint/test_is_activated.py
@@ -1,0 +1,102 @@
+import uuid
+
+from globus_sdk._testing import RegisteredResponse, load_response
+
+
+def test_no_activation_required(run_line):
+    epid = str(uuid.uuid4())
+    load_response(
+        RegisteredResponse(
+            service="transfer",
+            path=f"/endpoint/{epid}/activation_requirements",
+            json={
+                "expires_in": -1,
+                "activated": True,
+                "auto_activation_supported": True,
+                "oauth_server": None,
+                "DATA": [],
+            },
+        )
+    )
+    result = run_line(f"globus endpoint is-activated {epid}")
+    assert f"'{epid}' does not require activation" in result.output
+
+
+def test_currently_active(run_line):
+    epid = str(uuid.uuid4())
+    load_response(
+        RegisteredResponse(
+            service="transfer",
+            path=f"/endpoint/{epid}/activation_requirements",
+            json={
+                "expires_in": 3600,
+                "activated": True,
+                "auto_activation_supported": False,
+                "oauth_server": None,
+                "DATA": [],
+            },
+        )
+    )
+    result = run_line(f"globus endpoint is-activated {epid}")
+    assert f"'{epid}' is activated" in result.output
+
+
+def test_not_currently_active(run_line):
+    epid = str(uuid.uuid4())
+    load_response(
+        RegisteredResponse(
+            service="transfer",
+            path=f"/endpoint/{epid}/activation_requirements",
+            json={
+                "expires_in": 0,
+                "activated": False,
+                "auto_activation_supported": False,
+                "oauth_server": None,
+                "DATA": [],
+            },
+        )
+    )
+    result = run_line(f"globus endpoint is-activated {epid}", assert_exit_code=1)
+    assert f"'{epid}' is not activated" in result.output
+
+
+def test_active_until_deadline(run_line):
+    epid = str(uuid.uuid4())
+    load_response(
+        RegisteredResponse(
+            service="transfer",
+            path=f"/endpoint/{epid}/activation_requirements",
+            json={
+                "expires_in": 3600,
+                "activated": True,
+                "auto_activation_supported": False,
+                "oauth_server": None,
+                "DATA": [],
+            },
+        )
+    )
+    result = run_line(f"globus endpoint is-activated {epid} --until 60")
+    assert f"'{epid}' will be active for at least 60 seconds" in result.output
+
+
+def test_not_active_until_deadline(run_line):
+    epid = str(uuid.uuid4())
+    load_response(
+        RegisteredResponse(
+            service="transfer",
+            path=f"/endpoint/{epid}/activation_requirements",
+            json={
+                "expires_in": 600,
+                "activated": True,
+                "auto_activation_supported": False,
+                "oauth_server": None,
+                "DATA": [],
+            },
+        )
+    )
+    result = run_line(
+        f"globus endpoint is-activated {epid} --until 3600", assert_exit_code=1
+    )
+    assert (
+        f"'{epid}' is not activated or will expire within 3600 seconds" in result.output
+    )

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -16,6 +16,7 @@ from tests.click_types import check_has_correct_annotations_for_click_args
         ("bookmark.rename", "bookmark_rename"),
         ("bookmark.show", "bookmark_show"),
         ("cli_profile_list", "cli_profile_list"),
+        ("endpoint.is_activated", "endpoint_is_activated"),
         ("transfer", "transfer_command"),
         ("update", "update_command"),
         ("version", "version_command"),


### PR DESCRIPTION
This command was not covered by the testsuite prior to this addition.

Add a new set of functional tests and remove the disallow_untyped_defs setting for this command. List it in the click annotation checks.

Several small tweaks are made to 'is_activated.py' -- modern use of f-strings, fix missing annotations, etc.
The output is changed in very minor ways, for text output only.

---

I ended up going after this because I've been having the coverage fail_under trigger during other work. I'd like to resolve that by moving coverage up a bit higher. A quick analysis of coverage report data shows this as one of the larger and easier to tackle bits of code.