### PR TITLE
Remove tox from the 'ancient venv test'

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-      - run: python -m pip install -U pip setuptool
+      - run: python -m pip install -U pip setuptools
       - name: Downgrade Virtualenv
         run: python -m pip install 'virtualenv==16.7.12'
       - name: Create virtualenv

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,9 +107,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-      # use tox v3 to support the old virtualenv version
-      - run: python -m pip install -U pip setuptools 'tox<4'
+      - run: python -m pip install -U pip setuptool
       - name: Downgrade Virtualenv
         run: python -m pip install 'virtualenv==16.7.12'
-      - name: Run Tests
-        run: python -m tox -e py
+      - name: Create virtualenv
+        run: virtualenv venv
+      - name: Install Into Virtualenv
+        run: venv/bin/python -m pip install '.[test]'
+      - name: Run tests
+        run: venv/bin/pytest


### PR DESCRIPTION
This will avoid potentially running into issues with newer 'tox' versions, minversion, etc.