### PR TITLE
Move user_message{,_link} into shared options

### DIFF
--- a/changelog.d/20230207_054708_sirosen_user_message_support.md
+++ b/changelog.d/20230207_054708_sirosen_user_message_support.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Support `--user-message` and `--user-message-link` for
+  `globus endpoint update` and `globus gcp create mapped`

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -13,8 +13,6 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
     AnnotatedOption,
     JSONStringOrFile,
-    StringOrNull,
-    UrlOrNull,
     collection_id_arg,
     command,
     endpointish_params,
@@ -95,23 +93,6 @@ class _FullDataField(Field):
         "Explicitly enable or disable  HTTPS support (requires a managed endpoint "
         "with API v1.1.0)"
     ),
-)
-@click.option(
-    "--user-message",
-    help=(
-        "A message for clients to display to users when interacting "
-        "with this collection"
-    ),
-    type=StringOrNull(),
-)
-@click.option(
-    "--user-message-link",
-    help=(
-        "Link to additional messaging for clients to display to users "
-        "when interacting with this endpoint, linked to an http or https URL "
-        "with this collection"
-    ),
-    type=UrlOrNull(),
 )
 @click.option(
     "--sharing-user-allow",

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -96,6 +96,8 @@ def endpoint_create(
     preferred_parallelism: int | None,
     public: bool | None,
     subscription_id: uuid.UUID | None,
+    user_message: str | None | ExplicitNullType,
+    user_message_link: str | None | ExplicitNullType,
 ) -> None:
     """
     WARNING:
@@ -160,6 +162,8 @@ For GCS, use the globus-connect-server CLI from your Endpoint."""
             preferred_parallelism=preferred_parallelism,
             public=public,
             subscription_id=subscription_id,
+            user_message=user_message,
+            user_message_link=user_message_link,
         )
     )
     kwargs["is_globus_connect"] = personal or None

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -65,6 +65,8 @@ def endpoint_update(
     preferred_parallelism: int | None,
     public: bool | None,
     subscription_id: uuid.UUID | None,
+    user_message: str | None | ExplicitNullType,
+    user_message_link: str | None | ExplicitNullType,
 ) -> None:
     """Update attributes of an endpoint"""
     from globus_cli.services.transfer import assemble_generic_doc
@@ -100,6 +102,8 @@ def endpoint_update(
         preferred_parallelism=preferred_parallelism,
         public=public,
         subscription_id=subscription_id,
+        user_message=user_message,
+        user_message_link=user_message_link,
     )
 
     validate_endpoint_create_and_update_params(

--- a/src/globus_cli/commands/gcp/create/guest.py
+++ b/src/globus_cli/commands/gcp/create/guest.py
@@ -13,7 +13,11 @@ from ._common import deprecated_verify_option
 
 
 @command("guest", short_help="Create a new Guest Collection on GCP")
-@endpointish_params.create(name="collection", keyword_style="string")
+@endpointish_params.create(
+    name="collection",
+    keyword_style="string",
+    skip=("user_message", "user_message_link"),
+)
 @click.argument("HOST_GCP_PATH", type=ENDPOINT_PLUS_REQPATH)
 @deprecated_verify_option
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)

--- a/src/globus_cli/commands/gcp/create/mapped.py
+++ b/src/globus_cli/commands/gcp/create/mapped.py
@@ -34,6 +34,8 @@ def mapped_command(
     verify: dict[str, bool],
     subscription_id: str | None,
     disable_verify: bool | None,
+    user_message: str | None | ExplicitNullType,
+    user_message_link: str | None | ExplicitNullType,
 ) -> None:
     """
     Create a new Globus Connect Personal Mapped Collection.
@@ -67,6 +69,8 @@ def mapped_command(
         default_directory=default_directory,
         force_encryption=force_encryption,
         subscription_id=subscription_id,
+        user_message=user_message,
+        user_message_link=user_message_link,
         **verify,
     )
 

--- a/src/globus_cli/parsing/shared_options/endpointish.py
+++ b/src/globus_cli/parsing/shared_options/endpointish.py
@@ -158,7 +158,7 @@ def _apply_endpointish_create_or_update_params(
                 "--user-message",
                 help=(
                     "A message for clients to display to users when interacting "
-                    "with this {name}"
+                    f"with this {name}"
                 ),
                 type=StringOrNull(),
             ),
@@ -166,7 +166,7 @@ def _apply_endpointish_create_or_update_params(
                 "--user-message-link",
                 help=(
                     "Link to additional messaging for clients to display to users "
-                    "when interacting with this {name}. Should be an HTTP or HTTPS URL "
+                    f"when interacting with this {name}. Should be an HTTP or HTTPS URL "
                 ),
                 type=UrlOrNull(),
             ),

--- a/src/globus_cli/parsing/shared_options/endpointish.py
+++ b/src/globus_cli/parsing/shared_options/endpointish.py
@@ -166,7 +166,8 @@ def _apply_endpointish_create_or_update_params(
                 "--user-message-link",
                 help=(
                     "Link to additional messaging for clients to display to users "
-                    f"when interacting with this {name}. Should be an HTTP or HTTPS URL "
+                    f"when interacting with this {name}. "
+                    "Should be an HTTP or HTTPS URL "
                 ),
                 type=UrlOrNull(),
             ),

--- a/src/globus_cli/parsing/shared_options/endpointish.py
+++ b/src/globus_cli/parsing/shared_options/endpointish.py
@@ -22,6 +22,7 @@ from globus_cli.parsing.param_types import (
     CommaDelimitedList,
     LocationType,
     StringOrNull,
+    UrlOrNull,
 )
 
 C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
@@ -43,6 +44,7 @@ class endpointish_params:
         display_name_style: Literal["argument", "option"] = "argument",
         keyword_style: Literal["string", "list"] = "list",
         verify_style: Literal["flag", "choice"] = "choice",
+        skip: tuple[str, ...] = (),
     ) -> t.Callable[[C], C]:
         def decorator(f: C) -> C:
             return _apply_endpointish_create_or_update_params(
@@ -51,6 +53,7 @@ class endpointish_params:
                 display_name_style=display_name_style,
                 keyword_style=keyword_style,
                 verify_style=verify_style,
+                skip=skip,
             )
 
         return decorator
@@ -63,6 +66,7 @@ class endpointish_params:
         display_name_style: Literal["argument", "option"] = "option",
         keyword_style: Literal["string", "list"] = "list",
         verify_style: Literal["flag", "choice"] = "choice",
+        skip: tuple[str, ...] = (),
     ) -> t.Callable[[C], C]:
         def decorator(f: C) -> C:
             return _apply_endpointish_create_or_update_params(
@@ -71,6 +75,7 @@ class endpointish_params:
                 display_name_style=display_name_style,
                 keyword_style=keyword_style,
                 verify_style=verify_style,
+                skip=skip,
             )
 
         return decorator
@@ -89,64 +94,83 @@ def _apply_endpointish_create_or_update_params(
     display_name_style: str,
     keyword_style: str,
     verify_style: str,
+    skip: tuple[str, ...] = (),
 ) -> C:
-    decorators: list[t.Callable[[C], C]] = []
+    decorators: dict[str, t.Callable[[C], C]] = {}
 
     if display_name_style == "argument":
-        decorators.append(click.argument("DISPLAY_NAME"))
+        decorators["display_name"] = click.argument("DISPLAY_NAME")
     elif display_name_style == "option":
-        decorators.append(click.option("--display-name", help=f"Name for the {name}"))
+        decorators["display_name"] = click.option(
+            "--display-name", help=f"Name for the {name}"
+        )
     else:
         raise NotImplementedError()
 
-    decorators.extend(
-        [
-            click.option(
+    decorators.update(
+        dict(
+            description=click.option(
                 "--description", help=f"Description for the {name}", type=StringOrNull()
             ),
-            click.option(
+            info_link=click.option(
                 "--info-link",
                 help=f"Link for info about the {name}",
                 type=StringOrNull(),
             ),
-            click.option(
+            contact_info=click.option(
                 "--contact-info",
                 help=f"Contact info for the {name}",
                 type=StringOrNull(),
             ),
-            click.option(
+            contact_email=click.option(
                 "--contact-email",
                 help=f"Contact email for the {name}",
                 type=StringOrNull(),
             ),
-            click.option(
+            organization=click.option(
                 "--organization",
                 help=f"Organization for the {name}",
                 type=StringOrNull(),
             ),
-            click.option(
+            department=click.option(
                 "--department",
                 help=f"Department which operates the {name}",
                 type=StringOrNull(),
             ),
-            click.option(
+            keywords=click.option(
                 "--keywords",
                 type=str if keyword_style == "string" else CommaDelimitedList(),
                 help="Comma separated list of keywords to help searches "
                 f"for the {name}",
             ),
-            click.option(
+            default_directory=click.option(
                 "--default-directory",
                 type=StringOrNull(),
                 help="Default directory when browsing or executing tasks "
                 f"on the {name}",
             ),
-            click.option(
+            force_encryption=click.option(
                 "--force-encryption/--no-force-encryption",
                 default=None,
                 help=f"Force the {name} to encrypt transfers",
             ),
-        ]
+            user_message=click.option(
+                "--user-message",
+                help=(
+                    "A message for clients to display to users when interacting "
+                    "with this {name}"
+                ),
+                type=StringOrNull(),
+            ),
+            user_message_link=click.option(
+                "--user-message-link",
+                help=(
+                    "Link to additional messaging for clients to display to users "
+                    "when interacting with this {name}. Should be an HTTP or HTTPS URL "
+                ),
+                type=UrlOrNull(),
+            ),
+        )
     )
 
     if verify_style == "choice":
@@ -162,29 +186,25 @@ def _apply_endpointish_create_or_update_params(
                 " When set on mapped collections, this policy is inherited by any "
                 "guest collections"
             )
-        decorators.append(
-            click.option(
-                "--verify",
-                type=click.Choice(
-                    ["force", "disable", "default"], case_sensitive=False
-                ),
-                callback=_verify_choice_to_dict,
-                help=verify_help,
-                type_annotation=DictType[str, bool],
-                cls=AnnotatedOption,
-            )
+        decorators["verify"] = click.option(
+            "--verify",
+            type=click.Choice(["force", "disable", "default"], case_sensitive=False),
+            callback=_verify_choice_to_dict,
+            help=verify_help,
+            type_annotation=DictType[str, bool],
+            cls=AnnotatedOption,
         )
     else:
-        decorators.append(
-            click.option(
-                "--disable-verify/--no-disable-verify",
-                default=None,
-                is_flag=True,
-                help=f"Set the {name} to ignore checksum verification",
-            )
+        decorators["verify"] = click.option(
+            "--disable-verify/--no-disable-verify",
+            default=None,
+            is_flag=True,
+            help=f"Set the {name} to ignore checksum verification",
         )
 
-    return utils.fold_decorators(f, decorators)
+    decorator_list = [v for k, v in decorators.items() if k not in skip]
+
+    return utils.fold_decorators(f, decorator_list)
 
 
 def _verify_choice_to_dict(


### PR DESCRIPTION
What's easier than creating a new issue in another issue tracker to move #476 over? Resolving #476.

I didn't bother about any new tests, since I think a combination of some quick manual tests and the type checking work we've done suffices to cover this change.

---

These parameters are now part of the shared create/update parameters for endpointish objects. They can be set on collections and host endpoints, but are noted in documentation as not being valid on shares. As such, they are not included in the options for `globus gcp create guest`.

In order to achieve the above semantics, the shared option decorators have gained a new ability, to accept a tuple of strings to denote options which should be omitted or "skipped".
The guest collection creation command passes

    skip=("user_message", "user_message_link")

and this is enough to signal that these two options are skipped. To do this, a mild refactor is applied, turning a list of decorators into a map of names to decorators. The final step, when they are applied, is a filter and conversion to a list.

closes #476