### PR TITLE
Fix test response registration time

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,12 @@ import globus_cli
 yaml = YAML()
 log = logging.getLogger(__name__)
 
+_test_file_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "files"))
+
+
+def pytest_configure(config):
+    _register_all_response_sets()
+
 
 @pytest.fixture(autouse=True)
 def mocksleep():
@@ -163,7 +169,7 @@ def add_flow_login(test_token_storage):
 
 @pytest.fixture(scope="session")
 def test_file_dir():
-    return os.path.normpath(os.path.join(os.path.dirname(__file__), "files"))
+    return _test_file_dir
 
 
 @pytest.fixture
@@ -282,9 +288,8 @@ def _iter_fixture_routes(routes):
         yield path, method, params
 
 
-@pytest.fixture(autouse=True, scope="session")
-def _register_all_response_sets(test_file_dir):
-    fixture_dir = os.path.join(test_file_dir, "api_fixtures")
+def _register_all_response_sets():
+    fixture_dir = os.path.join(_test_file_dir, "api_fixtures")
 
     def do_register(filename):
         with open(os.path.join(fixture_dir, filename)) as fp:


### PR DESCRIPTION
The registration of our response data can take a non-negligible amount of time (YAML parsing is slow and there are many files).

Unfortunately, structuring this as an autouse session fixture puts that within the timing for the execution of the first test. In concert with pytest-timeout being applied, this can in rare cases push a test over the timeout. (e.g. If run on a machine under heavy load.)

The issue can be dodged entirely by moving the registration of our response data into pytest_configure or pytest_sessionstart, which happen before any tests are running and being timed.

---

I got caught by timeouts twice in the last couple of days and I've never seen it happen before. I'm guessing this is partly to do with me simply having loaded up my dev box more than usual, but the fix is still a good improvement IMO.