### PR TITLE
Update globus-sdk to v3.16.0

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -377,9 +377,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.session.show]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.session.update]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.task._common]
 disallow_untyped_defs = false
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "globus-sdk==3.15.1",
+        "globus-sdk==3.16.0",
         "click>=8.0.0,<9",
         "jmespath==1.0.1",
         # these are dependencies of the SDK, but they are used directly in the CLI

--- a/src/globus_cli/commands/session/update.py
+++ b/src/globus_cli/commands/session/update.py
@@ -1,10 +1,22 @@
+from __future__ import annotations
+
+import typing as t
+
 import click
 
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import IdentityType, command, no_local_server_option
+from globus_cli.parsing import (
+    CommaDelimitedList,
+    IdentityType,
+    ParsedIdentity,
+    command,
+    no_local_server_option,
+)
 
 
-def _update_session_params_all_case(identity_set, session_params):
+def _update_session_params_all_case(
+    identity_set: list[dict[str, t.Any]], session_params: dict[str, t.Any]
+) -> None:
     """if --all use every identity id in the user's identity set"""
     identity_ids = [x["sub"] for x in identity_set]
     # set session params once we have all identity ids
@@ -71,7 +83,9 @@ def _update_session_params_identities_case(identity_set, session_params, identit
 )
 @click.option(
     "--policy",
+    "policies",
     help="Comma separated list of authentication policy UUIDs",
+    type=CommaDelimitedList(),
 )
 @click.option(
     "--all",
@@ -79,7 +93,14 @@ def _update_session_params_identities_case(identity_set, session_params, identit
     help="Add every identity in your identity set to your session",
 )
 @LoginManager.requires_login(LoginManager.AUTH_RS)
-def session_update(*, login_manager, identities, no_local_server, policy, all):
+def session_update(
+    *,
+    login_manager: LoginManager,
+    identities: list[ParsedIdentity],
+    no_local_server: bool,
+    policies: list[str] | None,
+    all: bool,
+) -> None:
     """
     Update your current CLI auth session by authenticating
     with specific identities.
@@ -96,7 +117,7 @@ def session_update(*, login_manager, identities, no_local_server, policy, all):
     mutually exclusive with IDs and usernames.
     When usernames or IDs are used, they must be in your identity set.
     """
-    modes = bool(identities) + bool(policy) + bool(all)
+    modes = bool(identities) + bool(policies) + all
     if modes > 1:
         raise click.UsageError(
             "IDENTITY values, --all, and --policy are all mutually exclusive"
@@ -112,8 +133,8 @@ def session_update(*, login_manager, identities, no_local_server, policy, all):
 
     if all:
         _update_session_params_all_case(identity_set, session_params)
-    elif policy:
-        session_params["session_required_policies"] = policy
+    elif policies:
+        session_params["session_required_policies"] = ",".join(policies)
     else:
         _update_session_params_identities_case(identity_set, session_params, identities)
 

--- a/src/globus_cli/commands/session/update.py
+++ b/src/globus_cli/commands/session/update.py
@@ -23,7 +23,11 @@ def _update_session_params_all_case(
     session_params["session_required_identities"] = ",".join(identity_ids)
 
 
-def _update_session_params_identities_case(identity_set, session_params, identities):
+def _update_session_params_identities_case(
+    identity_set: list[dict[str, t.Any]],
+    session_params: dict[str, t.Any],
+    identities: tuple[ParsedIdentity, ...],
+) -> None:
     """
     given a set of identities (which must be either a mix of usernames and IDs or a list
     of domains), use that to update the session as appropriate
@@ -96,7 +100,7 @@ def _update_session_params_identities_case(identity_set, session_params, identit
 def session_update(
     *,
     login_manager: LoginManager,
-    identities: list[ParsedIdentity],
+    identities: tuple[ParsedIdentity, ...],
     no_local_server: bool,
     policies: list[str] | None,
     all: bool,

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -39,7 +39,7 @@ def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
 
     identities = exception.info.authorization_parameters.session_required_identities
     domains = exception.info.authorization_parameters.session_required_single_domain
-    policy = exception.info.authorization_parameters.session_required_policies
+    policies = exception.info.authorization_parameters.session_required_policies
 
     if identities or domains:
         # cast: mypy can't deduce that `domains` is not None if `identities` is None
@@ -53,10 +53,10 @@ def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
             f"    globus session update {update_target}\n\n"
             "to re-authenticate with the required identities"
         )
-    elif policy:
+    elif policies:
         click.echo(
             "Please run\n\n"
-            f"    globus session update --policy {policy}\n\n"
+            f"    globus session update --policy '{','.join(policies)}'\n\n"
             "to re-authenticate with the required identities"
         )
     else:

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -22,6 +22,7 @@ from tests.click_types import check_has_correct_annotations_for_click_args
         ("endpoint.update", "endpoint_update"),
         ("gcp.create.guest", "guest_command"),
         ("gcp.create.mapped", "mapped_command"),
+        ("session.update", "session_update"),
         ("transfer", "transfer_command"),
         ("timer.delete", "delete_command"),
         ("timer.list", "list_command"),


### PR DESCRIPTION
And handle the change to session_required_policies between 3.15.1 and 3.16.0 .

Because this is now passed around as a list, several changes are made here to harmonize the way that this list of IDs is handled. The exception hook now expects the SDK to pass the list[str], but the `sesion update` command has also been changed to explicitly parse the input as a CommaDelimitedList and then comma-join it for use in Auth.

The existing tests, minimally updated, exercise this behavior.

Also ensure that the policy IDs are quoted when printed in a command, as a best-practice for how commands should be generated for users. Single-quotes ensure that we get verbatim values in all cases, even if they are not strictly required in this one.

---

_But wait, there's more._

Because I was already in here tinkering, I folded in a second change.

[Enforce type checking on 'session update' command](https://github.com/globus/globus-cli/commit/a09d76e10a6e9698c337320ec586e6822b804d62) 

- remove it from mypy.ini exemptions
- apply the `click` annotation checker to it
  - fix a minor issue this spotted with a type (list vs tuple)