### PR TITLE
Update to mypy v1.0.0

### DIFF
--- a/scripts/update_dependencies.py
+++ b/scripts/update_dependencies.py
@@ -30,7 +30,7 @@ def bump_pkg_version_on_file(
     print(f"updating {pkg_name} in {path.relative_to(REPO_ROOT)} ... ", end="")
     with open(path) as fp:
         content = fp.read()
-    match = re.search(re.escape(pkg_name) + "==" + version_format, content)
+    match = re.search(re.escape(pkg_name) + "==" + version_format + r"(\W|$)", content)
     if not match:
         raise Abort(f"{path} did not contain {pkg_name} version pattern")
 
@@ -50,9 +50,7 @@ def bump_sdk_version() -> None:
 
 def bump_mypy_version() -> None:
     mypy_version = get_pkg_latest("mypy")
-    bump_pkg_version_on_file(
-        REPO_ROOT / "tox.ini", "mypy", mypy_version, version_format=r"(\d+\.\d+)"
-    )
+    bump_pkg_version_on_file(REPO_ROOT / "tox.ini", "mypy", mypy_version)
 
 
 def main() -> None:

--- a/src/globus_cli/parsing/param_types/endpoint_plus_path.py
+++ b/src/globus_cli/parsing/param_types/endpoint_plus_path.py
@@ -23,9 +23,9 @@ class EndpointPlusPath(AnnotatedParamType):
 
     def get_type_annotation(self, param: click.Parameter) -> type:
         if self.path_required:
-            return tuple[uuid.UUID, str]  # type: ignore[no-any-return,misc]
+            return tuple[uuid.UUID, str]
         else:
-            return tuple[uuid.UUID, str | None]  # type: ignore[no-any-return,misc]
+            return tuple[uuid.UUID, str | None]
 
     def get_metavar(self, param):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands = pre-commit run --all-files
 
 [testenv:mypy]
 deps =
-    mypy==0.991
+    mypy==1.0.0
     types-jwt
     types-requests
     types-jmespath


### PR DESCRIPTION
Two minor changes from this:
- the handy updater script needed a little tweak to use the x.y.z version format for mypy (and also do a slightly nicer regex match in that script)
- Some type-ignore comments are no longer needed because mypy has fixed the handling of `tuple[...]` as a kind of type