### PR TITLE
Improve the formatting of failed test output

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import shlex
+import textwrap
 import time
 import uuid
 from unittest import mock
@@ -233,22 +234,31 @@ def run_line(cli_runner, request, patch_tokenstorage):
             raise (
                 Exception(
                     (
-                        "CliTest run_line exit_code assertion failed!\n"
-                        "Line:\n{}\nexited with {} when expecting {}\n"
-                        "stdout:\n{}\nstderr:\n{}\nnetwork calls recorded:"
-                        "\n  {}"
+                        """
+CliTest run_line exit_code assertion failed!
+Line:
+  {}
+exited with {} when expecting {}
+
+stdout:
+{}
+stderr:
+{}
+network calls recorded:
+{}"""
                     ).format(
                         line,
                         result.exit_code,
                         assert_exit_code,
-                        result.stdout,
-                        result.stderr,
-                        (
-                            "\n  ".join(
+                        textwrap.indent(result.stdout, "  "),
+                        textwrap.indent(result.stderr, "  "),
+                        textwrap.indent(
+                            "\n".join(
                                 f"{r.request.method} {r.request.url}"
                                 for r in responses.calls
                             )
-                            or "  <none>"
+                            or "<none>",
+                            "  ",
                         ),
                     )
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,38 +231,26 @@ def run_line(cli_runner, request, patch_tokenstorage):
             main, args[1:], input=stdin, catch_exceptions=bool(assert_exit_code)
         )
         if result.exit_code != assert_exit_code:
-            raise (
-                Exception(
-                    (
-                        """
+            formatted_network_calls = textwrap.indent(
+                "\n".join(
+                    f"{r.request.method} {r.request.url}" for r in responses.calls
+                )
+                or "<none>",
+                "  ",
+            )
+            message = f"""
 CliTest run_line exit_code assertion failed!
 Line:
-  {}
-exited with {} when expecting {}
+  {line}
+exited with {result.exit_code} when expecting {assert_exit_code}
 
 stdout:
-{}
+{textwrap.indent(result.stdout, "  ")}
 stderr:
-{}
+{textwrap.indent(result.stderr, "  ")}
 network calls recorded:
-{}"""
-                    ).format(
-                        line,
-                        result.exit_code,
-                        assert_exit_code,
-                        textwrap.indent(result.stdout, "  "),
-                        textwrap.indent(result.stderr, "  "),
-                        textwrap.indent(
-                            "\n".join(
-                                f"{r.request.method} {r.request.url}"
-                                for r in responses.calls
-                            )
-                            or "<none>",
-                            "  ",
-                        ),
-                    )
-                )
-            )
+{formatted_network_calls}"""
+            raise Exception(message)
         if matcher:
             return result, OutputMatcher(result)
         return result


### PR DESCRIPTION
The `run_line` fixture tries to present all of the behavior of a command which fails in the form of an exception message. But the message formatting is currently hard to read, and it can easily be improved with some better whitespace. This doesn't impact any tests passing/failing, as the output only appears in the case of a failing test.

---

This was an improvement I made during other work, but which I think is worth reviewing and keeping on its own merits.
`run_line` might be due for a deeper rethink/refactor, but for now this makes it behave better.