### PR TITLE
Fix handling of `globus api -Q` for multi-params

### DIFF
--- a/changelog.d/20230213_184034_sirosen_fix_multi_query_param.md
+++ b/changelog.d/20230213_184034_sirosen_fix_multi_query_param.md
@@ -1,0 +1,5 @@
+### Bugfixes
+
+* Fix the handling of multiple `-Q` parameters with the same name for
+  the `globus api` commands. Such usages were only sending the last value
+  used, but now correctly send all parameters.

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import typing as t
+from collections import defaultdict
 
 import click
 import globus_sdk
@@ -254,9 +255,9 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
             client.transport.max_retries = 0
 
         # Prepare Query Params
-        query_params_d = {}
+        query_params_d = defaultdict(list)
         for param_name, param_value in query_param:
-            query_params_d[param_name] = param_value
+            query_params_d[param_name].append(param_value)
 
         # Prepare Request Body
         # the value in 'body' will be passed in the request

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -1,5 +1,27 @@
+import urllib.parse
+
 import pytest
-from globus_sdk._testing import RegisteredResponse, load_response
+from globus_sdk._testing import (
+    RegisteredResponse,
+    get_last_request,
+    load_response,
+    register_response_set,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _register_stub_transfer_response():
+    register_response_set(
+        "cli.api.transfer_stub",
+        {
+            "default": {
+                "service": "transfer",
+                "status": 200,
+                "path": "/foo",
+                "json": {"foo": "bar"},
+            }
+        },
+    )
 
 
 @pytest.mark.parametrize(
@@ -24,14 +46,48 @@ def test_api_command_get(run_line, service_name, is_error_response):
 
 
 def test_api_command_can_use_jmespath(run_line):
-    load_response(
-        RegisteredResponse(
-            service="transfer",
-            status=200,
-            path="/foo",
-            json={"foo": "bar"},
-        )
-    )
+    load_response("cli.api.transfer_stub")
 
     result = run_line(["globus", "api", "transfer", "get", "/foo", "--jmespath", "foo"])
     assert result.output == '"bar"\n'
+
+
+def test_api_command_query_param(run_line):
+    load_response("cli.api.transfer_stub")
+
+    result = run_line(
+        ["globus", "api", "transfer", "get", "/foo", "-Q", "frobulation_mode=reversed"]
+    )
+    assert result.output == '{"foo": "bar"}\n'
+
+    last_req = get_last_request()
+    parsed_url = urllib.parse.urlparse(last_req.url)
+    parsed_query_string = urllib.parse.parse_qs(parsed_url.query)
+    assert parsed_query_string == {"frobulation_mode": ["reversed"]}
+
+
+def test_api_command_query_params_multiple_become_list(run_line):
+    load_response("cli.api.transfer_stub")
+
+    result = run_line(
+        [
+            "globus",
+            "api",
+            "transfer",
+            "get",
+            "/foo",
+            "-Q",
+            "filter=frobulated",
+            "-Q",
+            "filter=demuddled",
+            "-Q",
+            "filter=reversed",
+        ]
+    )
+    assert result.output == '{"foo": "bar"}\n'
+
+    last_req = get_last_request()
+    parsed_url = urllib.parse.urlparse(last_req.url)
+    parsed_query_string = urllib.parse.parse_qs(parsed_url.query)
+    assert list(parsed_query_string.keys()) == ["filter"]
+    assert set(parsed_query_string["filter"]) == {"frobulated", "demuddled", "reversed"}


### PR DESCRIPTION
A parameter passed multiple times with different values should be encoded and sent with all of the values, not just the last one. This constitutes as switch from tracking these as `dict[str, str]` to `dict[str, list[str]]`. Tests confirm that this correctly encodes parameters like a Transfer ls `filter`.

Some minor refactoring to the tests for the `globus api` command makes this simpler to write.