### PR TITLE
Minor testsuite cleanup: remove LoginManager._TEST_MODE

### DIFF
--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -32,9 +32,6 @@ if t.TYPE_CHECKING:
 
 
 class LoginManager:
-    # TEST_MODE skips token validation
-    _TEST_MODE: bool = False
-
     AUTH_RS = AuthScopes.resource_server
     FLOWS_RS = FlowsScopes.resource_server
     GROUPS_RS = GroupsScopes.resource_server
@@ -102,9 +99,6 @@ class LoginManager:
         return all(res)
 
     def _validate_token(self, token: str) -> bool:
-        if self._TEST_MODE:
-            return True
-
         auth_client = internal_auth_client()
         try:
             res = auth_client.oauth2_validate_token(token)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,8 +37,17 @@ def mocksleep():
 
 
 @pytest.fixture(autouse=True)
-def set_login_manager_testmode():
-    globus_cli.login_manager.LoginManager._TEST_MODE = True
+def disable_login_manager_validate_token():
+    def fake_validate_token(self, token):
+        return True
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(
+            globus_cli.login_manager.LoginManager,
+            "_validate_token",
+            fake_validate_token,
+        )
+        yield mp
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -12,9 +12,11 @@ from globus_cli.login_manager.auth_flows import (
 from tests.conftest import _mock_token_response_data
 
 
-def test_login_validates_token(run_line, mock_login_token_response):
-    # turn off test mode, to allow token validation
-    LoginManager._TEST_MODE = False
+def test_login_validates_token(
+    run_line, mock_login_token_response, disable_login_manager_validate_token
+):
+    # undo the validate_token disabling patch which is done for most tests
+    disable_login_manager_validate_token.undo()
 
     with mock.patch("globus_cli.login_manager.manager.internal_auth_client") as m:
         ac = mock.MagicMock(spec=globus_sdk.NativeAppAuthClient)


### PR DESCRIPTION
There was a testing-aware path in the source which allowed a callout to be enabled/disabled with a class variable. Although this might be nice from the perspective of the testsuite, it isn't really necessary. It's very easy to replace this with a more clearly named monkeypatch usage in the testsuite, and use `MonkeyPatch.undo()` to reverse the patch in the one test which needs to do this.

---

I rediscovered this oddity in the course of other work on the LoginManager, and think this change simplifies things by removing the question of "what is test mode and what does it do?"