### PR TITLE
Strictly enforce static scope requirements

### DIFF
--- a/changelog.d/20230214_030123_sirosen_strictly_enforce_static_scopes.md
+++ b/changelog.d/20230214_030123_sirosen_strictly_enforce_static_scopes.md
@@ -1,0 +1,11 @@
+### Other
+
+* The CLI's handling of changes to its scope requirements over time has been
+  improved. After CLI updates which change the required scopes, users will be
+  prompted to login again, ensuring that the most up-to-date set of scopes are
+  in use.
+
+  ** Changes to the CLI which adjust scopes, and therefore force this
+     re-login behavior, will note this in the changelog.
+
+  ** This change, in itself, will not force re-login for any users.

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -125,6 +125,15 @@ class LoginManager:
         tokens = self._token_storage.get_token_data(resource_server)
         if tokens is None or "refresh_token" not in tokens:
             return False
+
+        # for resource servers in the static scope set, check that the scope
+        # requirements are satisfied by the token data
+        if resource_server in self.STATIC_SCOPES:
+            token_scopes = set(tokens["scope"].split(" "))
+            required_scopes = set(self.STATIC_SCOPES[resource_server])
+            if required_scopes - token_scopes:
+                return False
+
         rt = tokens["refresh_token"]
         return self._validate_token(rt)
 


### PR DESCRIPTION
The LoginManager now checks to see if the scope requirements for statically declared scopes are met, according to the data in token storage. When scope requirements are not met, the login is not considered valid for the `requires_login` decorator and related methods. As a result, when new scope requirements are added to the CLI, users may be prompted to re-login in order to gain the newly desired scope.

This ensures that newly added scope requirements are enforced, which means that the applicaiton has fewer potential states to reason about when scopes are added.

The STATIC_SCOPES map has added new sections but has not updated the scope list for any section since the release of globus-cli v3.0.0. Therefore, we can be confident that no users on modern versions of the CLI will be impacted by this change on its own.