### PR TITLE
Improve test coverage for type params

### DIFF
--- a/src/globus_cli/parsing/param_classes.py
+++ b/src/globus_cli/parsing/param_classes.py
@@ -86,7 +86,7 @@ def one_use_option(*args: t.Any, **kwargs: t.Any) -> t.Callable[[C], C]:
 
     # cannot force a non Option Paramater (argument) to be a OneUseOption
     if kwargs.get("cls"):
-        raise TypeError(
+        raise ValueError(
             "Internal error, one_use_option cannot overwrite "
             "cls {}.".format(kwargs.get("cls"))
         )

--- a/src/globus_cli/parsing/param_types/comma_delimited.py
+++ b/src/globus_cli/parsing/param_types/comma_delimited.py
@@ -28,8 +28,6 @@ class CommaDelimitedList(AnnotatedParamType):
 
     def convert(self, value, param, ctx):
         value = super().convert(value, param, ctx)
-        if value is None:
-            return None
 
         # if `--foo` is a comma delimited list and someone passes
         # `--foo ""`, take that as `foo=[]` rather than foo=[""]

--- a/src/globus_cli/parsing/param_types/endpoint_plus_path.py
+++ b/src/globus_cli/parsing/param_types/endpoint_plus_path.py
@@ -49,7 +49,7 @@ class EndpointPlusPath(AnnotatedParamType):
         provided parameter and parses it.
         """
         # passthrough conditions: None or already processed
-        if value is None or isinstance(value, tuple):
+        if isinstance(value, tuple):
             return value
 
         # split the value on the first colon, leave the rest intact

--- a/src/globus_cli/parsing/param_types/nullable.py
+++ b/src/globus_cli/parsing/param_types/nullable.py
@@ -48,9 +48,7 @@ class StringOrNull(AnnotatedParamType):
         return "TEXT"
 
     def convert(self, value, param, ctx):
-        if value is None:
-            return None
-        elif value == "":
+        if value == "":
             return EXPLICIT_NULL
         else:
             return value
@@ -66,9 +64,7 @@ class UrlOrNull(StringOrNull):
         return "TEXT"
 
     def convert(self, value, param, ctx):
-        if value is None:
-            return None
-        elif value == "":
+        if value == "":
             return EXPLICIT_NULL
         else:
             try:

--- a/src/globus_cli/parsing/param_types/prefix_mapper.py
+++ b/src/globus_cli/parsing/param_types/prefix_mapper.py
@@ -30,8 +30,6 @@ class StringPrefixMapper(AnnotatedParamType):
         return "[" + "|".join(self.__prefix_metavars__) + "]"
 
     def convert(self, value, param, ctx):
-        if value is None:
-            return None
         if self.null is not None and value == self.null:
             return EXPLICIT_NULL
 

--- a/src/globus_cli/parsing/param_types/task_path.py
+++ b/src/globus_cli/parsing/param_types/task_path.py
@@ -87,7 +87,7 @@ class TaskPath(AnnotatedParamType):
         return TaskPath
 
     def convert(self, value, param, ctx):
-        if value is None or (ctx and ctx.resilient_parsing):
+        if ctx.resilient_parsing:
             return
         if isinstance(value, TaskPath):
             return value

--- a/tests/unit/param_classes/test_annotated_options.py
+++ b/tests/unit/param_classes/test_annotated_options.py
@@ -1,0 +1,24 @@
+import pytest
+
+from globus_cli.parsing import AnnotatedOption
+
+
+def test_annotated_option_defaults_to_no_explicit_annotation():
+    opt = AnnotatedOption(("--foo",))
+    assert not opt.has_explicit_annotation()
+
+
+def test_annotated_option_can_have_explicit_annotation():
+    opt = AnnotatedOption(("--foo",), type_annotation=str)
+    assert opt.has_explicit_annotation()
+
+
+def test_annotated_option_returns_annotation_if_present():
+    opt = AnnotatedOption(("--foo",), type_annotation=str)
+    assert opt.type_annotation is str
+
+
+def test_annotated_option_errors_if_nonexistent_annotation_is_accessed():
+    opt = AnnotatedOption(("--foo",))
+    with pytest.raises(ValueError, match="cannot get annotation"):
+        opt.type_annotation

--- a/tests/unit/param_classes/test_one_use_option.py
+++ b/tests/unit/param_classes/test_one_use_option.py
@@ -1,0 +1,94 @@
+import click
+import pytest
+
+from globus_cli.parsing.param_classes import OneUseOption, one_use_option
+
+
+def test_one_use_option_multiple_allows_unused(runner):
+    @click.command()
+    @click.option("--foo", multiple=True, cls=OneUseOption)
+    def testcmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(testcmd, [])
+    assert result.exit_code == 0
+    assert result.output == "\n"
+
+
+def test_one_use_option_multiple_allows_single_use(runner):
+    @click.command()
+    @click.option("--foo", multiple=True, cls=OneUseOption)
+    def testcmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(testcmd, ["--foo", "a"])
+    assert result.exit_code == 0
+    assert result.output == "a\n"
+
+
+def test_one_use_option_multiple_rejects_opt_used_twice(runner):
+    @click.command()
+    @click.option("--foo", multiple=True, cls=OneUseOption)
+    def testcmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(testcmd, ["--foo", "a", "--foo", "b"])
+    assert result.exit_code == 2
+    assert "Option used multiple times" in result.output
+
+
+def test_one_use_option_count_allows_unused(runner):
+    @click.command()
+    @click.option("--foo", count=True, cls=OneUseOption)
+    def testcmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(testcmd, [])
+    assert result.exit_code == 0
+    assert result.output == "False\n"
+
+
+def test_one_use_option_count_allows_used_once(runner):
+    @click.command()
+    @click.option("--foo", count=True, cls=OneUseOption)
+    def testcmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(testcmd, ["--foo"])
+    assert result.exit_code == 0
+    assert result.output == "True\n"
+
+
+def test_one_use_option_count_rejects_opt_used_twice(runner):
+    @click.command()
+    @click.option("--foo", count=True, cls=OneUseOption)
+    def testcmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(testcmd, ["--foo", "--foo"])
+    assert result.exit_code == 2
+    assert "Option used multiple times" in result.output
+
+
+def test_one_use_option_fails_if_neither_count_nor_multiple(runner):
+    @click.command()
+    @click.option("--foo", cls=OneUseOption)
+    def testcmd(foo):
+        click.echo(foo)
+
+    with pytest.raises(
+        ValueError,
+        match="Internal error, OneUseOption expected either multiple or count",
+    ):
+        runner.invoke(testcmd, ["--foo", "bar"], catch_exceptions=False)
+
+
+@pytest.mark.parametrize("kwargs", ({"multiple": True}, {"count": True}))
+def test_one_use_option_decorator_rejects_params(kwargs):
+    with pytest.raises(ValueError, match="cannot be used with multiple or count"):
+        one_use_option("--foo", **kwargs)
+
+
+def test_one_use_option_decorator_rejects_alternate_cls():
+    with pytest.raises(ValueError, match="cannot overwrite cls"):
+        one_use_option("--foo", cls=click.Option)

--- a/tests/unit/param_types/test_comma_delimited.py
+++ b/tests/unit/param_types/test_comma_delimited.py
@@ -1,0 +1,53 @@
+import click
+import pytest
+
+from globus_cli.parsing import CommaDelimitedList
+
+
+def test_comma_delimited_list_help(runner):
+    @click.command()
+    @click.option("--foo", type=CommaDelimitedList(), help="a comma delimited list")
+    def mycmd(foo):
+        click.echo(foo)
+
+    # in helptext, it shows up with "string,string,..." as the metavar
+    result = runner.invoke(mycmd, ["--help"])
+    assert "--foo TEXT,TEXT,...  a comma delimited list" in result.output
+
+
+def test_comma_delimited_list_help_with_choices(runner):
+    @click.command()
+    @click.option("--foo", type=CommaDelimitedList(choices=("alpha", "beta")))
+    def mycmd(foo):
+        click.echo(foo)
+
+    # in helptext, it shows up with "string,string,..." as the metavar
+    result = runner.invoke(mycmd, ["--help"])
+    assert "--foo {alpha,beta}" in result.output
+
+
+@pytest.mark.parametrize(
+    "add_args, expect_output",
+    (
+        # absent, it returns None
+        ([], ("nil\n")),
+        # given empty string (this is ambiguous!) returns empty array
+        (["--foo", ""], "0\n"),
+        # given one or more values, it listifies them
+        (["--foo", "alpha"], "1\nalpha\n"),
+        (["--foo", "alpha,beta"], "2\nalpha\nbeta\n"),
+    ),
+)
+def test_comma_delimited_list_outputs(runner, add_args, expect_output):
+    @click.command()
+    @click.option("--foo", type=CommaDelimitedList(), default=None)
+    def mycmd(foo):
+        if foo is None:
+            click.echo("nil")
+        else:
+            click.echo(len(foo))
+            for x in foo:
+                click.echo(x)
+
+    result = runner.invoke(mycmd, add_args)
+    assert result.output == expect_output

--- a/tests/unit/param_types/test_param_types.py
+++ b/tests/unit/param_types/test_param_types.py
@@ -4,12 +4,7 @@ import json
 import click
 
 from globus_cli.constants import EXPLICIT_NULL
-from globus_cli.parsing import (
-    CommaDelimitedList,
-    JSONStringOrFile,
-    StringOrNull,
-    TimedeltaType,
-)
+from globus_cli.parsing import JSONStringOrFile, StringOrNull, TimedeltaType
 from globus_cli.parsing.param_types.prefix_mapper import StringPrefixMapper
 
 
@@ -41,40 +36,6 @@ def test_string_or_null(runner):
     # given a string, it returns that string
     result = runner.invoke(foo, ["--bar", "alpha"])
     assert result.output == "alpha\n"
-
-
-def test_comma_delimited_list(runner):
-    @click.command()
-    @click.option(
-        "--bar", type=CommaDelimitedList(), default=None, help="a comma delimited list"
-    )
-    def foo(bar):
-        if bar is None:
-            click.echo("nil")
-        else:
-            click.echo(len(bar))
-            for x in bar:
-                click.echo(x)
-
-    # in helptext, it shows up with "string,string,..." as the metavar
-    result = runner.invoke(foo, ["--help"])
-    assert "--bar TEXT,TEXT,...  a comma delimited list" in result.output
-
-    # absent, it returns None
-    result = runner.invoke(foo, [])
-    assert result.output == "nil\n"
-
-    # given empty string (this is ambiguous!) returns empty array
-    result = runner.invoke(foo, ["--bar", ""])
-    assert result.output == "0\n"
-
-    # given "alpha" it returns "['alpha']"
-    result = runner.invoke(foo, ["--bar", "alpha"])
-    assert result.output == "1\nalpha\n"
-
-    # given a UUID it returns that UUID
-    result = runner.invoke(foo, ["--bar", "alpha,beta"])
-    assert result.output == "2\nalpha\nbeta\n"
 
 
 def test_string_prefix_mapper(runner, tmpdir):


### PR DESCRIPTION
While doing some other things, I noticed some small coverage gaps which are easy to close up.

There are two commits here, each doing a separate bit of cleanup to the param type testing.