### PR TITLE
Add "well_known_config" internal APIs for storage

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -20,9 +20,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.login_manager._old_config]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.login_manager.auth_flows]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.login_manager.client_login]
 disallow_untyped_defs = false
 
@@ -33,9 +30,6 @@ disallow_untyped_defs = false
 disallow_untyped_defs = false
 
 [mypy-globus_cli.login_manager.manager]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.login_manager.tokenstore]
 disallow_untyped_defs = false
 
 [mypy-globus_cli.login_manager.utils]
@@ -303,9 +297,6 @@ disallow_untyped_defs = false
 disallow_untyped_defs = false
 
 [mypy-globus_cli.commands.login]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.logout]
 disallow_untyped_defs = false
 
 [mypy-globus_cli.commands.ls]

--- a/src/globus_cli/commands/logout.py
+++ b/src/globus_cli/commands/logout.py
@@ -6,13 +6,13 @@ from globus_cli.login_manager import (
     delete_templated_client,
     internal_native_client,
     is_client_login,
+    remove_well_known_config,
     token_storage_adapter,
 )
-from globus_cli.login_manager.auth_flows import _STORE_CONFIG_USERINFO
 from globus_cli.parsing import command
 
 
-def warnecho(msg):
+def warnecho(msg: str) -> None:
     click.echo(click.style(msg, fg="yellow"), err=True)
 
 
@@ -55,7 +55,7 @@ flow.
     default=False,
 )
 @LoginManager.requires_login()
-def logout_command(*, login_manager: LoginManager, ignore_errors):
+def logout_command(*, login_manager: LoginManager, ignore_errors: bool) -> None:
     """
     Logout of the Globus CLI
 
@@ -142,7 +142,7 @@ def logout_command(*, login_manager: LoginManager, ignore_errors):
 
         adapter.remove_tokens_for_resource_server(rs)
 
-    adapter.remove_config(_STORE_CONFIG_USERINFO)
+    remove_well_known_config("auth_user_data")
 
     if is_client_login():
         click.echo(_CLIENT_LOGOUT_EPILOG)

--- a/src/globus_cli/login_manager/__init__.py
+++ b/src/globus_cli/login_manager/__init__.py
@@ -5,6 +5,9 @@ from .tokenstore import (
     delete_templated_client,
     internal_auth_client,
     internal_native_client,
+    read_well_known_config,
+    remove_well_known_config,
+    store_well_known_config,
     token_storage_adapter,
 )
 from .utils import is_remote_session
@@ -19,4 +22,7 @@ __all__ = [
     "token_storage_adapter",
     "is_client_login",
     "get_client_login",
+    "store_well_known_config",
+    "read_well_known_config",
+    "remove_well_known_config",
 ]


### PR DESCRIPTION
Define clear helpers for interacting with the config storage. This will enable use from outside of the narrow space of login/logout functionality, but also defines a better interface for other future uses.

We have already encountered some need for this kind of change in order to support the Timer commands.

Because the API defined here relies on `Literal` checking for safety, we need to ensure that all of its usage sites are properly annotated. Therefore, annotate several functions which previously were not annotated.

---

This was extracted from #699 to be a standalone PR for better review.