### PR TITLE
Add dynamic dependencies to the Timer scope and enforce them

### DIFF
--- a/changelog.d/20230221_220357_sirosen_timer_scope_dep.md
+++ b/changelog.d/20230221_220357_sirosen_timer_scope_dep.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* The CLI now has stronger requirements around the scope used for the Timer
+  service, and will treat past Timer tokens as invalid. Users running
+  `globus timer` commands will find that they must login agian.

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -9,6 +9,7 @@ import globus_sdk
 
 from globus_cli import termio, version
 from globus_cli.login_manager import LoginManager
+from globus_cli.login_manager.scopes import CLI_SCOPE_REQUIREMENTS
 from globus_cli.parsing import command, group, mutex_option_group
 from globus_cli.termio import display
 
@@ -110,16 +111,6 @@ def print_error_or_response(
         display(data, simple_text=data.text)
 
 
-_SERVICE_MAP = {
-    "auth": LoginManager.AUTH_RS,
-    "flows": LoginManager.FLOWS_RS,
-    "groups": LoginManager.GROUPS_RS,
-    "search": LoginManager.SEARCH_RS,
-    "transfer": LoginManager.TRANSFER_RS,
-    "timer": LoginManager.TIMER_RS,
-}
-
-
 def _get_client(
     login_manager: LoginManager, service_name: str
 ) -> globus_sdk.BaseClient:
@@ -172,7 +163,7 @@ For example, a call of
 sends a 'GET' request to '{_get_url(service_name)}foo/bar'
 """,
     )
-    @LoginManager.requires_login(_SERVICE_MAP[service_name])
+    @LoginManager.requires_login(service_name)
     @click.argument(
         "method",
         type=click.Choice(
@@ -307,5 +298,5 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
     return t.cast(click.Command, service_command)
 
 
-for service_name in _SERVICE_MAP:
+for service_name in CLI_SCOPE_REQUIREMENTS.keys():
     api_command.add_command(build_command(service_name))

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -12,6 +12,7 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.login_manager.scopes import CLI_SCOPE_REQUIREMENTS
 from globus_cli.parsing import command, group, mutex_option_group
 from globus_cli.termio import display
+from globus_cli.types import ServiceNameLiteral
 
 
 class QueryParamType(click.ParamType):
@@ -148,7 +149,7 @@ def api_command() -> None:
 
 # note: this must be written as a separate call and not inlined into the loop body
 # this ensures that it acts as a closure over 'service_name'
-def build_command(service_name: str) -> click.Command:
+def build_command(service_name: ServiceNameLiteral) -> click.Command:
     @command(
         service_name,
         help=f"""\

--- a/src/globus_cli/commands/bookmark/create.py
+++ b/src/globus_cli/commands/bookmark/create.py
@@ -36,7 +36,7 @@ $ globus bookmark create \
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
 @click.argument("bookmark_name")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def bookmark_create(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/bookmark/delete.py
+++ b/src/globus_cli/commands/bookmark/delete.py
@@ -23,7 +23,7 @@ $ globus bookmark delete "Bookmark Name"
     short_help="Delete a bookmark",
 )
 @click.argument("bookmark_id_or_name")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def bookmark_delete(*, login_manager: LoginManager, bookmark_id_or_name: str) -> None:
     """
     Delete one bookmark, given its ID or name.

--- a/src/globus_cli/commands/bookmark/list.py
+++ b/src/globus_cli/commands/bookmark/list.py
@@ -47,7 +47,7 @@ $ globus bookmark list --jmespath='DATA[*].[name, endpoint_id]' --format=unix
 """,
     short_help="List your bookmarks",
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def bookmark_list(*, login_manager: LoginManager) -> None:
     """List all bookmarks for the current user"""
     from globus_cli.services.transfer import iterable_response_to_dict

--- a/src/globus_cli/commands/bookmark/rename.py
+++ b/src/globus_cli/commands/bookmark/rename.py
@@ -24,7 +24,7 @@ $ globus bookmark rename oldname newname
 )
 @click.argument("bookmark_id_or_name")
 @click.argument("new_bookmark_name")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def bookmark_rename(
     *, login_manager: LoginManager, bookmark_id_or_name: str, new_bookmark_name: str
 ) -> None:

--- a/src/globus_cli/commands/bookmark/show.py
+++ b/src/globus_cli/commands/bookmark/show.py
@@ -31,7 +31,7 @@ $ globus ls "$(globus bookmark show BOOKMARK_NAME)"
     short_help="Resolve a bookmark name or ID to an endpoint:path",
 )
 @click.argument("bookmark_id_or_name")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def bookmark_show(*, login_manager: LoginManager, bookmark_id_or_name: str) -> None:
     """
     Given a single bookmark ID or bookmark name, show the bookmark details. By default,

--- a/src/globus_cli/commands/collection/delete.py
+++ b/src/globus_cli/commands/collection/delete.py
@@ -5,7 +5,7 @@ from globus_cli.termio import TextMode, display
 
 @command("delete", short_help="Delete an existing Collection")
 @collection_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def collection_delete(*, login_manager: LoginManager, collection_id):
     """
     Delete an existing Collection. This requires the administrator role on the

--- a/src/globus_cli/commands/collection/list.py
+++ b/src/globus_cli/commands/collection/list.py
@@ -72,7 +72,7 @@ created-by-me:
         "the ID of the Mapped Collection"
     ),
 )
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def collection_list(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/collection/list.py
+++ b/src/globus_cli/commands/collection/list.py
@@ -72,7 +72,7 @@ created-by-me:
         "the ID of the Mapped Collection"
     ),
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def collection_list(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -72,7 +72,7 @@ PRIVATE_FIELDS: list[Field] = [
         "Some policy data may only be visible in `--format JSON` output"
     ),
 )
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def collection_show(
     *, login_manager: LoginManager, include_private_policies, collection_id
 ):

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -72,7 +72,7 @@ PRIVATE_FIELDS: list[Field] = [
         "Some policy data may only be visible in `--format JSON` output"
     ),
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def collection_show(
     *, login_manager: LoginManager, include_private_policies, collection_id
 ):

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -121,7 +121,7 @@ class _FullDataField(Field):
     type_annotation=t.Union[ListType[str], None, ExplicitNullType],
 )
 @mutex_option_group("--enable-https", "--disable-https")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def collection_update(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -121,7 +121,7 @@ class _FullDataField(Field):
     type_annotation=t.Union[ListType[str], None, ExplicitNullType],
 )
 @mutex_option_group("--enable-https", "--disable-https")
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def collection_update(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -66,7 +66,7 @@ $ globus task wait "$task_id"
 @task_submission_options
 @delete_and_rm_options
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_OPTPATH)
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def delete_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -109,7 +109,7 @@ $ globus endpoint activate $ep_id --myproxy -U username
     help="Force activation even if endpoint is already activated.",
 )
 @mutex_option_group("--web", "--myproxy", "--delegate-proxy")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def endpoint_activate(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -65,7 +65,7 @@ GCP_FIELDS = [Field("Setup Key", "globus_connect_setup_key")]
     type_annotation=t.Optional[TupleType[uuid.UUID, str]],  # type: ignore[type-arg]
 )
 @mutex_option_group("--shared", "--server", "--personal")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def endpoint_create(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/deactivate.py
+++ b/src/globus_cli/commands/endpoint/deactivate.py
@@ -16,7 +16,7 @@ $ globus endpoint deactivate $ep_id
 """,
 )
 @endpoint_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def endpoint_deactivate(*, login_manager: LoginManager, endpoint_id: str) -> None:
     """
     Remove the credential previously assigned to an endpoint via

--- a/src/globus_cli/commands/endpoint/delete.py
+++ b/src/globus_cli/commands/endpoint/delete.py
@@ -15,7 +15,7 @@ $ globus endpoint delete $ep_id
 """,
 )
 @endpoint_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def endpoint_delete(*, login_manager: LoginManager, endpoint_id: str) -> None:
     """Delete a given endpoint.
 

--- a/src/globus_cli/commands/endpoint/is_activated.py
+++ b/src/globus_cli/commands/endpoint/is_activated.py
@@ -82,7 +82,7 @@ fi
         "since Epoch), not a number of seconds into the future."
     ),
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def endpoint_is_activated(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
+++ b/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
@@ -14,7 +14,7 @@ $ globus endpoint my-shared-endpoint-list $ep_id
 """,
 )
 @endpoint_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def my_shared_endpoint_list(*, login_manager: LoginManager, endpoint_id: str) -> None:
     """
     Show a list of all shared endpoints hosted on the target endpoint for which the user

--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -45,7 +45,7 @@ $ globus endpoint permission create $ep_id:/ --permissions rw --identity go@glob
     help="A custom message to add to email notifications",
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
-@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("auth", "transfer")
 def create_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/permission/delete.py
+++ b/src/globus_cli/commands/endpoint/permission/delete.py
@@ -18,7 +18,7 @@ $ globus endpoint permission delete $ep_id $rule_id
 )
 @endpoint_id_arg
 @click.argument("rule_id")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def delete_command(*, login_manager: LoginManager, endpoint_id, rule_id):
     """
     Delete an existing access control rule, removing whatever permissions it previously

--- a/src/globus_cli/commands/endpoint/permission/list.py
+++ b/src/globus_cli/commands/endpoint/permission/list.py
@@ -20,7 +20,7 @@ $ globus endpoint permission list $ep_id
 """,
 )
 @endpoint_id_arg
-@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("auth", "transfer")
 def list_command(*, login_manager: LoginManager, endpoint_id: uuid.UUID):
     """List all rules in an endpoint's access control list."""
     transfer_client = login_manager.get_transfer_client()

--- a/src/globus_cli/commands/endpoint/permission/show.py
+++ b/src/globus_cli/commands/endpoint/permission/show.py
@@ -24,7 +24,7 @@ $ globus endpoint permission show $ep_id $rule_id
 )
 @endpoint_id_arg
 @click.argument("rule_id")
-@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("auth", "transfer")
 def show_command(*, login_manager: LoginManager, endpoint_id: uuid.UUID, rule_id: str):
     """
     Show detailed information about a single access control rule on an endpoint.

--- a/src/globus_cli/commands/endpoint/permission/update.py
+++ b/src/globus_cli/commands/endpoint/permission/update.py
@@ -26,7 +26,7 @@ $ globus endpoint permission update $ep_id $rule_id --permissions r
     type=click.Choice(("r", "rw"), case_sensitive=False),
     help="Permissions to add. Read-Only or Read/Write",
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def update_command(*, login_manager: LoginManager, permissions, rule_id, endpoint_id):
     """
     Update an existing access control rule's permissions.

--- a/src/globus_cli/commands/endpoint/role/create.py
+++ b/src/globus_cli/commands/endpoint/role/create.py
@@ -43,7 +43,7 @@ $ globus endpoint role create 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
     ),
     help="A role to assign.",
 )
-@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("auth", "transfer")
 def role_create(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/role/delete.py
+++ b/src/globus_cli/commands/endpoint/role/delete.py
@@ -23,7 +23,7 @@ $ globus endpoint role delete 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
 )
 @endpoint_id_arg
 @role_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def role_delete(
     *, login_manager: LoginManager, role_id: str, endpoint_id: uuid.UUID
 ) -> None:

--- a/src/globus_cli/commands/endpoint/role/list.py
+++ b/src/globus_cli/commands/endpoint/role/list.py
@@ -30,7 +30,7 @@ $ globus endpoint role list 'ddb59aef-6d04-11e5-ba46-22000b92c6ec'
 """,
 )
 @endpoint_id_arg
-@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("auth", "transfer")
 def role_list(*, login_manager: LoginManager, endpoint_id: uuid.UUID) -> None:
     """
     List the assigned roles on an endpoint.

--- a/src/globus_cli/commands/endpoint/role/show.py
+++ b/src/globus_cli/commands/endpoint/role/show.py
@@ -32,7 +32,7 @@ $ globus endpoint role show EP_ID ROLE_ID
 )
 @endpoint_id_arg
 @role_id_arg
-@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("auth", "transfer")
 def role_show(
     *, login_manager: LoginManager, endpoint_id: uuid.UUID, role_id: str
 ) -> None:

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -66,7 +66,7 @@ $ globus endpoint search --filter-scope my-endpoints
     help="The maximum number of results to return.",
 )
 @click.argument("filter_fulltext", required=False)
-@LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("auth", "transfer")
 def endpoint_search(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/server/add.py
+++ b/src/globus_cli/commands/endpoint/server/add.py
@@ -19,7 +19,7 @@ $ globus endpoint server add $ep_id --hostname gridftp.example.org
 )
 @endpoint_id_arg
 @server_add_and_update_opts(add=True)
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def server_add(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/server/delete.py
+++ b/src/globus_cli/commands/endpoint/server/delete.py
@@ -62,7 +62,7 @@ $ globus endpoint server delete $ep_id $server_id
 )
 @endpoint_id_arg
 @click.argument("server")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def server_delete(*, login_manager: LoginManager, endpoint_id, server):
     """
     Delete a server belonging to an endpoint.

--- a/src/globus_cli/commands/endpoint/server/list.py
+++ b/src/globus_cli/commands/endpoint/server/list.py
@@ -29,7 +29,7 @@ $ globus endpoint server list $ep_id
 """,
 )
 @endpoint_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def server_list(*, login_manager: LoginManager, endpoint_id):
     """List all servers belonging to an endpoint."""
     transfer_client = login_manager.get_transfer_client()

--- a/src/globus_cli/commands/endpoint/server/show.py
+++ b/src/globus_cli/commands/endpoint/server/show.py
@@ -64,7 +64,7 @@ $ globus endpoint server show $ep_id $server_id
 )
 @endpoint_id_arg
 @server_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def server_show(*, login_manager: LoginManager, endpoint_id, server_id):
     """
     Display inofrmation about a server belonging to an endpoint.

--- a/src/globus_cli/commands/endpoint/server/update.py
+++ b/src/globus_cli/commands/endpoint/server/update.py
@@ -21,7 +21,7 @@ $ globus endpoint server update $ep_id $server_id --scheme ftp
 @server_add_and_update_opts
 @endpoint_id_arg
 @server_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def server_update(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -27,7 +27,7 @@ class SubscriptionIdType(click.ParamType):
 @command("set-subscription-id", short_help="Set an endpoint's subscription")
 @endpoint_id_arg
 @click.argument("SUBSCRIPTION_ID", type=SubscriptionIdType())
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def set_endpoint_subscription_id(
     *, login_manager: LoginManager, endpoint_id: str, subscription_id: str | None
 ) -> None:

--- a/src/globus_cli/commands/endpoint/show.py
+++ b/src/globus_cli/commands/endpoint/show.py
@@ -37,7 +37,7 @@ GCP_FIELDS = STANDARD_FIELDS + [
 @command("show")
 @endpoint_id_arg
 @click.option("--skip-endpoint-type-check", is_flag=True, hidden=True)
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def endpoint_show(
     *, login_manager: LoginManager, endpoint_id: str, skip_endpoint_type_check: bool
 ) -> None:

--- a/src/globus_cli/commands/endpoint/storage_gateway/list.py
+++ b/src/globus_cli/commands/endpoint/storage_gateway/list.py
@@ -17,7 +17,7 @@ STANDARD_FIELDS = [
     "endpoint_id",
     metavar="ENDPOINT_ID",
 )
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def storage_gateway_list(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/storage_gateway/list.py
+++ b/src/globus_cli/commands/endpoint/storage_gateway/list.py
@@ -17,7 +17,7 @@ STANDARD_FIELDS = [
     "endpoint_id",
     metavar="ENDPOINT_ID",
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def storage_gateway_list(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -36,7 +36,7 @@ else:
     help="Unset any default directory on the endpoint",
 )
 @mutex_option_group("--default-directory", "--no-default-directory")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def endpoint_update(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
@@ -8,7 +8,7 @@ from globus_cli.termio import display
 @command("from-json", short_help="Create a User Credential from a JSON document")
 @endpoint_id_arg
 @click.argument("user_credential_json", type=JSONStringOrFile())
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def from_json(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
@@ -8,7 +8,7 @@ from globus_cli.termio import display
 @command("from-json", short_help="Create a User Credential from a JSON document")
 @endpoint_id_arg
 @click.argument("user_credential_json", type=JSONStringOrFile())
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def from_json(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/create/posix.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/posix.py
@@ -14,7 +14,7 @@ from .._common import user_credential_create_and_update_params
 @command("posix", short_help="Create a User Credential for a POSIX storage gateway")
 @endpoint_id_arg
 @user_credential_create_and_update_params(create=True)
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def posix(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/create/posix.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/posix.py
@@ -14,7 +14,7 @@ from .._common import user_credential_create_and_update_params
 @command("posix", short_help="Create a User Credential for a POSIX storage gateway")
 @endpoint_id_arg
 @user_credential_create_and_update_params(create=True)
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def posix(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/create/s3.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/s3.py
@@ -17,7 +17,7 @@ from .._common import user_credential_create_and_update_params
 @user_credential_create_and_update_params(create=True)
 @click.argument("s3_key_id")
 @click.argument("s3_secret_key")
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def s3(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/create/s3.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/s3.py
@@ -17,7 +17,7 @@ from .._common import user_credential_create_and_update_params
 @user_credential_create_and_update_params(create=True)
 @click.argument("s3_key_id")
 @click.argument("s3_secret_key")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def s3(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/delete.py
+++ b/src/globus_cli/commands/endpoint/user_credential/delete.py
@@ -8,7 +8,7 @@ from ._common import user_credential_id_arg
 @command("delete", short_help="Delete a specific User Credential on an Endpoint")
 @endpoint_id_arg
 @user_credential_id_arg
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def user_credential_delete(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/delete.py
+++ b/src/globus_cli/commands/endpoint/user_credential/delete.py
@@ -8,7 +8,7 @@ from ._common import user_credential_id_arg
 @command("delete", short_help="Delete a specific User Credential on an Endpoint")
 @endpoint_id_arg
 @user_credential_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def user_credential_delete(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/list.py
+++ b/src/globus_cli/commands/endpoint/user_credential/list.py
@@ -21,7 +21,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
         "this UUID"
     ),
 )
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def user_credential_list(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/list.py
+++ b/src/globus_cli/commands/endpoint/user_credential/list.py
@@ -21,7 +21,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
         "this UUID"
     ),
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def user_credential_list(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/show.py
+++ b/src/globus_cli/commands/endpoint/user_credential/show.py
@@ -10,7 +10,7 @@ from ._common import user_credential_id_arg
 @command("show", short_help="Show a specific User Credential on an Endpoint")
 @endpoint_id_arg
 @user_credential_id_arg
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def user_credential_show(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/show.py
+++ b/src/globus_cli/commands/endpoint/user_credential/show.py
@@ -10,7 +10,7 @@ from ._common import user_credential_id_arg
 @command("show", short_help="Show a specific User Credential on an Endpoint")
 @endpoint_id_arg
 @user_credential_id_arg
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def user_credential_show(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
@@ -11,7 +11,7 @@ from .._common import user_credential_id_arg
 @endpoint_id_arg
 @user_credential_id_arg
 @click.argument("user_credential_json", type=JSONStringOrFile())
-@LoginManager.requires_login("transfer", "auth")
+@LoginManager.requires_login("auth", "transfer")
 def from_json(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
@@ -11,7 +11,7 @@ from .._common import user_credential_id_arg
 @endpoint_id_arg
 @user_credential_id_arg
 @click.argument("user_credential_json", type=JSONStringOrFile())
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("transfer", "auth")
 def from_json(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/flows/delete.py
+++ b/src/globus_cli/commands/flows/delete.py
@@ -9,7 +9,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
 
 @command("delete", short_help="Delete a flow")
 @flow_id_arg
-@LoginManager.requires_login(LoginManager.FLOWS_RS)
+@LoginManager.requires_login("flows")
 def delete_command(login_manager: LoginManager, flow_id: uuid.UUID):
     """
     Delete a flow

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -30,7 +30,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
     type=click.IntRange(1),
     help="The maximum number of results to return.",
 )
-@LoginManager.requires_login(LoginManager.FLOWS_RS)
+@LoginManager.requires_login("flows")
 def list_command(
     login_manager: LoginManager,
     filter_role: str | None,

--- a/src/globus_cli/commands/flows/show.py
+++ b/src/globus_cli/commands/flows/show.py
@@ -9,7 +9,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
 
 @command("show")
 @flow_id_arg
-@LoginManager.requires_login(LoginManager.FLOWS_RS)
+@LoginManager.requires_login("flows")
 def show_command(login_manager: LoginManager, flow_id: uuid.UUID):
     """
     Show a flow

--- a/src/globus_cli/commands/flows/start.py
+++ b/src/globus_cli/commands/flows/start.py
@@ -78,7 +78,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
         to create a list of tags.
     """,
 )
-@LoginManager.requires_login(LoginManager.FLOWS_RS)
+@LoginManager.requires_login("flows")
 def start_command(
     login_manager: LoginManager,
     flow_id: uuid.UUID,

--- a/src/globus_cli/commands/gcp/create/guest.py
+++ b/src/globus_cli/commands/gcp/create/guest.py
@@ -20,7 +20,7 @@ from ._common import deprecated_verify_option
 )
 @click.argument("HOST_GCP_PATH", type=ENDPOINT_PLUS_REQPATH)
 @deprecated_verify_option
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def guest_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/gcp/create/mapped.py
+++ b/src/globus_cli/commands/gcp/create/mapped.py
@@ -17,7 +17,7 @@ from ._common import deprecated_verify_option
     help="Set the collection as managed with the given subscription ID",
 )
 @deprecated_verify_option
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def mapped_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/get_identities.py
+++ b/src/globus_cli/commands/get_identities.py
@@ -36,7 +36,7 @@ $ globus get-identities --verbose go@globusid.org clitester1a@globusid.org \
     "values", type=IdentityType(allow_b32_usernames=True), required=True, nargs=-1
 )
 @click.option("--provision", hidden=True, is_flag=True)
-@LoginManager.requires_login(LoginManager.AUTH_RS)
+@LoginManager.requires_login("auth")
 def get_identities_command(*, login_manager: LoginManager, values, provision):
     """
     Lookup Globus Auth Identities given one or more uuids

--- a/src/globus_cli/commands/group/create.py
+++ b/src/globus_cli/commands/group/create.py
@@ -9,7 +9,7 @@ from ._common import group_create_and_update_params
 
 @group_create_and_update_params(create=True)
 @command("create")
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def group_create(*, login_manager: LoginManager, **kwargs: t.Any):
     """Create a new group"""
     groups_client = login_manager.get_groups_client()

--- a/src/globus_cli/commands/group/delete.py
+++ b/src/globus_cli/commands/group/delete.py
@@ -7,7 +7,7 @@ from ._common import group_id_arg
 
 @group_id_arg
 @command("delete")
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def group_delete(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/group/invite/accept.py
+++ b/src/globus_cli/commands/group/invite/accept.py
@@ -18,7 +18,7 @@ from ._common import build_invite_actions, get_invite_formatter
     type=IdentityType(),
     help="Only accept invitations for a specific identity",
 )
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def invite_accept(
     *, group_id: uuid.UUID, identity: ParsedIdentity | None, login_manager: LoginManager
 ):

--- a/src/globus_cli/commands/group/invite/decline.py
+++ b/src/globus_cli/commands/group/invite/decline.py
@@ -18,7 +18,7 @@ from ._common import build_invite_actions, get_invite_formatter
     type=IdentityType(),
     help="Only decline invitations for a specific identity",
 )
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def invite_decline(
     *, group_id: uuid.UUID, identity: ParsedIdentity | None, login_manager: LoginManager
 ):

--- a/src/globus_cli/commands/group/join.py
+++ b/src/globus_cli/commands/group/join.py
@@ -28,7 +28,7 @@ JOIN_USER_FIELDS = [
     help="Instead of attempting to join the group directly, create a join "
     "request which can be approved by a group administrator",
 )
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def group_join(
     *,
     group_id: uuid.UUID,

--- a/src/globus_cli/commands/group/leave.py
+++ b/src/globus_cli/commands/group/leave.py
@@ -38,7 +38,7 @@ def group_leave_formatter(data: globus_sdk.GlobusHTTPResponse) -> None:
     type=IdentityType(),
     help="Only remove membership for a specific identity, not all identities",
 )
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def group_leave(
     *,
     group_id: uuid.UUID,

--- a/src/globus_cli/commands/group/list.py
+++ b/src/globus_cli/commands/group/list.py
@@ -6,7 +6,7 @@ from ._common import SESSION_ENFORCEMENT_FIELD
 
 
 @command("list", short_help="List groups you belong to")
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def group_list(*, login_manager: LoginManager):
     """List all groups for the current user"""
     groups_client = login_manager.get_groups_client()

--- a/src/globus_cli/commands/group/member/add.py
+++ b/src/globus_cli/commands/group/member/add.py
@@ -21,7 +21,7 @@ ADD_USER_FIELDS = [
     help="The role for the added user",
     show_default=True,
 )
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def member_add(
     *, group_id: str, user: ParsedIdentity, role: str, login_manager: LoginManager
 ):

--- a/src/globus_cli/commands/group/member/approve.py
+++ b/src/globus_cli/commands/group/member/approve.py
@@ -14,7 +14,7 @@ APPROVED_USER_FIELDS = [
 @command("approve", short_help="Approve a member to join a group")
 @click.argument("group_id", type=click.UUID)
 @click.argument("user", type=IdentityType())
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def member_approve(group_id: str, user: ParsedIdentity, login_manager):
     """
     Approve a pending member to join a group, changing their status from 'invited'

--- a/src/globus_cli/commands/group/member/invite.py
+++ b/src/globus_cli/commands/group/member/invite.py
@@ -26,7 +26,7 @@ INVITED_USER_FIELDS = [
     help="The role for the added user",
     show_default=True,
 )
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def member_invite(
     *,
     group_id: str,

--- a/src/globus_cli/commands/group/member/list.py
+++ b/src/globus_cli/commands/group/member/list.py
@@ -21,7 +21,7 @@ def _str2field(fieldname: str) -> Field:
     type=CommaDelimitedList(choices=MEMBERSHIP_FIELDS, convert_values=str.lower),
 )
 @command("list")
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def member_list(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/group/member/reject.py
+++ b/src/globus_cli/commands/group/member/reject.py
@@ -14,7 +14,7 @@ REJECTED_USER_FIELDS = [
 @command("reject", short_help="Reject a member from a group")
 @click.argument("group_id", type=click.UUID)
 @click.argument("user", type=IdentityType())
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def member_reject(*, group_id: str, user: ParsedIdentity, login_manager: LoginManager):
     """
     Reject a pending member from a group.

--- a/src/globus_cli/commands/group/member/remove.py
+++ b/src/globus_cli/commands/group/member/remove.py
@@ -14,7 +14,7 @@ REMOVED_USER_FIELDS = [
 @command("remove", short_help="Remove a member from a group")
 @click.argument("group_id", type=click.UUID)
 @click.argument("user", type=IdentityType())
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def member_remove(group_id: str, user: ParsedIdentity, login_manager):
     """
     Remove a member from a group.

--- a/src/globus_cli/commands/group/set_policies.py
+++ b/src/globus_cli/commands/group/set_policies.py
@@ -55,7 +55,7 @@ from ._common import MEMBERSHIP_FIELDS, group_id_arg
 )
 @group_id_arg
 @command("set-policies")
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def group_set_policies(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/group/show.py
+++ b/src/globus_cli/commands/group/show.py
@@ -7,7 +7,7 @@ from ._common import SESSION_ENFORCEMENT_FIELD, group_id_arg
 
 @group_id_arg
 @command("show")
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def group_show(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/group/update.py
+++ b/src/globus_cli/commands/group/update.py
@@ -10,7 +10,7 @@ from ._common import group_create_and_update_params, group_id_arg
 @group_create_and_update_params()
 @group_id_arg
 @command("update")
-@LoginManager.requires_login(LoginManager.GROUPS_RS)
+@LoginManager.requires_login("groups")
 def group_update(*, login_manager: LoginManager, group_id: str, **kwargs: t.Any):
     """Update an existing group."""
     groups_client = login_manager.get_groups_client()

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -122,7 +122,7 @@ $ globus ls $ep_id:/share/godata/ --filter '~*.txt'  # done with --filter, bette
         "this should behave like a non-recursive `ls`"
     ),
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def ls_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/mkdir.py
+++ b/src/globus_cli/commands/mkdir.py
@@ -18,7 +18,7 @@ $ mkdir ep_id:~/testfolder
 """,
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def mkdir_command(*, login_manager: LoginManager, endpoint_plus_path):
     """Make a directory on an endpoint at the given path.
 

--- a/src/globus_cli/commands/rename.py
+++ b/src/globus_cli/commands/rename.py
@@ -20,7 +20,7 @@ $ globus rename $ep_id:~/tempdir $ep_id:~/project-foo
 @endpoint_id_arg
 @click.argument("source", metavar="SOURCE_PATH")
 @click.argument("destination", metavar="DEST_PATH")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def rename_command(*, login_manager: LoginManager, endpoint_id, source, destination):
     """Rename a file or directory on an endpoint.
 

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -38,7 +38,7 @@ $ globus rm $ep_id:~/mydir --recursive
 @delete_and_rm_options(supports_batch=False, default_enable_globs=True)
 @synchronous_task_wait_options
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def rm_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/search/delete_by_query.py
+++ b/src/globus_cli/commands/search/delete_by_query.py
@@ -28,7 +28,7 @@ from ._common import index_id_arg
 )
 @index_id_arg
 @mutex_option_group("-q", "--query-document")
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 def delete_by_query_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/search/index/create.py
+++ b/src/globus_cli/commands/search/index/create.py
@@ -8,7 +8,7 @@ from .._common import INDEX_FIELDS
 
 
 @command("create")
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 @click.argument("DISPLAY_NAME")
 @click.argument("DESCRIPTION")
 def create_command(*, login_manager: LoginManager, display_name: str, description: str):

--- a/src/globus_cli/commands/search/index/delete.py
+++ b/src/globus_cli/commands/search/index/delete.py
@@ -6,7 +6,7 @@ from globus_cli.termio import display
 
 
 @command("delete")
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 @click.argument("INDEX_ID")
 def delete_command(*, login_manager: LoginManager, index_id: str):
     """(BETA) Delete a Search Index"""

--- a/src/globus_cli/commands/search/index/list.py
+++ b/src/globus_cli/commands/search/index/list.py
@@ -10,7 +10,7 @@ INDEX_LIST_FIELDS = INDEX_FIELDS + [
 
 
 @command("list")
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 def list_command(*, login_manager: LoginManager):
     """List indices where you have some permissions"""
     search_client = login_manager.get_search_client()

--- a/src/globus_cli/commands/search/index/role/create.py
+++ b/src/globus_cli/commands/search/index/role/create.py
@@ -26,7 +26,7 @@ from ..._common import index_id_arg, resolved_principals_field
         "principal as a URN."
     ),
 )
-@LoginManager.requires_login(LoginManager.SEARCH_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("search", "auth")
 def create_command(
     *,
     index_id: uuid.UUID,

--- a/src/globus_cli/commands/search/index/role/create.py
+++ b/src/globus_cli/commands/search/index/role/create.py
@@ -26,7 +26,7 @@ from ..._common import index_id_arg, resolved_principals_field
         "principal as a URN."
     ),
 )
-@LoginManager.requires_login("search", "auth")
+@LoginManager.requires_login("auth", "search")
 def create_command(
     *,
     index_id: uuid.UUID,

--- a/src/globus_cli/commands/search/index/role/delete.py
+++ b/src/globus_cli/commands/search/index/role/delete.py
@@ -12,7 +12,7 @@ from ..._common import index_id_arg
 @command("delete")
 @index_id_arg
 @click.argument("ROLE_ID")
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 def delete_command(
     *,
     index_id: uuid.UUID,

--- a/src/globus_cli/commands/search/index/role/list.py
+++ b/src/globus_cli/commands/search/index/role/list.py
@@ -9,7 +9,7 @@ from ..._common import index_id_arg, resolved_principals_field
 
 @command("list")
 @index_id_arg
-@LoginManager.requires_login("search", "auth")
+@LoginManager.requires_login("auth", "search")
 def list_command(*, login_manager: LoginManager, index_id: uuid.UUID):
     """List roles on an index (requires admin)"""
     search_client = login_manager.get_search_client()

--- a/src/globus_cli/commands/search/index/role/list.py
+++ b/src/globus_cli/commands/search/index/role/list.py
@@ -9,7 +9,7 @@ from ..._common import index_id_arg, resolved_principals_field
 
 @command("list")
 @index_id_arg
-@LoginManager.requires_login(LoginManager.SEARCH_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("search", "auth")
 def list_command(*, login_manager: LoginManager, index_id: uuid.UUID):
     """List roles on an index (requires admin)"""
     search_client = login_manager.get_search_client()

--- a/src/globus_cli/commands/search/index/show.py
+++ b/src/globus_cli/commands/search/index/show.py
@@ -9,7 +9,7 @@ from .._common import INDEX_FIELDS, index_id_arg
 
 @command("show")
 @index_id_arg
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 def show_command(*, login_manager: LoginManager, index_id: uuid.UUID):
     """Display information about an index"""
     search_client = login_manager.get_search_client()

--- a/src/globus_cli/commands/search/ingest.py
+++ b/src/globus_cli/commands/search/ingest.py
@@ -14,7 +14,7 @@ from ._common import index_id_arg
 @command("ingest", short_help="Ingest a document into Globus Search")
 @index_id_arg
 @click.argument("DOCUMENT", type=click.File("r"))
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 def ingest_command(
     *, login_manager: LoginManager, index_id: uuid.UUID, document: TextIOWrapper
 ):

--- a/src/globus_cli/commands/search/query.py
+++ b/src/globus_cli/commands/search/query.py
@@ -53,7 +53,7 @@ def _print_subjects(data):
 )
 @index_id_arg
 @mutex_option_group("-q", "--query-document")
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 def query_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/search/subject/delete.py
+++ b/src/globus_cli/commands/search/subject/delete.py
@@ -12,7 +12,7 @@ from .._common import index_id_arg
 @command("delete")
 @index_id_arg
 @click.argument("subject")
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 def delete_command(
     *,
     index_id: uuid.UUID,

--- a/src/globus_cli/commands/search/subject/show.py
+++ b/src/globus_cli/commands/search/subject/show.py
@@ -22,7 +22,7 @@ def _print_subject(subject_doc: "globus_sdk.GlobusHTTPResponse"):
 @command("show")
 @index_id_arg
 @click.argument("subject")
-@LoginManager.requires_login(LoginManager.SEARCH_RS, LoginManager.AUTH_RS)
+@LoginManager.requires_login("search", "auth")
 def show_command(
     *, login_manager: LoginManager, index_id: uuid.UUID, subject: str
 ) -> None:

--- a/src/globus_cli/commands/search/subject/show.py
+++ b/src/globus_cli/commands/search/subject/show.py
@@ -22,7 +22,7 @@ def _print_subject(subject_doc: "globus_sdk.GlobusHTTPResponse"):
 @command("show")
 @index_id_arg
 @click.argument("subject")
-@LoginManager.requires_login("search", "auth")
+@LoginManager.requires_login("auth", "search")
 def show_command(
     *, login_manager: LoginManager, index_id: uuid.UUID, subject: str
 ) -> None:

--- a/src/globus_cli/commands/search/task/list.py
+++ b/src/globus_cli/commands/search/task/list.py
@@ -16,7 +16,7 @@ TASK_FIELDS = [
 
 @command("list", short_help="List recent Tasks for an index")
 @index_id_arg
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 def list_command(*, login_manager: LoginManager, index_id: uuid.UUID):
     """List the 1000 most recent Tasks for an index"""
     search_client = login_manager.get_search_client()

--- a/src/globus_cli/commands/search/task/show.py
+++ b/src/globus_cli/commands/search/task/show.py
@@ -21,7 +21,7 @@ TASK_FIELDS = [
 
 @command("show")
 @task_id_arg
-@LoginManager.requires_login(LoginManager.SEARCH_RS)
+@LoginManager.requires_login("search")
 def show_command(*, login_manager: LoginManager, task_id: uuid.UUID):
     """Display a Task"""
     search_client = login_manager.get_search_client()

--- a/src/globus_cli/commands/session/show.py
+++ b/src/globus_cli/commands/session/show.py
@@ -43,7 +43,7 @@ $ globus session show --format json
 ----
 """,
 )
-@LoginManager.requires_login(LoginManager.AUTH_RS)
+@LoginManager.requires_login("auth")
 def session_show(*, login_manager):
     """List all identities in your current CLI auth session.
 
@@ -60,7 +60,7 @@ def session_show(*, login_manager):
     except AttributeError:  # if we have no RefreshTokenAuthorizor
         pass
 
-    tokendata = adapter.get_token_data(LoginManager.AUTH_RS)
+    tokendata = adapter.get_token_data("auth.globus.org")
     # if there's no token (e.g. not logged in), stub with empty data
     if not tokendata:
         session_info = {}

--- a/src/globus_cli/commands/session/update.py
+++ b/src/globus_cli/commands/session/update.py
@@ -96,7 +96,7 @@ def _update_session_params_identities_case(
     is_flag=True,
     help="Add every identity in your identity set to your session",
 )
-@LoginManager.requires_login(LoginManager.AUTH_RS)
+@LoginManager.requires_login("auth")
 def session_update(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/task/cancel.py
+++ b/src/globus_cli/commands/task/cancel.py
@@ -51,7 +51,7 @@ $ globus task cancel --all
 @click.option(
     "--all", "-a", is_flag=True, help="Cancel all in-progress tasks that you own"
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def cancel_task(*, login_manager: LoginManager, all: bool, task_id: uuid.UUID) -> None:
     """
     Cancel a task you own or all tasks which you own.

--- a/src/globus_cli/commands/task/event_list.py
+++ b/src/globus_cli/commands/task/event_list.py
@@ -70,7 +70,7 @@ $ globus task pause-info TASK_ID --format JSON
 )
 @click.option("--filter-errors", is_flag=True, help="Filter results to errors")
 @click.option("--filter-non-errors", is_flag=True, help="Filter results to non errors")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def task_event_list(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/task/generate_submission_id.py
+++ b/src/globus_cli/commands/task/generate_submission_id.py
@@ -18,7 +18,7 @@ $ globus transfer --submission-id "$sub_id" ...
 ----
 """,
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def generate_submission_id(*, login_manager: LoginManager) -> None:
     """
     Generate a new task submission ID for use in  `globus transfer` and `globus delete`.

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -167,7 +167,7 @@ globus task list --format=unix --jmespath='DATA[*].[task_id, status]' | \
     cls=AnnotatedOption,
     type_annotation=str,
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def task_list(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/task/pause_info.py
+++ b/src/globus_cli/commands/task/pause_info.py
@@ -87,7 +87,7 @@ $ globus task pause-info TASK_ID --format JSON
 """,
 )
 @task_id_arg()
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def task_pause_info(*, login_manager: LoginManager, task_id: uuid.UUID) -> None:
     """
     Show messages from activity managers who have explicitly paused the given

--- a/src/globus_cli/commands/task/show.py
+++ b/src/globus_cli/commands/task/show.py
@@ -169,7 +169,7 @@ $ globus task show TASK_ID
     ),
 )
 @mutex_option_group("--successful-transfers", "--skipped-errors")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def show_task(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/task/update.py
+++ b/src/globus_cli/commands/task/update.py
@@ -30,7 +30,7 @@ $ globus task update TASK_ID --label 'my task updated by me' \
 @task_id_arg()
 @click.option("--label", help="New Label for the task")
 @click.option("--deadline", help="New Deadline for the task")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def update_task(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/task/wait.py
+++ b/src/globus_cli/commands/task/wait.py
@@ -38,7 +38,7 @@ $ globus task wait --polling-interval 300 TASK_ID
 )
 @task_id_arg()
 @synchronous_task_wait_options
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def task_wait(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -96,7 +96,7 @@ def resolve_start_time(start: datetime.datetime | None) -> datetime.datetime:
     type=click.IntRange(min=1),
     help="Stop running the transfer after this number of runs have happened",
 )
-@LoginManager.requires_login(LoginManager.TIMER_RS, LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("timer", "transfer")
 def transfer_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/timer/delete.py
+++ b/src/globus_cli/commands/timer/delete.py
@@ -11,7 +11,7 @@ from ._common import DELETED_JOB_FORMAT_FIELDS
 
 @command("delete", short_help="Delete a timer job", hidden=True)
 @click.argument("JOB_ID", type=click.UUID)
-@LoginManager.requires_login(LoginManager.TIMER_RS)
+@LoginManager.requires_login("timer")
 def delete_command(*, login_manager: LoginManager, job_id: uuid.UUID) -> None:
     """
     Delete a Timer job.

--- a/src/globus_cli/commands/timer/list.py
+++ b/src/globus_cli/commands/timer/list.py
@@ -6,7 +6,7 @@ from ._common import JOB_FORMAT_FIELDS
 
 
 @command("list", short_help="List your jobs")
-@LoginManager.requires_login(LoginManager.TIMER_RS)
+@LoginManager.requires_login("timer")
 def list_command(*, login_manager: LoginManager) -> None:
     """
     List your Timer jobs.

--- a/src/globus_cli/commands/timer/show.py
+++ b/src/globus_cli/commands/timer/show.py
@@ -11,7 +11,7 @@ from ._common import JOB_FORMAT_FIELDS
 
 @command("show", short_help="Display a Timer job")
 @click.argument("JOB_ID", type=click.UUID)
-@LoginManager.requires_login(LoginManager.TIMER_RS)
+@LoginManager.requires_login("timer")
 def show_command(*, login_manager: LoginManager, job_id: uuid.UUID) -> None:
     """
     Display information about a particular job.

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -176,7 +176,7 @@ fi
 @click.option("--perf-pp", type=int, hidden=True)
 @click.option("--perf-udt", is_flag=True, default=None, hidden=True)
 @mutex_option_group("--recursive", "--external-checksum")
-@LoginManager.requires_login(LoginManager.TRANSFER_RS)
+@LoginManager.requires_login("transfer")
 def transfer_command(
     *,
     login_manager: LoginManager,

--- a/src/globus_cli/commands/whoami.py
+++ b/src/globus_cli/commands/whoami.py
@@ -48,7 +48,7 @@ $ globus whoami --linked-identities
     is_flag=True,
     help="Also show identities linked to the currently logged-in primary identity.",
 )
-@LoginManager.requires_login(LoginManager.AUTH_RS)
+@LoginManager.requires_login("auth")
 def whoami_command(*, login_manager: LoginManager, linked_identities: bool) -> None:
     """
     Display information for the currently logged-in user.

--- a/src/globus_cli/globus_cli_flake8.py
+++ b/src/globus_cli/globus_cli_flake8.py
@@ -7,6 +7,7 @@ import ast
 
 CODEMAP = {
     "CLI001": "CLI001 import from globus_sdk module, defeats lazy importer",
+    "CLI002": "CLI002 names in `requires_login` were out of sorted order",
 }
 
 
@@ -22,7 +23,7 @@ class Plugin:
     # Plugin.run() is how checks will run. For detail, see implementation of:
     # https://flake8.pycqa.org/en/latest/internal/checker.html#flake8.checker.FileChecker.run_ast_checks
     def run(self):
-        visitor = ImportVisitor()
+        visitor = CLIVisitor()
         visitor.visit(self.tree)
         for lineno, col, code in visitor.collect:
             yield lineno, col, CODEMAP[code], type(self)
@@ -37,7 +38,67 @@ class ErrorRecordingVisitor(ast.NodeVisitor):
         self.collect.append((node.lineno, node.col_offset, code))
 
 
-class ImportVisitor(ErrorRecordingVisitor):
+class CLIVisitor(ErrorRecordingVisitor):
     def visit_ImportFrom(self, node):  # a `from globus_sdk import ...` clause
         if node.module == "globus_sdk":
             self._record(node, "CLI001")
+
+    # you can check how a FunctionDef with decorators is shaped by running something
+    # like...
+    #
+    # print(
+    #     ast.dump(
+    #         ast.parse('''@frob.foo("bar", "baz")\ndef muddle(): return 1'''),
+    #         indent=4
+    #     )
+    # )
+    #
+    # outputs:
+    #
+    # Module(
+    #     body=[
+    #         FunctionDef(
+    #             name='muddle',
+    #             args=arguments(
+    #                 posonlyargs=[],
+    #                 args=[],
+    #                 kwonlyargs=[],
+    #                 kw_defaults=[],
+    #                 defaults=[]),
+    #             body=[
+    #                 Return(
+    #                     value=Constant(value=1))],
+    #             decorator_list=[
+    #                 Call(
+    #                     func=Attribute(
+    #                         value=Name(id='frob', ctx=Load()),
+    #                         attr='foo',
+    #                         ctx=Load()),
+    #                     args=[
+    #                         Constant(value='bar'),
+    #                         Constant(value='baz')],
+    #                     keywords=[])])],
+    #     type_ignores=[])
+    def visit_FunctionDef(self, node):  # a function definition
+        if not node.decorator_list:
+            return
+
+        for decorator_call in node.decorator_list:
+            if not isinstance(decorator_call, ast.Call):
+                continue  # e.g. a Name node, for a decorator w/ no args
+            if not isinstance(decorator_call.func, ast.Attribute):
+                # a decorator which is not accessed as an attr
+                # unlike `LoginManager.requires_login`
+                continue
+            if decorator_call.func.attr != "requires_login":
+                continue  # wrong name
+            self._check_requires_login_decorator(decorator_call)
+
+    # a function call already identified as a decorator named "X.requires_login"
+    def _check_requires_login_decorator(self, node):
+        args = node.args
+        if not all(isinstance(arg, ast.Constant) for arg in node.args):
+            return
+        arg_values = [x.value for x in args]
+        if sorted(arg_values) != arg_values:
+            self._record(node, "CLI002")

--- a/src/globus_cli/login_manager/__init__.py
+++ b/src/globus_cli/login_manager/__init__.py
@@ -1,6 +1,7 @@
 from .client_login import get_client_login, is_client_login
 from .errors import MissingLoginError
 from .manager import LoginManager
+from .scopes import compute_timer_scope
 from .tokenstore import (
     delete_templated_client,
     internal_auth_client,
@@ -25,4 +26,5 @@ __all__ = [
     "store_well_known_config",
     "read_well_known_config",
     "remove_well_known_config",
+    "compute_timer_scope",
 ]

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -4,6 +4,7 @@ import typing as t
 
 import click
 import globus_sdk
+from globus_sdk.scopes import MutableScope
 
 from .tokenstore import (
     internal_auth_client,
@@ -14,7 +15,9 @@ from .tokenstore import (
 
 
 def do_link_auth_flow(
-    scopes: str | t.Sequence[str], *, session_params: dict[str, t.Any] | None = None
+    scopes: str | t.Sequence[str | MutableScope],
+    *,
+    session_params: dict[str, t.Any] | None = None,
 ) -> bool:
     """
     Prompts the user with a link to authenticate with globus auth
@@ -53,7 +56,9 @@ def do_link_auth_flow(
 
 
 def do_local_server_auth_flow(
-    scopes: str | t.Sequence[str], *, session_params: dict[str, t.Any] | None = None
+    scopes: str | t.Sequence[str | MutableScope],
+    *,
+    session_params: dict[str, t.Any] | None = None,
 ) -> bool:
     """
     Starts a local http server, opens a browser to have the user authenticate,
@@ -73,7 +78,9 @@ def do_local_server_auth_flow(
         # get the ConfidentialApp client object and start a flow
         auth_client = internal_auth_client()
         auth_client.oauth2_start_flow(
-            refresh_tokens=True, redirect_uri=redirect_uri, requested_scopes=scopes
+            refresh_tokens=True,
+            redirect_uri=redirect_uri,
+            requested_scopes=scopes,
         )
         query_params = {"prompt": "login"}
         query_params.update(session_params)

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -177,20 +177,15 @@ class LoginManager:
             )
 
     @classmethod
-    def requires_login(cls, *resource_servers: ServiceNameLiteral):
+    def requires_login(cls, *services: ServiceNameLiteral):
         """
         Command decorator for specifying a resource server that the user must have
         tokens for in order to run the command.
 
         Simple usage for commands that have static resource needs: simply list all
-        needed resource servers as args. Known services can be referred to by
-        "short names":
-
-        @LoginManager.requires_login("auth.globus.org")
+        needed services as args. Services should be referred to by "short names":
 
         @LoginManager.requires_login("auth")
-
-        @LoginManager.requires_login("auth.globus.org", "transfer.api.globus.org")
 
         @LoginManager.requires_login("auth", "transfer")
 
@@ -201,20 +196,19 @@ class LoginManager:
         def command(login_manager, endpoint_id)
 
             login_manager.<do the thing>(endpoint_id)
-
         """
-        resolved_resource_server_names = [
+        resource_servers = [
             rs_name
             if rs_name not in CLI_SCOPE_REQUIREMENTS
             else CLI_SCOPE_REQUIREMENTS[rs_name]["resource_server"]
-            for rs_name in resource_servers
+            for rs_name in services
         ]
 
         def inner(func):
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
                 manager = cls()
-                manager.assert_logins(*resolved_resource_server_names)
+                manager.assert_logins(*resource_servers)
                 return func(*args, login_manager=manager, **kwargs)
 
             return wrapper

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -18,6 +18,7 @@ from globus_sdk.scopes import (
 )
 
 from globus_cli.endpointish import Endpointish, EntityType
+from globus_cli.types import ServiceNameLiteral
 
 from .. import version
 from .auth_flows import do_link_auth_flow, do_local_server_auth_flow
@@ -176,7 +177,7 @@ class LoginManager:
             )
 
     @classmethod
-    def requires_login(cls, *resource_servers: str):
+    def requires_login(cls, *resource_servers: ServiceNameLiteral):
         """
         Command decorator for specifying a resource server that the user must have
         tokens for in order to run the command.
@@ -203,11 +204,9 @@ class LoginManager:
 
         """
         resolved_resource_server_names = [
-            rs_name if rs_name not in CLI_SCOPE_REQUIREMENTS
-            # ignore the type error (Literal vs str)
-            else CLI_SCOPE_REQUIREMENTS[rs_name][  # type: ignore[index]
-                "resource_server"
-            ]
+            rs_name
+            if rs_name not in CLI_SCOPE_REQUIREMENTS
+            else CLI_SCOPE_REQUIREMENTS[rs_name]["resource_server"]
             for rs_name in resource_servers
         ]
 

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
+import sys
 import typing as t
 
 from globus_sdk.scopes import (
+    AuthScopes,
+    FlowsScopes,
     GCSCollectionScopeBuilder,
+    GroupsScopes,
     MutableScope,
+    SearchScopes,
     TimerScopes,
     TransferScopes,
 )
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal, TypedDict
+else:
+    from typing import Literal, TypedDict
 
 TRANSFER_AP_SCOPE_STR: str = (
     "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer"
@@ -34,3 +44,100 @@ def compute_timer_scope(
 # with no args, this builds
 #   timer[transferAP[transfer]]
 TIMER_SCOPE_WITH_DEPENDENCIES = compute_timer_scope()
+
+
+class _ServiceRequirement(TypedDict):
+    min_contract_version: int
+    resource_server: str
+    scopes: list[str | MutableScope]
+
+
+class _CLIScopeRequirements:
+    def __init__(self) -> None:
+        self.requirement_map: dict[str, _ServiceRequirement] = {
+            "auth": {
+                "min_contract_version": 0,
+                "resource_server": AuthScopes.resource_server,
+                "scopes": [
+                    AuthScopes.openid,
+                    AuthScopes.profile,
+                    AuthScopes.email,
+                    AuthScopes.view_identity_set,
+                ],
+            },
+            "transfer": {
+                "min_contract_version": 0,
+                "resource_server": TransferScopes.resource_server,
+                "scopes": [
+                    TransferScopes.all,
+                ],
+            },
+            "groups": {
+                "min_contract_version": 0,
+                "resource_server": GroupsScopes.resource_server,
+                "scopes": [
+                    GroupsScopes.all,
+                ],
+            },
+            "search": {
+                "min_contract_version": 0,
+                "resource_server": SearchScopes.resource_server,
+                "scopes": [
+                    SearchScopes.all,
+                ],
+            },
+            "timer": {
+                "min_contract_version": 1,
+                "resource_server": TimerScopes.resource_server,
+                "scopes": [
+                    TIMER_SCOPE_WITH_DEPENDENCIES,
+                ],
+            },
+            "flows": {
+                "min_contract_version": 0,
+                "resource_server": FlowsScopes.resource_server,
+                "scopes": [
+                    FlowsScopes.manage_flows,
+                    FlowsScopes.view_flows,
+                    FlowsScopes.run,
+                    FlowsScopes.run_status,
+                    FlowsScopes.run_manage,
+                ],
+            },
+        }
+
+    def __getitem__(
+        self, key: Literal["auth", "transfer", "groups", "search", "timer", "flows"]
+    ) -> _ServiceRequirement:
+        return self.requirement_map[key]
+
+    def get_by_resource_server(self, rs_name: str) -> _ServiceRequirement:
+        for req in self.requirement_map.values():
+            if req["resource_server"] == rs_name:
+                return req
+
+        raise LookupError(f"{rs_name} was not a listed service requirement for the CLI")
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.requirement_map
+
+    def resource_servers(self) -> frozenset[str]:
+        return frozenset(req["resource_server"] for req in self.values())
+
+    def keys(self) -> t.Iterable[str]:
+        yield from self.requirement_map.keys()
+
+    def values(self) -> t.Iterable[_ServiceRequirement]:
+        yield from self.requirement_map.values()
+
+
+CLI_SCOPE_REQUIREMENTS = _CLIScopeRequirements()
+
+# the contract version number for the LoginManager's scope behavior
+# this will be annotated on every token acquired and stored, in order to see what
+# version we were at when we got a token
+# it is defined as the max of the version numbers required by the various different
+# services
+CURRENT_SCOPE_CONTRACT_VERSION: int = max(
+    req["min_contract_version"] for req in CLI_SCOPE_REQUIREMENTS.values()
+)

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -14,10 +14,12 @@ from globus_sdk.scopes import (
     TransferScopes,
 )
 
+from globus_cli.types import ServiceNameLiteral
+
 if sys.version_info < (3, 8):
-    from typing_extensions import Literal, TypedDict
+    from typing_extensions import TypedDict
 else:
-    from typing import Literal, TypedDict
+    from typing import TypedDict
 
 TRANSFER_AP_SCOPE_STR: str = (
     "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer"
@@ -54,7 +56,7 @@ class _ServiceRequirement(TypedDict):
 
 class _CLIScopeRequirements:
     def __init__(self) -> None:
-        self.requirement_map: dict[str, _ServiceRequirement] = {
+        self.requirement_map: dict[ServiceNameLiteral, _ServiceRequirement] = {
             "auth": {
                 "min_contract_version": 0,
                 "resource_server": AuthScopes.resource_server,
@@ -106,9 +108,7 @@ class _CLIScopeRequirements:
             },
         }
 
-    def __getitem__(
-        self, key: Literal["auth", "transfer", "groups", "search", "timer", "flows"]
-    ) -> _ServiceRequirement:
+    def __getitem__(self, key: ServiceNameLiteral) -> _ServiceRequirement:
         return self.requirement_map[key]
 
     def get_by_resource_server(self, rs_name: str) -> _ServiceRequirement:
@@ -124,7 +124,7 @@ class _CLIScopeRequirements:
     def resource_servers(self) -> frozenset[str]:
         return frozenset(req["resource_server"] for req in self.values())
 
-    def keys(self) -> t.Iterable[str]:
+    def keys(self) -> t.Iterable[ServiceNameLiteral]:
         yield from self.requirement_map.keys()
 
     def values(self) -> t.Iterable[_ServiceRequirement]:

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import typing as t
+
+from globus_sdk.scopes import (
+    GCSCollectionScopeBuilder,
+    MutableScope,
+    TimerScopes,
+    TransferScopes,
+)
+
+TRANSFER_AP_SCOPE_STR: str = (
+    "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer"
+)
+
+
+def compute_timer_scope(
+    *, data_access_collection_ids: t.Sequence[str] | None = None
+) -> MutableScope:
+    transfer_scope = TransferScopes.make_mutable("all")
+    for cid in data_access_collection_ids or ():
+        transfer_scope.add_dependency(
+            GCSCollectionScopeBuilder(cid).make_mutable("data_access", optional=True)
+        )
+
+    transfer_ap_scope = MutableScope(TRANSFER_AP_SCOPE_STR)
+    transfer_ap_scope.add_dependency(transfer_scope)
+
+    timer_scope = TimerScopes.make_mutable("timer")
+    timer_scope.add_dependency(transfer_ap_scope)
+    return timer_scope
+
+
+# with no args, this builds
+#   timer[transferAP[transfer]]
+TIMER_SCOPE_WITH_DEPENDENCIES = compute_timer_scope()

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -17,9 +17,9 @@ from globus_sdk.scopes import (
 from globus_cli.types import ServiceNameLiteral
 
 if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
+    from typing_extensions import Final, TypedDict
 else:
-    from typing import TypedDict
+    from typing import Final, TypedDict
 
 TRANSFER_AP_SCOPE_STR: str = (
     "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer"
@@ -136,8 +136,6 @@ CLI_SCOPE_REQUIREMENTS = _CLIScopeRequirements()
 # the contract version number for the LoginManager's scope behavior
 # this will be annotated on every token acquired and stored, in order to see what
 # version we were at when we got a token
-# it is defined as the max of the version numbers required by the various different
+# it should be the max of the version numbers required by the various different
 # services
-CURRENT_SCOPE_CONTRACT_VERSION: int = max(
-    req["min_contract_version"] for req in CLI_SCOPE_REQUIREMENTS.values()
-)
+CURRENT_SCOPE_CONTRACT_VERSION: Final[int] = 1

--- a/src/globus_cli/login_manager/tokenstore.py
+++ b/src/globus_cli/login_manager/tokenstore.py
@@ -7,6 +7,7 @@ import typing as t
 import globus_sdk
 
 from .client_login import get_client_login, is_client_login
+from .utils import CURRENT_SCOPE_CONTRACT_VERSION
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -109,9 +110,43 @@ def _resolve_namespace() -> str:
         return "userprofile/" + env + (f"/{profile}" if profile else "")
 
 
-def token_storage_adapter() -> SQLiteAdapter:
+def build_storage_adapter(fname: str) -> SQLiteAdapter:
+    """
+    Customize the SQLiteAdapter with extra storage operation steps
+    In order to avoid eager imports, which have a perf impact on the CLI, we need to
+    define the class dynamically in this function.
+    """
     from globus_sdk.tokenstorage import SQLiteAdapter
 
+    class GeneratedAdapterClass(SQLiteAdapter):
+        def store(self, token_response: globus_sdk.OAuthTokenResponse) -> None:
+            super().store(token_response)
+            # store contract versions for all of the tokens which were acquired
+            # this could overwrite data from another CLI version *earlier or later* than
+            # the current one
+            #
+            # in the case that the old data was from a prior version, this makes sense
+            # because we have added new constraints or behaviors
+            #
+            # if the data was from a *newer* CLI version than what we are currently
+            # running we can't really know with certainty that "downgrading" the version
+            # numbers is correct, but because we can't know we need to just do our best
+            # to indicate that the tokens in storage may have lost capabilities
+            contract_versions: dict[str, t.Any] | None = read_well_known_config(
+                "scope_contract_versions", adapter=self
+            )
+            if contract_versions is None:
+                contract_versions = {}
+            for rs_name in token_response.by_resource_server:
+                contract_versions[rs_name] = CURRENT_SCOPE_CONTRACT_VERSION
+            store_well_known_config(
+                "scope_contract_versions", contract_versions, adapter=self
+            )
+
+    return GeneratedAdapterClass(fname, namespace=_resolve_namespace())
+
+
+def token_storage_adapter() -> SQLiteAdapter:
     as_proto = t.cast(_TokenStoreFuncProto, token_storage_adapter)
     if not hasattr(as_proto, "_instance"):
         # when initializing the token storage adapter, check if the storage file exists
@@ -122,7 +157,7 @@ def token_storage_adapter() -> SQLiteAdapter:
 
             invalidate_old_config(internal_native_client())
         # namespace is equal to the current environment
-        as_proto._instance = SQLiteAdapter(fname, namespace=_resolve_namespace())
+        as_proto._instance = build_storage_adapter(fname)
     return as_proto._instance
 
 
@@ -169,6 +204,7 @@ def delete_templated_client() -> None:
 
     # now, remove its relevant data from storage
     remove_well_known_config("auth_client_data")
+    remove_well_known_config("scope_contract_versions")
 
     # finally, try to delete via the API
     # note that this could raise an exception if the creds are already invalid -- the
@@ -177,7 +213,7 @@ def delete_templated_client() -> None:
 
 
 def store_well_known_config(
-    name: Literal["auth_client_data", "auth_user_data"],
+    name: Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
     data: dict[str, t.Any],
     *,
     adapter: SQLiteAdapter | None = None,
@@ -187,7 +223,7 @@ def store_well_known_config(
 
 
 def read_well_known_config(
-    name: Literal["auth_client_data", "auth_user_data"],
+    name: Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
     *,
     adapter: SQLiteAdapter | None = None,
 ) -> dict[str, t.Any] | None:
@@ -196,7 +232,7 @@ def read_well_known_config(
 
 
 def remove_well_known_config(
-    name: Literal["auth_client_data", "auth_user_data"],
+    name: Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
     *,
     adapter: SQLiteAdapter | None = None,
 ) -> None:

--- a/src/globus_cli/login_manager/tokenstore.py
+++ b/src/globus_cli/login_manager/tokenstore.py
@@ -7,7 +7,7 @@ import typing as t
 import globus_sdk
 
 from .client_login import get_client_login, is_client_login
-from .utils import CURRENT_SCOPE_CONTRACT_VERSION
+from .scopes import CURRENT_SCOPE_CONTRACT_VERSION
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal

--- a/src/globus_cli/login_manager/utils.py
+++ b/src/globus_cli/login_manager/utils.py
@@ -1,5 +1,11 @@
 import os
 
+# the contract version number for the LoginManager's scope behavior
+# this will be annotated on every token acquired and stored, in order to see what
+# version we were at when we got a token
+# make sure it is available to the LoginManager and the tokenstorage module
+CURRENT_SCOPE_CONTRACT_VERSION: int = 1
+
 
 def is_remote_session():
     return os.environ.get("SSH_TTY", os.environ.get("SSH_CONNECTION"))

--- a/src/globus_cli/login_manager/utils.py
+++ b/src/globus_cli/login_manager/utils.py
@@ -1,11 +1,5 @@
 import os
 
-# the contract version number for the LoginManager's scope behavior
-# this will be annotated on every token acquired and stored, in order to see what
-# version we were at when we got a token
-# make sure it is available to the LoginManager and the tokenstorage module
-CURRENT_SCOPE_CONTRACT_VERSION: int = 1
-
 
 def is_remote_session():
     return os.environ.get("SSH_TTY", os.environ.get("SSH_CONNECTION"))

--- a/src/globus_cli/types.py
+++ b/src/globus_cli/types.py
@@ -23,6 +23,11 @@ else:
     ListType = list
     TupleType = tuple
 
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
+
 # all imports from globus_cli modules done here are done under TYPE_CHECKING
 # in order to ensure that the use of type annotations never introduces circular
 # imports at runtime
@@ -45,4 +50,9 @@ DATA_CONTAINER_T = t.Union[
 
 JsonValue: TypeAlias = t.Union[
     int, float, str, bool, None, t.List["JsonValue"], t.Dict[str, "JsonValue"]
+]
+
+
+ServiceNameLiteral: TypeAlias = Literal[
+    "auth", "transfer", "groups", "search", "timer", "flows"
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,11 +15,11 @@ import responses
 from click.testing import CliRunner
 from globus_sdk._testing import register_response_set
 from globus_sdk.scopes import TimerScopes
-from globus_sdk.tokenstorage import SQLiteAdapter
 from globus_sdk.transport import RequestsTransport
 from ruamel.yaml import YAML
 
 import globus_cli
+from globus_cli.login_manager.tokenstore import build_storage_adapter
 
 yaml = YAML()
 log = logging.getLogger(__name__)
@@ -129,7 +129,7 @@ def user_profile(monkeypatch):
 @pytest.fixture
 def test_token_storage(mock_login_token_response):
     """Put memory-backed sqlite token storage in place for the testsuite to use."""
-    mockstore = SQLiteAdapter(":memory:")
+    mockstore = build_storage_adapter(":memory:")
     mockstore.store_config(
         "auth_client_data",
         {"client_id": "fakeClientIDString", "client_secret": "fakeClientSecret"},

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -1,4 +1,6 @@
 import re
+import sys
+import typing as t
 import uuid
 from unittest import mock
 
@@ -12,6 +14,7 @@ from globus_cli.login_manager import (
     compute_timer_scope,
 )
 from globus_cli.login_manager.scopes import CLI_SCOPE_REQUIREMENTS
+from globus_cli.types import ServiceNameLiteral
 
 
 @pytest.fixture
@@ -302,3 +305,15 @@ def test_compute_timer_scope_multiple_data_access():
     start_part = f"{BASE_TIMER_SCOPE}[{TRANSFER_AP_SCOPE}[{transfer_scope}["
     end_part = "]]]"
     assert computed == f"{start_part}*{foo_scope} *{bar_scope} *{baz_scope}{end_part}"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="test requires py3.8+")
+def test_cli_scope_requirements_exactly_match_service_name_literal(
+    patch_scope_requirements,
+):
+    # undo the scope requirements patch
+    patch_scope_requirements.undo()
+    scope_requirements_keys = CLI_SCOPE_REQUIREMENTS.keys()
+
+    service_name_literal_values = t.get_args(ServiceNameLiteral)
+    assert set(service_name_literal_values) == set(scope_requirements_keys)


### PR DESCRIPTION
_Extracted from #699_

There are two commits here so far:
1. Add dependencies to the Timer scope
2. Enforce the dependencies

This is, however, opened as a draft. (1) is primarily a data change but features a bit of testing. (2) is important enforcement logic and has no new tests yet.

I was able to test this out and see that it works manually, but I don't think this "contract version" idea is okay to leave untested.