### PR TITLE
Add more annotations to `endpoint role` commands

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -155,21 +155,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.permission.update]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.endpoint.role._common]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.endpoint.role.create]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.endpoint.role.delete]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.endpoint.role.list]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.endpoint.role.show]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.server._common]
 disallow_untyped_defs = false
 

--- a/src/globus_cli/commands/endpoint/role/_common.py
+++ b/src/globus_cli/commands/endpoint/role/_common.py
@@ -1,6 +1,10 @@
+import typing as t
+
 import click
 
 from globus_cli.termio import formatters
+
+C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
 
 
 class RolePrincipalFormatter(formatters.auth.PrincipalDictFormatter):
@@ -8,5 +12,5 @@ class RolePrincipalFormatter(formatters.auth.PrincipalDictFormatter):
         return f"https://app.globus.org/groups/{group_id}"
 
 
-def role_id_arg(f):
+def role_id_arg(f: C) -> C:
     return click.argument("role_id")(f)

--- a/src/globus_cli/commands/endpoint/role/create.py
+++ b/src/globus_cli/commands/endpoint/role/create.py
@@ -1,8 +1,18 @@
+from __future__ import annotations
+
+import sys
+import uuid
+
 import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg, security_principal_opts
 from globus_cli.termio import display
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
 
 
 @command(
@@ -34,7 +44,15 @@ $ globus endpoint role create 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
     help="A role to assign.",
 )
 @LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
-def role_create(*, login_manager: LoginManager, role, principal, endpoint_id):
+def role_create(
+    *,
+    login_manager: LoginManager,
+    role: Literal[
+        "administrator", "access_manager", "activity_manager", "activity_monitor"
+    ],
+    principal: tuple[str, str],
+    endpoint_id: uuid.UUID,
+) -> None:
     """
     Create a role on an endpoint.
     You must have sufficient privileges to modify the roles on the endpoint.

--- a/src/globus_cli/commands/endpoint/role/delete.py
+++ b/src/globus_cli/commands/endpoint/role/delete.py
@@ -1,3 +1,5 @@
+import uuid
+
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import TextMode, display
@@ -22,7 +24,9 @@ $ globus endpoint role delete 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
 @endpoint_id_arg
 @role_id_arg
 @LoginManager.requires_login(LoginManager.TRANSFER_RS)
-def role_delete(*, login_manager: LoginManager, role_id, endpoint_id):
+def role_delete(
+    *, login_manager: LoginManager, role_id: str, endpoint_id: uuid.UUID
+) -> None:
     """
     Remove a role from an endpoint.
 

--- a/src/globus_cli/commands/endpoint/role/list.py
+++ b/src/globus_cli/commands/endpoint/role/list.py
@@ -31,7 +31,7 @@ $ globus endpoint role list 'ddb59aef-6d04-11e5-ba46-22000b92c6ec'
 )
 @endpoint_id_arg
 @LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
-def role_list(*, login_manager: LoginManager, endpoint_id: uuid.UUID):
+def role_list(*, login_manager: LoginManager, endpoint_id: uuid.UUID) -> None:
     """
     List the assigned roles on an endpoint.
 

--- a/src/globus_cli/commands/endpoint/role/show.py
+++ b/src/globus_cli/commands/endpoint/role/show.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import Field, TextMode, display
@@ -31,7 +33,9 @@ $ globus endpoint role show EP_ID ROLE_ID
 @endpoint_id_arg
 @role_id_arg
 @LoginManager.requires_login(LoginManager.AUTH_RS, LoginManager.TRANSFER_RS)
-def role_show(*, login_manager: LoginManager, endpoint_id, role_id):
+def role_show(
+    *, login_manager: LoginManager, endpoint_id: uuid.UUID, role_id: str
+) -> None:
     """
     Show full info for a role on an endpoint.
 

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -19,6 +19,12 @@ from tests.click_types import check_has_correct_annotations_for_click_args
         ("collection.update", "collection_update"),
         ("endpoint.create", "endpoint_create"),
         ("endpoint.is_activated", "endpoint_is_activated"),
+        # TODO: role_create uses the security_principal_opts decorator, which transforms
+        # arguments. This needs to be refactored to be checkable using this method
+        # ("endpoint.role.create", "role_create"),
+        ("endpoint.role.delete", "role_delete"),
+        ("endpoint.role.list", "role_list"),
+        ("endpoint.role.show", "role_show"),
         ("endpoint.update", "endpoint_update"),
         ("gcp.create.guest", "guest_command"),
         ("gcp.create.mapped", "mapped_command"),


### PR DESCRIPTION
These are almost all "clean" changes, but `endpoint role create` has an unfortunate wrinkle, in that it can't be accurately checked with the click annotation checker test right now. (Comments explain a little.)
So that is left out, but everything else has been listed.