### PR TITLE
Fix support for py3.7 and 3.8 and tests of login_manager

### DIFF
--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -54,7 +54,7 @@ class _ServiceRequirement(TypedDict):
     scopes: list[str | MutableScope]
 
 
-class _CLIScopeRequirements(dict[ServiceNameLiteral, _ServiceRequirement]):
+class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
     def __init__(self) -> None:
         self["auth"] = {
             "min_contract_version": 0,

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -58,26 +58,33 @@ def patched_tokenstorage():
 @pytest.fixture
 def patch_scope_requirements():
     with pytest.MonkeyPatch().context() as mp:
-        mp.setattr(
+        prior_keys = list(CLI_SCOPE_REQUIREMENTS)
+        # clear prior contents
+        for k in prior_keys:
+            mp.delitem(CLI_SCOPE_REQUIREMENTS, k)
+
+        mp.setitem(
             CLI_SCOPE_REQUIREMENTS,
-            "requirement_map",
+            "a",
             {
-                "a": {
-                    "min_contract_version": 0,
-                    "resource_server": "a.globus.org",
-                    "scopes": [
-                        "scopeA1",
-                        "scopeA2",
-                    ],
-                },
-                "b": {
-                    "min_contract_version": 0,
-                    "resource_server": "b.globus.org",
-                    "scopes": [
-                        "scopeB1",
-                        "scopeB2",
-                    ],
-                },
+                "min_contract_version": 0,
+                "resource_server": "a.globus.org",
+                "scopes": [
+                    "scopeA1",
+                    "scopeA2",
+                ],
+            },
+        )
+        mp.setitem(
+            CLI_SCOPE_REQUIREMENTS,
+            "b",
+            {
+                "min_contract_version": 0,
+                "resource_server": "b.globus.org",
+                "scopes": [
+                    "scopeB1",
+                    "scopeB2",
+                ],
             },
         )
         yield mp
@@ -126,7 +133,7 @@ def test_requires_login_single_server_fail(
 
 
 def test_requiring_new_scope_fails(patch_scope_requirements, patched_tokenstorage):
-    CLI_SCOPE_REQUIREMENTS.requirement_map["a"]["scopes"].append("scopeA3")
+    CLI_SCOPE_REQUIREMENTS["a"]["scopes"].append("scopeA3")
 
     @LoginManager.requires_login("a")
     def dummy_command(login_manager):
@@ -141,7 +148,7 @@ def test_requiring_new_scope_fails(patch_scope_requirements, patched_tokenstorag
 
 
 def test_scope_contract_version_bump_forces_login(patch_scope_requirements):
-    CLI_SCOPE_REQUIREMENTS.requirement_map["a"]["min_contract_version"] = 2
+    CLI_SCOPE_REQUIREMENTS["a"]["min_contract_version"] = 2
 
     @LoginManager.requires_login("a")
     def dummy_command(login_manager):


### PR DESCRIPTION
Use the runtime-safe 't.Dict' rather than 'dict' for a base class for CLI_SCOPE_REQUIREMENTS.

Fix tests which weren't correctly rewritten when CLI_SCOPE_REQUIREMENTS changed. It no longer is an object with 'requirement_map' as an attribute.