### PR TITLE
Switch to 'packaging' for version parsing

### DIFF
--- a/changelog.d/20230306_175210_sirosen_use_packaging.md
+++ b/changelog.d/20230306_175210_sirosen_use_packaging.md
@@ -1,0 +1,4 @@
+### Other
+
+* `globus-cli` now uses `packaging` for version parsing. This improves
+  compatibility with python 3.12

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "globus-sdk==3.17.0",
         "click>=8.0.0,<9",
         "jmespath==1.0.1",
+        "packaging>=17.0",
         # these are dependencies of the SDK, but they are used directly in the CLI
         # declare them here in case the underlying lib ever changes
         "requests>=2.19.1,<3.0.0",

--- a/src/globus_cli/commands/version.py
+++ b/src/globus_cli/commands/version.py
@@ -12,7 +12,7 @@ from globus_cli.termio import is_verbose, verbosity
 from globus_cli.version import get_versions
 
 if t.TYPE_CHECKING:
-    from distutils.version import LooseVersion
+    from packaging.version import Version
 
 
 def _get_package_data() -> list[list[str]]:
@@ -57,13 +57,13 @@ def _get_package_data() -> list[list[str]]:
     return moddata
 
 
-def _get_versionblock_message(current: LooseVersion, latest: LooseVersion) -> str:
+def _get_versionblock_message(current: Version, latest: Version) -> str:
     return f"""\
 Installed version:  {current}
 Latest version:     {latest}"""
 
 
-def _get_post_message(current: LooseVersion, latest: LooseVersion) -> str:
+def _get_post_message(current: Version, latest: Version) -> str:
     if current == latest:
         return "You are running the latest version of the Globus CLI"
     if current > latest:

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 
 if t.TYPE_CHECKING:
-    from distutils.version import LooseVersion
+    from packaging.version import Version
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
@@ -14,7 +14,7 @@ app_name = f"Globus CLI v{__version__}"
 
 
 # pull down version data from PyPi
-def get_versions() -> tuple[LooseVersion | None, LooseVersion]:
+def get_versions() -> tuple[Version | None, Version]:
     """
     Wrap in a function to ensure that we don't run this every time a CLI
     command runs or when version number is loaded by setuptools.
@@ -22,17 +22,16 @@ def get_versions() -> tuple[LooseVersion | None, LooseVersion]:
     Returns a pair: (latest_version, current_version)
     """
     # import in the func (rather than top-level scope) so that at setup time,
-    # `requests` isn't required -- otherwise, setuptools will fail to run
-    # because it isn't installed yet.
-    from distutils.version import LooseVersion
-
+    # libraries aren't required -- otherwise, setuptools will fail to run
+    # because these packages aren't installed yet.
     import requests
+    from packaging.version import Version
 
     try:
         response = requests.get("https://pypi.python.org/pypi/globus-cli/json")
     # if the fetch from pypi fails
     except requests.RequestException:
-        return None, LooseVersion(__version__)
-    parsed_versions = [LooseVersion(v) for v in response.json()["releases"]]
+        return None, Version(__version__)
+    parsed_versions = [Version(v) for v in response.json()["releases"]]
     latest = max(parsed_versions)
-    return latest, LooseVersion(__version__)
+    return latest, Version(__version__)

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,8 +1,7 @@
-from distutils.version import LooseVersion
-
 import pytest
 import requests
 import responses
+from packaging.version import Version
 
 import globus_cli.version
 
@@ -14,7 +13,6 @@ import globus_cli.version
         ("1000.1000.1000", "1000.1000.1000"),
     ),
 )
-@pytest.mark.filterwarnings("ignore:distutils Version classes are deprecated")
 def test_get_versions_success(injected_version, expected):
     # Only a portion of the PyPI response is needed.
     pypi_json_response = {
@@ -27,12 +25,11 @@ def test_get_versions_success(injected_version, expected):
         "GET", "https://pypi.python.org/pypi/globus-cli/json", json=pypi_json_response
     )
     assert globus_cli.version.get_versions() == (
-        LooseVersion(expected),
-        LooseVersion(globus_cli.version.__version__),
+        Version(expected),
+        Version(globus_cli.version.__version__),
     )
 
 
-@pytest.mark.filterwarnings("ignore:distutils Version classes are deprecated")
 def test_get_versions_failure():
     responses.add(
         "GET",
@@ -41,5 +38,5 @@ def test_get_versions_failure():
     )
     assert globus_cli.version.get_versions() == (
         None,
-        LooseVersion(globus_cli.version.__version__),
+        Version(globus_cli.version.__version__),
     )

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     mindeps: requests==2.19.1
     mindeps: pyjwt==2.0.0
     mindeps: cryptography==3.3.1
+    mindeps: packaging==17.0
     sdkmain: https://github.com/globus/globus-sdk-python/archive/main.tar.gz
 # the 'localsdk' factor allows CLI tests to be run against a local repo copy of globus-sdk
 # it requires that the GLOBUS_SDK_PATH env var is set and uses subprocess and os to pass it as


### PR DESCRIPTION
This removes the dependency on distutils, which causes newer pythons to emit warnings and makes globus-cli incompatible with python 3.12 (which removes distutils).

---

I was able to install 3.12.0a5 this morning and run the testsuite against it after this change. Everything passed!