### PR TITLE
Add publishing workflows + version "smudger"

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -1,0 +1,23 @@
+name: Publish PyPI Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - run: python -m pip install build
+      - run: python -m build .
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -16,8 +16,8 @@ jobs:
 
       - run: python -m pip install build
 
-      - name: Smudge with dev version prior to upload
-        run: python ./scripts/version_smudge.py
+      - name: Set dev version prior to upload
+        run: python ./scripts/set_dev_version.py
 
       - run: python -m build .
 

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -1,0 +1,28 @@
+name: Publish Test PyPI Release
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - run: python -m pip install build
+
+      - name: Smudge with dev version prior to upload
+        run: python ./scripts/version_smudge.py
+
+      - run: python -m build .
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/scripts/version_smudge.py
+++ b/scripts/version_smudge.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import time
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+VERSION_PATH = REPO_ROOT / "src" / "globus_cli" / "version.py"
+PRETTYPATH = VERSION_PATH.relative_to(REPO_ROOT)
+
+
+class Abort(RuntimeError):
+    pass
+
+
+def bump_version_in_file(
+    smudge_value: str,
+) -> None:
+    print(f"smudging version in {PRETTYPATH} (smudge={smudge_value}) ... ", end="")
+    with open(VERSION_PATH) as fp:
+        content = fp.read()
+    match = re.search('^__version__ = "([^"]+)"$', content, flags=re.MULTILINE)
+    if not match:
+        raise Abort(f"{PRETTYPATH} did not contain version pattern")
+
+    old_version = match.group(1)
+    old_str = f'__version__ = "{old_version}"'
+    new_str = f'__version__ = "{old_version}.{smudge_value}"'
+    content = content.replace(old_str, new_str)
+    with open(VERSION_PATH, "w") as fp:
+        fp.write(content)
+    print("ok")
+
+
+def revert_smudge() -> None:
+    print(f"reverting smudged version in {PRETTYPATH} ... ", end="")
+    with open(VERSION_PATH) as fp:
+        content = fp.read()
+    match = re.search('^__version__ = "([^"]+)"$', content, flags=re.MULTILINE)
+    if not match:
+        raise Abort(f"{PRETTYPATH} did not contain version pattern")
+
+    old_version = match.group(1)
+    unsmudged = ".".join(old_version.split(".")[:3])
+    old_str = f'__version__ = "{old_version}"'
+    new_str = f'__version__ = "{unsmudged}"'
+    content = content.replace(old_str, new_str)
+    with open(VERSION_PATH, "w") as fp:
+        fp.write(content)
+    print("ok")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--smudge-value",
+        help="set a smudge value -- defaults to 'devX' where 'X' is the epoch",
+    )
+    parser.add_argument(
+        "--revert",
+        action="store_true",
+        help="remove any smudge value from the version",
+    )
+    args = parser.parse_args()
+
+    if not args.smudge_value:
+        args.smudge_value = f"dev{int(time.time())}"
+
+    if args.revert:
+        revert_smudge()
+    else:
+        bump_version_in_file(args.smudge_value)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I've taken nearly the same workflows which we used in globus-sdk but added a step for "smudging" the version number with `.dev{EPOCH}` so that multiple uploads can go to test-pypi if needed.

I've already put the requisite secrets into repo storage.

I considered but rejected the addition of another build to run
```
scripts/version_smudge.py
pytest
```
to test and ensure that the script never breaks things.