### PR TITLE
Unquote scope strings when seen with single quotes

### DIFF
--- a/changelog.d/20230314_120621_sirosen_cmdprompt_quoting_fix.md
+++ b/changelog.d/20230314_120621_sirosen_cmdprompt_quoting_fix.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Strip single quotes from scope strings passed to `globus session consent`,
+  fixing the behavior of this command when run from Windows Command Prompt

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import click
+from globus_sdk.scopes import MutableScope
 
 from globus_cli import utils
 from globus_cli.login_manager import LoginManager
@@ -22,7 +23,9 @@ def session_consent(scopes: tuple[str], no_local_server: bool) -> None:
     This command is necessary when the CLI needs access to resources which require the
     user to explicitly consent to access.
     """
-    scope_list = [utils.unquote_cmdprompt_single_quotes(s) for s in scopes]
+    scope_list: list[str | MutableScope] = [
+        utils.unquote_cmdprompt_single_quotes(s) for s in scopes
+    ]
     manager = LoginManager()
 
     manager.run_login_flow(

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import click
 
+from globus_cli import utils
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, no_local_server_option
 
@@ -21,7 +22,9 @@ def session_consent(scopes: tuple[str], no_local_server: bool) -> None:
     This command is necessary when the CLI needs access to resources which require the
     user to explicitly consent to access.
     """
+    scope_list = [utils.unquote_cmdprompt_single_quotes(s) for s in scopes]
     manager = LoginManager()
+
     manager.run_login_flow(
         no_local_server=no_local_server,
         local_server_message=(
@@ -33,5 +36,5 @@ def session_consent(scopes: tuple[str], no_local_server: bool) -> None:
             "\n---"
         ),
         epilog="\nYou have successfully updated your CLI session.\n",
-        scopes=list(scopes),
+        scopes=scope_list,
     )

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -9,6 +9,24 @@ from globus_cli.types import DATA_CONTAINER_T, ClickContextTree
 F = t.TypeVar("F", bound=t.Callable)
 
 
+def unquote_cmdprompt_single_quotes(arg: str) -> str:
+    """
+    remove leading and trailing single quotes from a string when
+    there is a leading and trailing single quote
+
+    per the name of this function, it is meant to provide compatibility
+    with cmdprompt which interprets inputs like
+
+        $ mycmd 'foo'
+
+    as including the single quote chars and passes "'foo'" to our
+    commands
+    """
+    if len(arg) >= 2 and arg[0] == "'" and arg[-1] == "'":
+        return arg[1:-1]
+    return arg
+
+
 def fold_decorators(f: F, decorators: list[t.Callable[[F], F]]) -> F:
     for deco in decorators:
         f = deco(f)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,10 @@
-from globus_cli.utils import format_list_of_words, format_plural_str
+import pytest
+
+from globus_cli.utils import (
+    format_list_of_words,
+    format_plural_str,
+    unquote_cmdprompt_single_quotes,
+)
 
 
 def test_format_word_list():
@@ -16,3 +22,19 @@ def test_format_plural_str():
     wordforms = {"this": "these", "command": "commands"}
     assert format_plural_str(fmt, wordforms, True) == "you need to run these commands"
     assert format_plural_str(fmt, wordforms, False) == "you need to run this command"
+
+
+@pytest.mark.parametrize(
+    "arg, expect",
+    (
+        ("foo", "foo"),
+        ("'foo'", "foo"),
+        ("'", "'"),
+        ("'foo", "'foo"),
+        ("foo'", "foo'"),
+        ("''", ""),
+        ('"foo"', '"foo"'),
+    ),
+)
+def test_unquote_cmdprompt_squote(arg, expect):
+    assert unquote_cmdprompt_single_quotes(arg) == expect


### PR DESCRIPTION
This change originates with a bug report about `globus session consent` on Windows Command Prompt. The single quote chars are not interpreted by the shell, so we receive them verbatim.

After discussing the tradeoffs between this fix and switching to double-quotes for the scope string emission piece, choose this one. The impact is small and easy to test in unit tests.

Fun fact: there's also an "easy" bypass mechanism on modern shells if anyone needs to pass leading and trailing single quotes in the future. Just pass an extra (literal) leading and trailing quote.

Because there is no suite of functional tests for `globus session consent` today, none is added here.