### PR TITLE
Add nice names for known resource servers

### DIFF
--- a/changelog.d/20230315_163544_sirosen_nicer_missing_login_errors.md
+++ b/changelog.d/20230315_163544_sirosen_nicer_missing_login_errors.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* When showing login requirements for known Globus services, the error message
+  instructing users to run `globus login` will use recognizable nice names for
+  those services, e.g. `Globus Timers`

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -51,6 +51,7 @@ TIMER_SCOPE_WITH_DEPENDENCIES = compute_timer_scope()
 class _ServiceRequirement(TypedDict):
     min_contract_version: int
     resource_server: str
+    nice_server_name: str
     scopes: list[str | MutableScope]
 
 
@@ -59,6 +60,7 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
         self["auth"] = {
             "min_contract_version": 0,
             "resource_server": AuthScopes.resource_server,
+            "nice_server_name": "Globus Auth",
             "scopes": [
                 AuthScopes.openid,
                 AuthScopes.profile,
@@ -69,6 +71,7 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
         self["transfer"] = {
             "min_contract_version": 0,
             "resource_server": TransferScopes.resource_server,
+            "nice_server_name": "Globus Transfer",
             "scopes": [
                 TransferScopes.all,
             ],
@@ -76,6 +79,7 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
         self["groups"] = {
             "min_contract_version": 0,
             "resource_server": GroupsScopes.resource_server,
+            "nice_server_name": "Globus Groups",
             "scopes": [
                 GroupsScopes.all,
             ],
@@ -83,6 +87,7 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
         self["search"] = {
             "min_contract_version": 0,
             "resource_server": SearchScopes.resource_server,
+            "nice_server_name": "Globus Search",
             "scopes": [
                 SearchScopes.all,
             ],
@@ -90,6 +95,7 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
         self["timer"] = {
             "min_contract_version": 1,
             "resource_server": TimerScopes.resource_server,
+            "nice_server_name": "Globus Timers",
             "scopes": [
                 TIMER_SCOPE_WITH_DEPENDENCIES,
             ],
@@ -97,6 +103,7 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
         self["flows"] = {
             "min_contract_version": 0,
             "resource_server": FlowsScopes.resource_server,
+            "nice_server_name": "Globus Flows",
             "scopes": [
                 FlowsScopes.manage_flows,
                 FlowsScopes.view_flows,

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -69,6 +69,7 @@ def patch_scope_requirements():
             {
                 "min_contract_version": 0,
                 "resource_server": "a.globus.org",
+                "nice_server_name": "A is for Awesome",
                 "scopes": [
                     "scopeA1",
                     "scopeA2",
@@ -81,6 +82,7 @@ def patch_scope_requirements():
             {
                 "min_contract_version": 0,
                 "resource_server": "b.globus.org",
+                "nice_server_name": "B Cool",
                 "scopes": [
                     "scopeB1",
                     "scopeB2",
@@ -128,7 +130,23 @@ def test_requires_login_single_server_fail(
         dummy_command()
 
     assert str(ex.value) == (
-        "Missing login for c.globus.org, please run\n\n  globus login\n"
+        "Missing login for c.globus.org, please run:\n\n  globus login\n"
+    )
+
+
+def test_requiring_login_for_multiple_known_servers_renders_nice_error(
+    patch_scope_requirements,
+):
+    @LoginManager.requires_login("a", "b")
+    def dummy_command(login_manager):
+        return True
+
+    with pytest.raises(MissingLoginError) as ex:
+        dummy_command()
+
+    assert str(ex.value) == (
+        "Missing logins for A is for Awesome and B Cool, please run:"
+        "\n\n  globus login\n"
     )
 
 
@@ -143,7 +161,7 @@ def test_requiring_new_scope_fails(patch_scope_requirements, patched_tokenstorag
         dummy_command()
 
     assert str(ex.value) == (
-        "Missing login for a.globus.org, please run\n\n  globus login\n"
+        "Missing login for A is for Awesome, please run:\n\n  globus login\n"
     )
 
 
@@ -158,7 +176,7 @@ def test_scope_contract_version_bump_forces_login(patch_scope_requirements):
         dummy_command()
 
     assert str(ex.value) == (
-        "Missing login for a.globus.org, please run\n\n  globus login\n"
+        "Missing login for A is for Awesome, please run:\n\n  globus login\n"
     )
 
 
@@ -174,7 +192,7 @@ def test_requires_login_fail_two_servers(
 
     assert re.match(
         "Missing logins for ..globus.org and ..globus.org, "
-        "please run\n\n  globus login\n",
+        "please run:\n\n  globus login\n",
         str(ex.value),
     )
     for server in ("c.globus.org", "d.globus.org"):


### PR DESCRIPTION
Each resource server listed in our scope requirements map has a nice_server_name attribute associated with it, resulting in the expected mapping

    auth -> Globus Auth
    transfer -> Globus Transfer

but notably also

    $timer_service_id -> Globus Timers

This enables better output when a command fails the `requires_login` check, as the user is prompted with a known short name rather than a less readable resource_server value.

To implement this, the MissingLoginError class now depends upon the scope requirements. But this could be refactored in the future to make the integration between the two more loosely coupled.