### PR TITLE
fix: updates CLI Documentation link in the login_manager

### DIFF
--- a/src/globus_cli/login_manager/local_server.py
+++ b/src/globus_cli/login_manager/local_server.py
@@ -135,5 +135,5 @@ HTML_TEMPLATE = Template(
 )
 
 DOC_URL = """
-<a href="https://globus.github.io/globus-cli/">CLI Documentation</a>
+<a href="https://docs.globus.org/cli/">CLI Documentation</a>
 """


### PR DESCRIPTION
Existing URL (https://globus.github.io/globus-cli/) does not resolve... as far as I know, https://docs.globus.org/cli/ is the official CLI documentation URL.