### PR TITLE
add base_python to mypy tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,9 @@ skip_install = true
 commands = pre-commit run --all-files
 
 [testenv:mypy]
+base_python =
+   python3.11
+   python3.10
 deps =
     mypy==1.0.1
     types-jwt


### PR DESCRIPTION
`tox -e mypy` was failing when running with my default of py3.8. We discovered they also fail on 3.9, so this config forces 3.11 or 3.10.