### PR TITLE
add --include option to globus transfer

### DIFF
--- a/changelog.d/20230321_115826_aaschaer_include.md
+++ b/changelog.d/20230321_115826_aaschaer_include.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* The `--exclude` option for `globus transfer` only applies to files.
+* Add `--include` option to `globus transfer` allowing ordered overrides of `--exclude` rules.

--- a/changelog.d/20230321_115826_aaschaer_include.md
+++ b/changelog.d/20230321_115826_aaschaer_include.md
@@ -1,4 +1,4 @@
 ### Enhancements
 
-* The `--exclude` option for `globus transfer` only applies to files.
+* Modify the `--exclude` option for `globus transfer` so it only applies to files.
 * Add `--include` option to `globus transfer` allowing ordered overrides of `--exclude` rules.

--- a/changelog.d/20230321_115826_aaschaer_include.md
+++ b/changelog.d/20230321_115826_aaschaer_include.md
@@ -1,4 +1,8 @@
 ### Enhancements
 
-* Modify the `--exclude` option for `globus transfer` so it only applies to files.
 * Add `--include` option to `globus transfer` allowing ordered overrides of `--exclude` rules.
+
+### Breaking Changes
+
+* The `--exclude` option for `globus transfer` now only applies to files to better
+  support excluding files within a directory structure

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "globus-sdk==3.17.0",
+        "globus-sdk==3.19.0",
         "click>=8.0.0,<9",
         "jmespath==1.0.1",
         "packaging>=17.0",

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -33,6 +33,10 @@ else:
 
 @command(
     "transfer",
+    opts_to_combine={
+        "include": "filter_rules",
+        "exclude": "filter_rules",
+    },
     short_help="Submit a transfer task (asynchronous)",
     adoc_examples="""Transfer a single file:
 
@@ -161,14 +165,29 @@ fi
     help=("Specify an algorithm for --external-checksum or --verify-checksum"),
 )
 @click.option(
+    "--include",
+    multiple=True,
+    show_default=True,
+    expose_value=False,  # this is combined into the filter_rules parameter
+    help=(
+        "Include files found with names that match the given pattern in "
+        "recursive transfers. Pattern may include * ? or [] for unix style "
+        "globbing. This option can be given multiple times along with "
+        "--exclude to control which files are transferred, with earlier "
+        "options having priority."
+    ),
+)
+@click.option(
     "--exclude",
     multiple=True,
     show_default=True,
+    expose_value=False,  # this is combined into the filter_rules parameter
     help=(
-        "Exclude files and directories found with names that match the given "
-        "pattern in recursive transfers. Pattern may include * ? or [] for "
-        "unix style globbing. Give this option multiple times to exclude "
-        "multiple patterns."
+        "Exclude files found with names that match the given pattern in "
+        "recursive transfers. Pattern may include * ? or [] for unix style "
+        "globbing. This option can be given multiple times along with "
+        "--include to control which files are transferred, with earlier "
+        "options having priority."
     ),
 )
 @click.option("--perf-cc", type=int, hidden=True)
@@ -189,7 +208,7 @@ def transfer_command(
     external_checksum: str | None,
     skip_source_errors: bool,
     fail_on_quota_errors: bool,
-    exclude: tuple[str, ...],
+    filter_rules: list[tuple[Literal["include", "exclude"], str]],
     label: str | None,
     preserve_timestamp: bool,
     verify_checksum: bool,
@@ -269,6 +288,20 @@ def transfer_command(
     If a transfer fails, CHECKSUM must be used to restart the transfer.
     All other levels can lead to data corruption.
 
+    \b
+    === Include and Exclude
+
+    The `--include` and `--exclude` options are evaluated in order together
+    to determine which files are transferred during recursive transfers.
+    Earlier `--include` and `exclude` options have priority over later such
+    options, with the first option that matches the name of a file being
+    applied. A file that does not match any `--include` or `exclude` options
+    is included by default, making the `--include` option only useful for
+    overriding later `--exclude` options.
+
+    For example, `globus transfer --include *.txt --exclude * ...` will
+    only transfer files ending in .txt found within the directory structure
+
     {AUTOMATIC_ACTIVATION}
     """
     from globus_cli.services.transfer import add_batch_to_transfer_data, autoactivate
@@ -321,8 +354,9 @@ def transfer_command(
         additional_fields={**perf_opts, **notify},
     )
 
-    for exclude_name in exclude:
-        transfer_data.add_filter_rule(exclude_name)
+    for rule in filter_rules:
+        method, name = rule
+        transfer_data.add_filter_rule(method=method, name=name, type="file")
 
     if batch:
         add_batch_to_transfer_data(
@@ -348,8 +382,10 @@ def transfer_command(
     else:
         has_recursive_items = False
 
-    if exclude and not has_recursive_items:
-        raise click.UsageError("--exclude can only be used with --recursive transfers")
+    if filter_rules and not has_recursive_items:
+        raise click.UsageError(
+            "--include and --exclude can only be used with --recursive transfers"
+        )
 
     if dry_run:
         display(

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -184,7 +184,7 @@ fi
     expose_value=False,  # this is combined into the filter_rules parameter
     help=(
         "Exclude files found with names that match the given pattern in "
-        "recursive transfers. Pattern may include * ? or [] for unix style "
+        'recursive transfers. Pattern may include "*", "?", or "[]" for Unix-style '
         "globbing. This option can be given multiple times along with "
         "--include to control which files are transferred, with earlier "
         "options having priority."

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -33,6 +33,8 @@ else:
 
 @command(
     "transfer",
+    # the order of filter_rules determines behavior, so we need to combine
+    # include and exclude options during argument parsing to preserve their ordering
     opts_to_combine={
         "include": "filter_rules",
         "exclude": "filter_rules",

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -171,7 +171,7 @@ fi
     expose_value=False,  # this is combined into the filter_rules parameter
     help=(
         "Include files found with names that match the given pattern in "
-        "recursive transfers. Pattern may include * ? or [] for unix style "
+        'recursive transfers. Pattern may include "*", "?", or "[]" for Unix-style '
         "globbing. This option can be given multiple times along with "
         "--exclude to control which files are transferred, with earlier "
         "options having priority."

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -300,7 +300,7 @@ def transfer_command(
     overriding later `--exclude` options.
 
     For example, `globus transfer --include *.txt --exclude * ...` will
-    only transfer files ending in .txt found within the directory structure
+    only transfer files ending in .txt found within the directory structure.
 
     {AUTOMATIC_ACTIVATION}
     """

--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -46,6 +46,7 @@ class GlobusCommand(click.Command):
         self.globus_disable_opts = kwargs.pop("globus_disable_opts", [])
         self.adoc_exit_status = kwargs.pop("adoc_exit_status", None)
         self.adoc_synopsis = kwargs.pop("adoc_synopsis", None)
+        self.opts_to_combine = kwargs.pop("opts_to_combine", {})
 
         helptext = kwargs.pop("help", None)
         if helptext:
@@ -74,7 +75,28 @@ class GlobusCommand(click.Command):
         # args will be consumed, so check it before super()
         had_args = bool(args)
         try:
+            # if we have any opts to be combined in order, do that now
+            if self.opts_to_combine:
+                combined_opts: dict[str, list[tuple[str, str]]] = {
+                    combined_name: [] for combined_name in self.opts_to_combine.values()
+                }
+                parser = self.make_parser(ctx)
+                values, _, order = parser.parse_args(args=list(args))
+                # values is a dict of value lists keyed by their option name
+                # in order for that value and opts is a list of option names
+                # in the order they were given at the command line
+                # we want a list of (name, value) tuples for multiple options
+                # in the order they were given at the command line
+                for opt in order:
+                    if opt.name and opt.name in self.opts_to_combine:
+                        value = values[opt.name].pop(0)
+                        combined_name = self.opts_to_combine[opt.name]
+                        combined_opts[combined_name].append((opt.name, value))
+
+                ctx.params.update(combined_opts)
+
             return super().parse_args(ctx, args)
+
         except click.MissingParameter as e:
             if not had_args:
                 click.secho(e.format_message(), fg="yellow", err=True)

--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -83,7 +83,7 @@ class GlobusCommand(click.Command):
                 parser = self.make_parser(ctx)
                 values, _, order = parser.parse_args(args=list(args))
                 # values is a dict of value lists keyed by their option name
-                # in order for that value and opts is a list of option names
+                # in order for that value and order is a list of option names
                 # in the order they were given at the command line
                 # we want a list of (name, value) tuples for multiple options
                 # in the order they were given at the command line

--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -30,7 +30,27 @@ class GlobusCommand(click.Command):
     adoc generator.
 
     It also automatically runs string formatting on command helptext to allow the
-    inclusion of common strings (e.g. autoactivation help).
+    inclusion of common strings (e.g. autoactivation help) and handles
+    custom argument parsing.
+
+    opts_to_combine is an interface for combining multiple options while preserving
+    their original order. Given a dict of original option names as keys
+    and combined option names as values, options are combined into a list of
+    tuples of the original option name and value. For example:
+
+    @command(
+        ...
+        opts_to_combine={
+            "foo": "foo_bar",
+            "bar": "foo_bar",
+        },
+    @click.option("--foo", multiple=True, expose_value=False)
+    @click.option("--bar", multiple=True, expose_value=False)
+    def example_command(*, foo_bar: list[tuple[Literal["foo", "bar"], Any]]):
+
+        for option in foo_bar:
+            original_option_name, value = option
+
     """
 
     AUTOMATIC_ACTIVATION_HELPTEXT = """=== Automatic Endpoint Activation
@@ -80,7 +100,7 @@ class GlobusCommand(click.Command):
                 combined_opts: dict[str, list[tuple[str, str]]] = {
                     combined_name: [] for combined_name in self.opts_to_combine.values()
                 }
-                parser = self.make_parser(ctx)
+                parser: click.parser.OptionParser = self.make_parser(ctx)
                 values, _, order = parser.parse_args(args=list(args))
                 # values is a dict of value lists keyed by their option name
                 # in order for that value and order is a list of option names


### PR DESCRIPTION
For https://app.shortcut.com/globus/story/22583/cli-add-support-for-include-filter-rules

Opening as draft because mypy will fail until https://github.com/globus/globus-sdk-python/pull/712 is released which is itself blocked on underlying transfer support being released.

After a reasonable amount of investigation on the team's part, there doesn't seem to be any better way to preserve ordering of options than to override `parse_args`.

It should be noted that this is technically a breaking change, as we are making `--exclude` only apply to files to support the `--include wanted_stuff.txt --exclude *` use case. Without this change, `--exclude *` would prevent traversing all directories, breaking recursion. I can get usage data from Transfer if we are worried about this.