### PR TITLE
Add server timing header ASCII graph with hidden flag control

### DIFF
--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -9,6 +9,7 @@ from globus_cli.parsing.command_state import (
     debug_option,
     format_option,
     map_http_status_option,
+    show_server_timing_option,
     verbose_option,
 )
 from globus_cli.parsing.param_classes import AnnotatedOption
@@ -46,6 +47,7 @@ def common_options(
         return functools.partial(common_options, disable_options=disable_options)
 
     f = debug_option(f)
+    f = show_server_timing_option(f)
     f = verbose_option(f)
     f = click.help_option("-h", "--help")(f)
 

--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -63,6 +63,15 @@ def is_verbose() -> bool:
     return state.is_verbose()
 
 
+def should_show_server_timing() -> bool:
+    """
+    Only safe to call within a click context.
+    """
+    ctx = click.get_current_context()
+    state = ctx.ensure_object(CommandState)
+    return state.show_server_timing
+
+
 def out_is_terminal() -> bool:
     return sys.stdout.isatty()
 

--- a/src/globus_cli/termio/printer.py
+++ b/src/globus_cli/termio/printer.py
@@ -12,6 +12,7 @@ from globus_cli.utils import CLIStubResponse
 from .awscli_text import unix_display
 from .context import get_jmespath_expression, outformat_is_json, outformat_is_unix
 from .field import Field
+from .server_timing import maybe_show_server_timing
 
 
 class TextMode(enum.Enum):
@@ -186,6 +187,9 @@ def display(
     gets a string. Necessary for certain formats like text table (text output
     only)
     """
+
+    if isinstance(response_data, globus_sdk.GlobusHTTPResponse):
+        maybe_show_server_timing(response_data)
 
     def _assert_fields():
         if fields is None:

--- a/src/globus_cli/termio/server_timing.py
+++ b/src/globus_cli/termio/server_timing.py
@@ -143,7 +143,7 @@ def _parse_simple_metric_part(metric: str) -> Metric:
         value = float(unparsed_value)
     except ValueError as e:
         raise ServerTimingParseError("Metric value did not parse as float") from e
-    return Metric(name=name, duration=value)
+    return Metric(name=name.strip(), duration=value)
 
 
 DEFAULT_PARSER = Draft2017Parser()

--- a/src/globus_cli/termio/server_timing.py
+++ b/src/globus_cli/termio/server_timing.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+import shutil
+
+import click
+import globus_sdk
+
+_BORDER_COLOR = "blue"
+_FILL_COLOR = "yellow"
+
+
+class ServerTimingParseError(ValueError):
+    pass
+
+
+def timing_string_to_dict(server_timing_string: str) -> dict[str, float]:
+    """
+    Given a Server Timing value as a string, parse it into a dict of the format
+      nice_name: value
+
+    For example
+
+      'a=1, "alpha"; b=2'
+
+    will parse as
+
+      {"alpha": 1, "b": 2}
+
+    """
+
+    def parse_item(item: str) -> tuple[str, float]:
+        item = [x.strip() for x in item.split(";")]
+        if len(item) > 2:
+            raise ServerTimingParseError(
+                "Too many semicolons in timing item, cannot parse"
+            )
+        nice_name = None
+        if len(item) == 2:
+            nice_name = item[1].strip('"')
+            item = item[0]
+        item = item.split("=")
+        if len(item) != 2:
+            raise ServerTimingParseError("Wrong number of '=' delimited values")
+        if not nice_name:
+            nice_name = item[0]
+        return (nice_name, float(item[1]))
+
+    items = [x.strip() for x in server_timing_string.split(",")]
+    return {key: value for (key, value) in [parse_item(x) for x in items]}
+
+
+def render_timing_dict_onscreen(timing_dict: dict[str, tuple[str, float]]) -> None:
+    click.echo("Server Timing Info", err=True)
+    term_width = shutil.get_terminal_size((80, 20)).columns
+    use_width = term_width - 4
+
+    items = sorted(
+        ((f"{name}={duration}", duration) for (name, duration) in timing_dict.items()),
+        key=lambda x: x[1],
+    )
+    last = items[-1]
+    factor = last[1]
+    desc_width = (max(len(x[0]) for x in items) if items else 0) + 1
+
+    hborder = click.style(f"+{'-' * (use_width + 2)}+", fg=_BORDER_COLOR)
+    vborder = click.style("|", fg=_BORDER_COLOR)
+    click.echo(hborder, err=True)
+
+    for desc, size in items:
+        desc = desc.ljust(desc_width, ".")
+        bar_width = max(int((use_width - desc_width) * size / factor), 1)
+        bar = "#" * bar_width
+        msg = desc + click.style(bar, fg=_FILL_COLOR)
+        style_char_length = len(msg) - len(click.unstyle(msg))
+        msg = msg.ljust(use_width + style_char_length, " ")
+        click.echo(f"{vborder} {msg} {vborder}", err=True)
+    click.echo(hborder, err=True)
+
+
+def maybe_show_server_timing(res: globus_sdk.GlobusHTTPResponse) -> None:
+    if os.getenv("GLOBUS_CLI_SHOW_SERVER_TIMING") != "1":
+        return
+
+    try:
+        parsed_timing = timing_string_to_dict(res.headers["Server-Timing"])
+    except (ServerTimingParseError, KeyError):
+        pass
+    else:
+        render_timing_dict_onscreen(parsed_timing)

--- a/src/globus_cli/termio/server_timing.py
+++ b/src/globus_cli/termio/server_timing.py
@@ -6,6 +6,8 @@ import shutil
 import click
 import globus_sdk
 
+from .context import should_show_server_timing
+
 _BORDER_COLOR = "blue"
 _FILL_COLOR = "yellow"
 
@@ -79,7 +81,7 @@ def render_timing_dict_onscreen(timing_dict: dict[str, tuple[str, float]]) -> No
 
 
 def maybe_show_server_timing(res: globus_sdk.GlobusHTTPResponse) -> None:
-    if os.getenv("GLOBUS_CLI_SHOW_SERVER_TIMING") != "1":
+    if not should_show_server_timing():
         return
 
     try:

--- a/src/globus_cli/termio/server_timing.py
+++ b/src/globus_cli/termio/server_timing.py
@@ -120,7 +120,7 @@ class Draft2017Parser(ServerTimingParser):
     spec_reference = "https://www.w3.org/TR/2017/WD-server-timing-20171018/"
 
     def parse_single_metric(self, metric_str: str) -> Metric:
-        part, *optionals = [p.strip() for p in metric_str.split(";")]
+        part, *optionals = (p.strip() for p in metric_str.split(";"))
         if len(optionals) > 1:
             raise ServerTimingParseError(
                 "Too many semicolons in timing item, cannot parse"

--- a/tests/unit/test_server_timing.py
+++ b/tests/unit/test_server_timing.py
@@ -1,0 +1,97 @@
+import pytest
+
+from globus_cli.termio.server_timing import (
+    Draft2017Parser,
+    Metric,
+    ServerTimingParseError,
+)
+
+
+@pytest.mark.parametrize(
+    "metricstr, expect",
+    (
+        ("a=1", Metric(name="a", duration=1.0)),
+        (
+            'a=1; "complex desc"',
+            Metric(name="a", duration=1.0, description="complex desc"),
+        ),
+        (
+            "some-str",
+            Metric(name="some-str"),
+        ),
+        (
+            'some-str; "with a description"',
+            Metric(name="some-str", description="with a description"),
+        ),
+        (
+            'some-str=52.4; "with a description"',
+            Metric(name="some-str", description="with a description", duration=52.4),
+        ),
+    ),
+)
+def test_draft2017_parse_of_single_metric(metricstr, expect):
+    parser = Draft2017Parser()
+    assert parser.parse_single_metric(metricstr) == expect
+
+
+@pytest.mark.parametrize("metricstr", ("a; b; c", "", "a=foo"))
+def test_draft2017_parse_single_metric_errors(metricstr):
+    parser = Draft2017Parser()
+    with pytest.raises(ServerTimingParseError):
+        parser.parse_single_metric(metricstr)
+
+
+@pytest.mark.parametrize(
+    "metricstr, expect",
+    (
+        (
+            "a=1, b=2.2",
+            [
+                Metric(name="a", duration=1.0),
+                Metric(name="b", duration=2.2),
+            ],
+        ),
+        (
+            'a=1, b, c=2.2; "callout"',
+            [
+                Metric(name="a", duration=1.0),
+                Metric(name="b"),
+                Metric(name="c", duration=2.2, description="callout"),
+            ],
+        ),
+    ),
+)
+def test_draft2017_parse_header_success(metricstr, expect):
+    parser = Draft2017Parser()
+    assert parser.parse_metric_header(metricstr) == expect
+
+
+@pytest.mark.parametrize(
+    "metricstr, expect_on_success",
+    (
+        (
+            "a=1, ,b=2.2",
+            [
+                Metric(name="a", duration=1.0),
+                Metric(name="b", duration=2.2),
+            ],
+        ),
+        (
+            'a=1, ;b, c=2.2; "callout"',
+            [
+                Metric(name="a", duration=1.0),
+                Metric(name="c", duration=2.2, description="callout"),
+            ],
+        ),
+    ),
+)
+@pytest.mark.parametrize("skip_errors", (True, False))
+def test_draft2017_parse_header_errors(metricstr, expect_on_success, skip_errors):
+    parser = Draft2017Parser()
+    if skip_errors:
+        assert (
+            parser.parse_metric_header(metricstr, skip_errors=True) == expect_on_success
+        )
+    else:
+        with pytest.raises(ServerTimingParseError):
+            parser.parse_metric_header(metricstr, skip_errors=False)

--- a/tests/unit/test_server_timing.py
+++ b/tests/unit/test_server_timing.py
@@ -59,6 +59,14 @@ def test_draft2017_parse_single_metric_errors(metricstr):
                 Metric(name="c", duration=2.2, description="callout"),
             ],
         ),
+        (
+            ' a = 1 , b  ,c=2.2;"callout"   ',
+            [
+                Metric(name="a", duration=1.0),
+                Metric(name="b"),
+                Metric(name="c", duration=2.2, description="callout"),
+            ],
+        ),
     ),
 )
 def test_draft2017_parse_header_success(metricstr, expect):


### PR DESCRIPTION
I started on this as a port of the version which was originally in globus-search-cli.
The main thing which is missing right now is some kind of tests, which is why it's currently just a draft.

I'm also not sure that it's hooked into the right place (e.g. for paginated methods), but this might be a good thing in most cases?
In particular, I'm looking at `globus api` commands' error behaviors, which use `click.echo` on the error body text rather than `display(...)`. Ideas about where and how to wire it up are welcome.