### PR TITLE
Add `globus flows create` command

### DIFF
--- a/changelog.d/20230425_113612_ada.md
+++ b/changelog.d/20230425_113612_ada.md
@@ -1,0 +1,4 @@
+
+### Enhancements
+
+* Add `globus flows create` as a new command for creating flows.

--- a/src/globus_cli/commands/flows/__init__.py
+++ b/src/globus_cli/commands/flows/__init__.py
@@ -4,6 +4,7 @@ from globus_cli.parsing import group
 @group(
     "flows",
     lazy_subcommands={
+        "create": (".create", "create_command"),
         "delete": (".delete", "delete_command"),
         "list": (".list", "list_command"),
         "show": (".show", "show_command"),

--- a/src/globus_cli/commands/flows/create.py
+++ b/src/globus_cli/commands/flows/create.py
@@ -35,12 +35,12 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
         Example: Inline JSON:
 
         \b
-            --input_schema '{"properties": {"src": {"type": "string"}}}'
+            --input-schema '{"properties": {"src": {"type": "string"}}}'
 
         Example: Path to JSON file:
 
         \b
-            --input_schema file:schema.json
+            --input-schema file:schema.json
 
         If unspecified, the default is an empty JSON object ('{}').
     """,

--- a/src/globus_cli/commands/flows/create.py
+++ b/src/globus_cli/commands/flows/create.py
@@ -76,7 +76,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
     help="""
         A principal that may run the flow.
 
-        Use "all_authenticated_users" to make the flow visible to everyone.
+        Use "all_authenticated_users" to allow any authenticated user to run the flow.
 
         This option can be specified multiple times
         to create a list of flow starters.
@@ -90,7 +90,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
     help="""
         A principal that may view the flow.
 
-        Use "public" to allow any authenticated user to run the flow.
+        Use "public" to make the flow visible to everyone.
 
         This option can be specified multiple times
         to create a list of flow viewers.

--- a/src/globus_cli/commands/flows/create.py
+++ b/src/globus_cli/commands/flows/create.py
@@ -29,8 +29,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
         The JSON input schema that governs the parameters
         used to start the flow.
 
-        The input document may be specified inline,
-        or it may be a path to a JSON file, prefixed with "file:".
+        The input document may be specified inline, or it may be a path to a JSON file.
 
         Example: Inline JSON:
 
@@ -40,7 +39,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
         Example: Path to JSON file:
 
         \b
-            --input-schema file:schema.json
+            --input-schema schema.json
 
         If unspecified, the default is an empty JSON object ('{}').
     """,
@@ -128,8 +127,8 @@ def create_command(
     TITLE is the name of the flow.
 
     DEFINITION is the JSON document that defines the flow's instructions.
-    The definition document may be specified inline,
-    or it may be a path to a JSON file, prefixed with "file:".
+    The definition document may be specified inline, or it may be
+    a path to a JSON file.
 
         Example: Inline JSON:
 
@@ -140,7 +139,7 @@ def create_command(
         Example: Path to JSON file:
 
         \b
-            globus flows create 'My Other Flow' file:definition.json
+            globus flows create 'My Other Flow' definition.json
     """
 
     if input_schema is None:

--- a/src/globus_cli/commands/flows/create.py
+++ b/src/globus_cli/commands/flows/create.py
@@ -72,9 +72,10 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
     type=str,
     multiple=True,
     help="""
-        A principal that may run the flow.
+        A principal that may start a new run of the flow.
 
-        Use "all_authenticated_users" to allow any authenticated user to run the flow.
+        Use "all_authenticated_users" to allow any authenticated user
+        to start a new run of the flow.
 
         This option can be specified multiple times
         to create a list of flow starters.

--- a/src/globus_cli/commands/flows/create.py
+++ b/src/globus_cli/commands/flows/create.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import typing as t
+
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import JSONStringOrFile, command
+from globus_cli.termio import Field, TextMode, display, formatters
+
+ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
+
+
+@command("create", short_help="Create a flow")
+@click.argument(
+    "title",
+    type=str,
+)
+@click.argument(
+    "definition",
+    type=JSONStringOrFile(),
+    metavar="DEFINITION",
+)
+@click.option(
+    "--input-schema",
+    "input_schema",
+    type=JSONStringOrFile(),
+    help="""
+        The JSON input schema that governs the parameters
+        used to start the flow.
+
+        The input document may be specified inline,
+        or it may be a path to a JSON file, prefixed with "file:".
+
+        Example: Inline JSON:
+
+        \b
+            --input_schema '{"properties": {"src": {"type": "string"}}}'
+
+        Example: Path to JSON file:
+
+        \b
+            --input_schema file:schema.json
+
+        If unspecified, the default is an empty JSON object ('{}').
+    """,
+)
+@click.option(
+    "--subtitle",
+    type=str,
+    help="A concise summary of the flow's purpose.",
+)
+@click.option(
+    "--description",
+    type=str,
+    help="A detailed description of the flow's purpose.",
+)
+@click.option(
+    "--administrator",
+    "administrators",
+    type=str,
+    multiple=True,
+    help="""
+        A principal that may perform administrative operations
+        on the flow (e.g., update, delete).
+
+        This option can be specified multiple times
+        to create a list of flow administrators.
+    """,
+)
+@click.option(
+    "--starter",
+    "starters",
+    type=str,
+    multiple=True,
+    help="""
+        A principal that may run the flow.
+
+        Use "all_authenticated_users" to make the flow visible to everyone.
+
+        This option can be specified multiple times
+        to create a list of flow starters.
+    """,
+)
+@click.option(
+    "--viewer",
+    "viewers",
+    type=str,
+    multiple=True,
+    help="""
+        A principal that may view the flow.
+
+        Use "public" to allow any authenticated user to run the flow.
+
+        This option can be specified multiple times
+        to create a list of flow viewers.
+    """,
+)
+@click.option(
+    "--keyword",
+    "keywords",
+    type=str,
+    multiple=True,
+    help="""
+        A term used to help discover this flow when
+        browsing and searching.
+
+        This option can be specified multiple times
+        to create a list of keywords.
+    """,
+)
+@LoginManager.requires_login("flows")
+def create_command(
+    login_manager: LoginManager,
+    title: str,
+    definition: dict,
+    input_schema: dict | None | t.Any,
+    subtitle: str | None,
+    description: str | None,
+    administrators: tuple[str],
+    starters: tuple[str],
+    viewers: tuple[str],
+    keywords: tuple[str],
+) -> None:
+    """
+    Create a new flow.
+
+    TITLE is the name of the flow.
+
+    DEFINITION is the JSON document that defines the flow's instructions.
+    The definition document may be specified inline,
+    or it may be a path to a JSON file, prefixed with "file:".
+
+        Example: Inline JSON:
+
+        \b
+            globus flows create 'My Cool Flow' \\
+            '{{"StartAt": "a", "States": {{"a": {{"Type": "Pass", "End": true}}}}}}'
+
+        Example: Path to JSON file:
+
+        \b
+            globus flows create 'My Other Flow' file:definition.json
+    """
+
+    if input_schema is None:
+        input_schema = {}
+
+    flows_client = login_manager.get_flows_client()
+    auth_client = login_manager.get_auth_client()
+
+    res = flows_client.create_flow(
+        title=title,
+        definition=definition,
+        input_schema=input_schema,
+        subtitle=subtitle,
+        description=description,
+        flow_viewers=list(viewers),
+        flow_starters=list(starters),
+        flow_administrators=list(administrators),
+        keywords=list(keywords),
+    )
+
+    principal_formatter = formatters.auth.PrincipalURNFormatter(auth_client)
+    for principal_set_name in ("flow_administrators", "flow_viewers", "flow_starters"):
+        for value in res.get(principal_set_name, ()):
+            principal_formatter.add_item(value)
+    principal_formatter.add_item(res.get("flow_owner"))
+
+    fields = [
+        Field("Flow ID", "id"),
+        Field("Title", "title"),
+        Field("Subtitle", "subtitle"),
+        Field("Description", "description"),
+        Field("Keywords", "keywords", formatter=formatters.ArrayFormatter()),
+        Field("Owner", "flow_owner", formatter=principal_formatter),
+        Field("Created At", "created_at", formatter=formatters.Date),
+        Field("Updated At", "updated_at", formatter=formatters.Date),
+        Field(
+            "Administrators",
+            "flow_administrators",
+            formatter=formatters.ArrayFormatter(element_formatter=principal_formatter),
+        ),
+        Field(
+            "Viewers",
+            "flow_viewers",
+            formatter=formatters.ArrayFormatter(element_formatter=principal_formatter),
+        ),
+        Field(
+            "Starters",
+            "flow_starters",
+            formatter=formatters.ArrayFormatter(element_formatter=principal_formatter),
+        ),
+    ]
+
+    display(res, fields=fields, text_mode=TextMode.text_record)

--- a/src/globus_cli/commands/flows/create.py
+++ b/src/globus_cli/commands/flows/create.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import typing as t
-
 import click
 
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import JSONStringOrFile, command
+from globus_cli.parsing import JSONStringOrFile, ParsedJSONData, command
 from globus_cli.termio import Field, TextMode, display, formatters
 
 ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
@@ -112,14 +110,14 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 def create_command(
     login_manager: LoginManager,
     title: str,
-    definition: dict,
-    input_schema: dict | None | t.Any,
+    definition: ParsedJSONData,
+    input_schema: ParsedJSONData | None,
     subtitle: str | None,
     description: str | None,
-    administrators: tuple[str],
-    starters: tuple[str],
-    viewers: tuple[str],
-    keywords: tuple[str],
+    administrators: tuple[str, ...],
+    starters: tuple[str, ...],
+    viewers: tuple[str, ...],
+    keywords: tuple[str, ...],
 ) -> None:
     """
     Create a new flow.
@@ -142,16 +140,13 @@ def create_command(
             globus flows create 'My Other Flow' definition.json
     """
 
-    if input_schema is None:
-        input_schema = {}
-
     flows_client = login_manager.get_flows_client()
     auth_client = login_manager.get_auth_client()
 
     res = flows_client.create_flow(
         title=title,
-        definition=definition,
-        input_schema=input_schema,
+        definition=definition.data,
+        input_schema=input_schema.data if input_schema is not None else {},
         subtitle=subtitle,
         description=description,
         flow_viewers=list(viewers),

--- a/tests/functional/flows/test_create_flow.py
+++ b/tests/functional/flows/test_create_flow.py
@@ -1,0 +1,170 @@
+import json
+import re
+
+from globus_sdk._testing import RegisteredResponse, load_response
+
+FLOW_IDENTITIES = {
+    "pete": {
+        "username": "pete@kreb.star",
+        "name": "Pete Wrigley",
+        "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+        "organization": "KrebStar Corp",
+        "status": "used",
+        "email": "pete@kreb.star",
+    },
+    "nona": {
+        "username": "nona@wellsville.gov",
+        "name": "Nona F. Mecklenberg",
+        "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+        "organization": "The City of Wellsville",
+        "status": "used",
+        "email": "nona@wellsville.gov",
+    },
+    "artie": {
+        "username": "artie@super.hero",
+        "name": "The Strongest Man in the World",
+        "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+        "organization": "Personal Superheroes",
+        "status": "used",
+        "email": "artie@super.hero",
+    },
+    "monica": {
+        "username": "monica@kreb.scouts",
+        "name": "Monica Perling",
+        "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
+        "organization": "Kreb Scouts",
+        "status": "used",
+        "email": "monica@kreb.scouts",
+    },
+}
+
+
+def get_identity(id, name):
+    """
+    Return an identity dict using the provided id for the user corresponding
+    to the provided name.
+    """
+    identity = FLOW_IDENTITIES[name].copy()
+    identity["id"] = id
+    return identity
+
+
+def value_for_field_from_output(name, output):
+    """
+    Return the value for a specified field from the output of a command.
+    """
+    match = re.search(rf"^{name}:[^\S\n\r]+(?P<value>.*)$", output, flags=re.M)
+    assert match is not None
+    return match.group("value")
+
+
+def test_create_flow_text_output(run_line):
+    # Load the response mock and extract metadata
+    response = load_response("flows.create_flow")
+    definition = response.metadata["params"]["definition"]
+    input_schema = response.metadata["params"]["input_schema"]
+    keywords = response.metadata["params"]["keywords"]
+    title = response.metadata["params"]["title"]
+    subtitle = response.metadata["params"]["subtitle"]
+    description = response.metadata["params"]["description"]
+    flow_administrators = response.metadata["params"]["flow_administrators"]
+    flow_starters = response.metadata["params"]["flow_starters"]
+    flow_viewers = response.metadata["params"]["flow_viewers"]
+
+    # Configure identities
+    owner_identity = get_identity(response.json["flow_owner"].split(":")[-1], "pete")
+    flow_administrator_identities = [
+        get_identity(flow_administrators[0].split(":")[-1], "nona")
+    ]
+    flow_starter_identities = [get_identity(flow_starters[0].split(":")[-1], "artie")]
+    flow_viewer_identities = [get_identity(flow_viewers[0].split(":")[-1], "monica")]
+
+    # FIXME: Remove as soon as upstream SDK changes are released
+    flow_administrator_identities = [owner_identity]
+    flow_starter_identities = [owner_identity]
+    flow_viewer_identities = [owner_identity]
+
+    load_response(
+        RegisteredResponse(
+            service="auth",
+            path="/v2/api/identities",
+            json={
+                "identities": [
+                    owner_identity,
+                    *flow_administrator_identities,
+                    *flow_starter_identities,
+                    *flow_viewer_identities,
+                ],
+            },
+        )
+    )
+
+    # Construct the command line
+    arguments = [
+        f"'{title}'",
+        f"'{json.dumps(definition)}'",
+    ]
+    for flow_administrator in flow_administrators:
+        arguments.extend(("--administrator", f"'{flow_administrator}'"))
+    for flow_starter in flow_starters:
+        arguments.extend(("--starter", f"'{flow_starter}'"))
+    for flow_viewer in flow_viewers:
+        arguments.extend(("--viewer", f"'{flow_viewer}'"))
+    for keyword in keywords:
+        arguments.extend(("--keyword", f"'{keyword}'"))
+    if input_schema is not None:
+        arguments.extend(("--input-schema", f"'{json.dumps(input_schema)}'"))
+    if subtitle is not None:
+        arguments.extend(("--subtitle", f"'{subtitle}'"))
+    if description is not None:
+        arguments.extend(("--description", f"'{description}'"))
+
+    result = run_line(f"globus flows create {' '.join(arguments)}")
+
+    # Check all fields are present
+    expected_fields = {
+        "Flow ID",
+        "Title",
+        "Subtitle",
+        "Description",
+        "Keywords",
+        "Owner",
+        "Created At",
+        "Updated At",
+        "Administrators",
+        "Starters",
+        "Viewers",
+    }
+    actual_fields = set(re.findall(r"^[\w ]+(?=:)", result.output, flags=re.M))
+    assert expected_fields == actual_fields, "Expected and actual field sets differ"
+
+    # Check values for simple fields
+    simple_fields = {
+        "Owner": owner_identity["username"],
+        "Title": title or "",
+        "Subtitle": subtitle or "",
+        "Description": description or "",
+    }
+
+    for name, value in simple_fields.items():
+        assert value_for_field_from_output(name, result.output) == value
+
+    # Check all multi-value fields
+    expected_sets = {
+        "Keywords": set(keywords),
+        "Administrators": {
+            *[identity["username"] for identity in flow_administrator_identities]
+        },
+        "Starters": {
+            "all_authenticated_users",
+            *[identity["username"] for identity in flow_starter_identities],
+        },
+        "Viewers": {
+            "public",
+            *[identity["username"] for identity in flow_viewer_identities],
+        },
+    }
+
+    for name, expected_values in expected_sets.items():
+        match_list = set(value_for_field_from_output(name, result.output).split(","))
+        assert match_list == expected_values

--- a/tests/functional/flows/test_create_flow.py
+++ b/tests/functional/flows/test_create_flow.py
@@ -135,26 +135,29 @@ def test_create_flow_text_output(run_line):
     )
 
     # Construct the command line
-    arguments = [
-        f"'{title}'",
-        f"'{json.dumps(definition)}'",
+    command = [
+        "globus",
+        "flows",
+        "create",
+        title,
+        json.dumps(definition),
     ]
     for flow_administrator in flow_administrators:
-        arguments.extend(("--administrator", f"'{flow_administrator}'"))
+        command.extend(("--administrator", flow_administrator))
     for flow_starter in flow_starters:
-        arguments.extend(("--starter", f"'{flow_starter}'"))
+        command.extend(("--starter", flow_starter))
     for flow_viewer in flow_viewers:
-        arguments.extend(("--viewer", f"'{flow_viewer}'"))
+        command.extend(("--viewer", flow_viewer))
     for keyword in keywords:
-        arguments.extend(("--keyword", f"'{keyword}'"))
+        command.extend(("--keyword", keyword))
     if input_schema is not None:
-        arguments.extend(("--input-schema", f"'{json.dumps(input_schema)}'"))
+        command.extend(("--input-schema", json.dumps(input_schema)))
     if subtitle is not None:
-        arguments.extend(("--subtitle", f"'{subtitle}'"))
+        command.extend(("--subtitle", subtitle))
     if description is not None:
-        arguments.extend(("--description", f"'{description}'"))
+        command.extend(("--description", description))
 
-    result = run_line(f"globus flows create {' '.join(arguments)}")
+    result = run_line(command)
 
     # Check all fields are present
     expected_fields = {


### PR DESCRIPTION
# Context
Implements [[sc-18412](https://app.shortcut.com/globus/story/18412/implement-initial-version-of-globus-flows-create)].

This adds the `globus flows create` command.

# Notes
- The title and definition are required arguments and thus positional. All others are optional. (The input schema is presumed to be `{}` if omitted).
- The definition and input schema support the JSONStringOrFile parameter and can accept a path to a JSON file (prefixed with `file:`) or a valid JSON string.
- I had initially pursued work on a principal ParamType, but ended up deciding based on conversation (where we agreed that we prefer that the service provides this feedback) that this was best set aside to keep the scope of this work constrained.
- There is a gap here where the SDK doesn't handle Flows's error formats. As a prerequisite, we'll need upstream extension of the FlowsAPIError in order for the CLI to handle this (subsequently, a custom hook for this error type may be added to the CLI). I've considered this non-blocking for this change.
- I tried to keep the test definition somewhat generic so that it shouldn't take too much work if we add more samples to responses. This will require a little work to fully genericize it, but I believe should be mostly around creating a proper list of the expected principals.
- There is an unreleased change in the SDK that will allow us to remove the overridden values on L82-85 and test distinct identities for these fields. I've added these lines for now to allow this to move forward.