### PR TITLE
Organize reflection code into 'globus_cli.reflect' and use it to improve annotation checking

### DIFF
--- a/reference/_generate.py
+++ b/reference/_generate.py
@@ -11,11 +11,10 @@ import time
 
 import click
 import requests
-from pkg_resources import load_entry_point
 
-from globus_cli.utils import walk_contexts
+from globus_cli.reflect import iter_all_commands, load_main_entrypoint, walk_contexts
 
-CLI = load_entry_point("globus-cli", "console_scripts", "globus")
+CLI = load_main_entrypoint()
 TARGET_DIR = os.path.dirname(__file__)
 
 log = logging.getLogger(__name__)
@@ -58,13 +57,6 @@ EXIT_STATUS_NOHTTP_TEXT = (
 """
     + _EXIT_STATUS_TEXT_COMMON
 )
-
-
-def iter_all_commands(tree=None):
-    ctx, subcmds, subgroups = tree or walk_contexts("globus", CLI)
-    yield from subcmds
-    for g in subgroups:
-        yield from iter_all_commands(g)
 
 
 def _format_option(optstr):

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 import click
 import globus_sdk
 
@@ -113,14 +115,14 @@ $ globus endpoint activate $ep_id --myproxy -U username
 def endpoint_activate(
     *,
     login_manager: LoginManager,
-    endpoint_id: str,
+    endpoint_id: uuid.UUID,
     myproxy: bool,
     myproxy_username: str | None,
     myproxy_password: str | None,
     myproxy_lifetime: int | None,
     web: bool,
     no_browser: bool,
-    delegate_proxy: bool,
+    delegate_proxy: str | None,
     proxy_lifetime: int | None,
     no_autoactivate: bool,
     force: bool,

--- a/src/globus_cli/commands/list_commands.py
+++ b/src/globus_cli/commands/list_commands.py
@@ -5,8 +5,8 @@ import typing as t
 import click
 
 from globus_cli.parsing import command
+from globus_cli.reflect import walk_contexts
 from globus_cli.types import ClickContextTree
-from globus_cli.utils import walk_contexts
 
 
 def _print_command(cmd_ctx: click.Context) -> None:

--- a/src/globus_cli/reflect.py
+++ b/src/globus_cli/reflect.py
@@ -1,0 +1,75 @@
+"""
+Tools for self-inspection or "reflection" of the CLI.
+Used for autodocumentation and testing.
+
+By keeping the tools as part of the application, we make them testable under the
+standard testsuite.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import click
+
+from globus_cli.commands import main as main_entrypoint
+from globus_cli.types import ClickContextTree
+
+
+def load_main_entrypoint() -> click.MultiCommand:
+    return t.cast(click.MultiCommand, main_entrypoint)
+
+
+def walk_contexts(
+    name: str,
+    cmd: click.MultiCommand,
+    parent_ctx: click.Context | None = None,
+    skip_hidden: bool = True,
+) -> ClickContextTree:
+    """
+    A recursive walk over click Contexts for all commands in a tree
+    Returns the results in a tree-like structure as triples,
+      (context, subcommands, subgroups)
+
+    subcommands is a list of contexts
+    subgroups is a list of (context, subcommands, subgroups) triples
+    """
+    current_ctx = click.Context(cmd, info_name=name, parent=parent_ctx)
+    cmds, groups = [], []
+    for subcmdname in cmd.list_commands(current_ctx):
+        subcmd = cmd.get_command(current_ctx, subcmdname)
+        # it should be impossible, but if there is no such command, skip
+        if subcmd is None:
+            continue
+        # explicitly skip hidden commands
+        if subcmd.hidden and skip_hidden:
+            continue
+
+        if not isinstance(subcmd, click.Group):
+            cmds.append(click.Context(subcmd, info_name=subcmdname, parent=current_ctx))
+        else:
+            groups.append(
+                walk_contexts(subcmdname, subcmd, current_ctx, skip_hidden=skip_hidden)
+            )
+
+    return (current_ctx, cmds, groups)
+
+
+def iter_all_commands(
+    *,
+    cli_main: click.MultiCommand | None = None,
+    tree: ClickContextTree | None = None,
+    skip_hidden: bool = True,
+) -> t.Iterator[click.Context]:
+    """
+    A recursive walk over all commands, done by walking all contexts in the tree and
+    yielding back only the contexts themselves.
+    """
+    if cli_main is None:
+        cli_main = load_main_entrypoint()
+
+    ctx, subcmds, subgroups = tree or walk_contexts(
+        "globus", cli_main, skip_hidden=skip_hidden
+    )
+    yield from subcmds
+    for g in subgroups:
+        yield from iter_all_commands(cli_main=cli_main, tree=g, skip_hidden=skip_hidden)

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -4,7 +4,7 @@ import typing as t
 
 import click
 
-from globus_cli.types import DATA_CONTAINER_T, ClickContextTree
+from globus_cli.types import DATA_CONTAINER_T
 
 F = t.TypeVar("F", bound=t.Callable)
 
@@ -172,33 +172,3 @@ def shlex_process_stream(process_command: click.Command, stream: t.TextIO) -> No
             except SystemExit as e:
                 if e.code != 0:
                     raise
-
-
-def walk_contexts(
-    name: str, cmd: click.MultiCommand, parent_ctx: click.Context | None = None
-) -> ClickContextTree:
-    """
-    A recursive walk over click Contexts for all commands in a tree
-    Returns the results in a tree-like structure as triples,
-      (context, subcommands, subgroups)
-
-    subcommands is a list of contexts
-    subgroups is a list of (context, subcommands, subgroups) triples
-    """
-    current_ctx = click.Context(cmd, info_name=name, parent=parent_ctx)
-    cmds, groups = [], []
-    for subcmdname in cmd.list_commands(current_ctx):
-        subcmd = cmd.get_command(current_ctx, subcmdname)
-        # it should be impossible, but if there is no such command, skip
-        if subcmd is None:
-            continue
-        # explicitly skip hidden commands
-        if subcmd.hidden:
-            continue
-
-        if not isinstance(subcmd, click.Group):
-            cmds.append(click.Context(subcmd, info_name=subcmdname, parent=current_ctx))
-        else:
-            groups.append(walk_contexts(subcmdname, subcmd, current_ctx))
-
-    return (current_ctx, cmds, groups)

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -1,54 +1,94 @@
-import importlib
+from __future__ import annotations
+
 import sys
 
+import click
 import pytest
 
+from globus_cli.reflect import iter_all_commands
 from tests.click_types import check_has_correct_annotations_for_click_args
+
+_SKIP_MODULES = (
+    "globus_cli.commands.api",
+    "globus_cli.commands.collection.delete",
+    "globus_cli.commands.collection.list",
+    "globus_cli.commands.collection.show",
+    "globus_cli.commands.delete",
+    "globus_cli.commands.endpoint.deactivate",
+    "globus_cli.commands.endpoint.delete",
+    "globus_cli.commands.endpoint.local_id",
+    "globus_cli.commands.endpoint.my_shared_endpoint_list",
+    "globus_cli.commands.endpoint.permission.create",
+    "globus_cli.commands.endpoint.permission.delete",
+    "globus_cli.commands.endpoint.permission.list",
+    "globus_cli.commands.endpoint.permission.show",
+    "globus_cli.commands.endpoint.permission.update",
+    "globus_cli.commands.endpoint.role.create",
+    "globus_cli.commands.endpoint.search",
+    "globus_cli.commands.endpoint.server.add",
+    "globus_cli.commands.endpoint.server.delete",
+    "globus_cli.commands.endpoint.server.list",
+    "globus_cli.commands.endpoint.server.show",
+    "globus_cli.commands.endpoint.server.update",
+    "globus_cli.commands.endpoint.set_subscription_id",
+    "globus_cli.commands.endpoint.show",
+    "globus_cli.commands.endpoint.storage_gateway.list",
+    "globus_cli.commands.endpoint.user_credential.create.from_json",
+    "globus_cli.commands.endpoint.user_credential.create.posix",
+    "globus_cli.commands.endpoint.user_credential.create.s3",
+    "globus_cli.commands.endpoint.user_credential.delete",
+    "globus_cli.commands.endpoint.user_credential.list",
+    "globus_cli.commands.endpoint.user_credential.show",
+    "globus_cli.commands.endpoint.user_credential.update.from_json",
+    "globus_cli.commands.flows.list",
+    "globus_cli.commands.flows.start",
+    "globus_cli.commands.get_identities",
+    "globus_cli.commands.group.create",
+    "globus_cli.commands.group.invite.accept",
+    "globus_cli.commands.group.invite.decline",
+    "globus_cli.commands.group.join",
+    "globus_cli.commands.group.leave",
+    "globus_cli.commands.group.list",
+    "globus_cli.commands.group.member.add",
+    "globus_cli.commands.group.member.approve",
+    "globus_cli.commands.group.member.invite",
+    "globus_cli.commands.group.member.list",
+    "globus_cli.commands.group.member.reject",
+    "globus_cli.commands.group.member.remove",
+    "globus_cli.commands.group.set_policies",
+    "globus_cli.commands.group.show",
+    "globus_cli.commands.group.update",
+    "globus_cli.commands.list_commands",
+    "globus_cli.commands.login",
+    "globus_cli.commands.logout",
+    "globus_cli.commands.ls",
+    "globus_cli.commands.mkdir",
+    "globus_cli.commands.rename",
+    "globus_cli.commands.rm",
+    "globus_cli.commands.search.delete_by_query",
+    "globus_cli.commands.search.index.role.create",
+    "globus_cli.commands.search.ingest",
+    "globus_cli.commands.search.query",
+)
+
+_ALL_NON_GROUP_COMMANDS: tuple[click.Command, ...] = (
+    ctx.command
+    for ctx in iter_all_commands(skip_hidden=False)
+    if not isinstance(ctx.command, click.Group)
+)
+_ALL_COMMANDS_TO_TEST: tuple[tuple[str, str], ...] = (
+    command
+    for command in _ALL_NON_GROUP_COMMANDS
+    if command.callback.__module__ not in _SKIP_MODULES
+)
+
+
+def _command_id_fn(val):
+    assert isinstance(val, click.Command)
+    return val.callback.__module__
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="test requires py3.10+")
-@pytest.mark.parametrize(
-    "modname, command_name",
-    (
-        ("bookmark.create", "bookmark_create"),
-        ("bookmark.delete", "bookmark_delete"),
-        ("bookmark.list", "bookmark_list"),
-        ("bookmark.rename", "bookmark_rename"),
-        ("bookmark.show", "bookmark_show"),
-        ("cli_profile_list", "cli_profile_list"),
-        ("collection.update", "collection_update"),
-        ("endpoint.create", "endpoint_create"),
-        ("endpoint.is_activated", "endpoint_is_activated"),
-        # TODO: role_create uses the security_principal_opts decorator, which transforms
-        # arguments. This needs to be refactored to be checkable using this method
-        # ("endpoint.role.create", "role_create"),
-        ("endpoint.role.delete", "role_delete"),
-        ("endpoint.role.list", "role_list"),
-        ("endpoint.role.show", "role_show"),
-        ("endpoint.update", "endpoint_update"),
-        ("gcp.create.guest", "guest_command"),
-        ("gcp.create.mapped", "mapped_command"),
-        ("session.update", "session_update"),
-        ("task.cancel", "cancel_task"),
-        ("task.event_list", "task_event_list"),
-        ("task.generate_submission_id", "generate_submission_id"),
-        ("task.list", "task_list"),
-        ("task.pause_info", "task_pause_info"),
-        ("task.show", "show_task"),
-        ("task.update", "update_task"),
-        ("task.wait", "task_wait"),
-        ("transfer", "transfer_command"),
-        ("timer.delete", "delete_command"),
-        ("timer.list", "list_command"),
-        ("timer.show", "show_command"),
-        ("timer.create.transfer", "transfer_command"),
-        ("update", "update_command"),
-        ("version", "version_command"),
-        ("whoami", "whoami_command"),
-    ),
-)
-def test_annotations_match_click_params(modname, command_name):
-    mod = importlib.import_module(f"globus_cli.commands.{modname}", "globus_cli")
-    cmd = getattr(mod, command_name)
-
-    check_has_correct_annotations_for_click_args(cmd)
+@pytest.mark.parametrize("command", _ALL_COMMANDS_TO_TEST, ids=_command_id_fn)
+def test_annotations_match_click_params(command):
+    check_has_correct_annotations_for_click_args(command)


### PR DESCRIPTION
- Move reflection tooling to a dedicated module, `globus_cli.reflect`, pulling from the doc generator and `globus_cli.utils`
- Use `reflect` to improve the implementation of the click annotation checker test to automatically pick up on any new modules

Once this is done, road-test the changes to the annotation checker by removing modules from the deny-list to ensure that the checker picks them up.
Using `globus endpoint activate`, verify that the checker can still be used to identify and fix a minor issue after the refactor.

This also enables the checker on many modules where it already passes, expanding the list of checks.