### PR TITLE
Bugfix: the server-timing display always showed

### DIFF
--- a/changelog.d/20230428_165835_sirosen_bugfix_server_timing.md
+++ b/changelog.d/20230428_165835_sirosen_bugfix_server_timing.md
@@ -1,0 +1,5 @@
+### Bugfixes
+
+* A debug display of server timing info was always enabled when it should have
+  been disabled by default. This produced extraneous output to stderr for some
+  commands.

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -233,6 +233,8 @@ def map_http_status_option(f: F) -> F:
 
 def show_server_timing_option(f: F) -> F:
     def callback(ctx, param, value):
+        if not value:
+            return
         state = ctx.ensure_object(CommandState)
         state.show_server_timing = True
 


### PR DESCRIPTION
The cause in this case was that the callback for `--show-server-timing` always fires, but should exit early if the flag is not set.