### PR TITLE
local user options with related type annotations and rm bugfix

### DIFF
--- a/changelog.d/20230606_141941_aaschaer_local_user.md
+++ b/changelog.d/20230606_141941_aaschaer_local_user.md
@@ -1,0 +1,11 @@
+### Bugfixes
+
+* Fix bug causing `globus rm` to fail when using the `--dry-run` option.
+
+### Enhancements
+
+* Add the `--local-user` option to the `globus ls`, `globus rename`, `globus mkdir`,
+  `globus delete`, and `globus rm` commands.
+
+* Add the `--source-local-user` and `--destination-local-user` options to the
+  `globus transfer` command.

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -1,3 +1,9 @@
+from __future__ import annotations
+
+import datetime
+import typing as t
+import uuid
+
 import click
 import globus_sdk
 
@@ -8,6 +14,7 @@ from globus_cli.parsing import (
     TaskPath,
     command,
     delete_and_rm_options,
+    local_user_option,
     task_submission_options,
 )
 from globus_cli.termio import (
@@ -65,23 +72,25 @@ $ globus task wait "$task_id"
 )
 @task_submission_options
 @delete_and_rm_options
+@local_user_option
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_OPTPATH)
 @LoginManager.requires_login("transfer")
 def delete_command(
     *,
     login_manager: LoginManager,
-    batch,
-    ignore_missing,
-    star_silent,
-    recursive,
-    enable_globs,
-    endpoint_plus_path,
-    label,
-    submission_id,
-    dry_run,
-    deadline,
-    skip_activation_check,
-    notify,
+    batch: t.TextIO | None,
+    ignore_missing: bool,
+    star_silent: bool,
+    recursive: bool,
+    enable_globs: bool,
+    endpoint_plus_path: tuple[uuid.UUID, str | None],
+    label: str | None,
+    submission_id: str | None,
+    dry_run: bool,
+    deadline: datetime.datetime | None,
+    skip_activation_check: bool,
+    notify: dict[str, bool],
+    local_user: str | None,
 ):
     """
     Submits an asynchronous task that deletes files and/or directories on the target
@@ -122,9 +131,6 @@ def delete_command(
     from globus_cli.services.transfer import autoactivate
 
     endpoint_id, path = endpoint_plus_path
-    if path is None and (not batch):
-        raise click.UsageError("delete requires either a PATH OR --batch")
-
     transfer_client = login_manager.get_transfer_client()
 
     # attempt to activate unless --skip-activation-check is given
@@ -138,6 +144,7 @@ def delete_command(
         recursive=recursive,
         submission_id=submission_id,
         deadline=deadline,
+        local_user=local_user,
         additional_fields={
             "ignore_missing": ignore_missing,
             "skip_activation_check": skip_activation_check,
@@ -161,6 +168,9 @@ def delete_command(
 
         utils.shlex_process_stream(process_batch_line, batch)
     else:
+        if path is None:
+            raise click.UsageError("delete requires either a PATH OR --batch")
+
         if not star_silent and enable_globs and path.endswith("*"):
             # not intuitive, but `click.confirm(abort=True)` prints to stdout
             # unnecessarily, which we don't really want...

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -133,10 +133,6 @@ def delete_command(
     endpoint_id, path = endpoint_plus_path
     transfer_client = login_manager.get_transfer_client()
 
-    # attempt to activate unless --skip-activation-check is given
-    if not skip_activation_check:
-        autoactivate(transfer_client, endpoint_id, if_expires_in=60)
-
     delete_data = globus_sdk.DeleteData(
         transfer_client,
         endpoint_id,
@@ -193,6 +189,10 @@ def delete_command(
         display(delete_data.data, response_key="DATA", fields=[Field("Path", "path")])
         # exit safely
         return
+
+    # attempt to activate unless --skip-activation-check is given
+    if not skip_activation_check:
+        autoactivate(transfer_client, endpoint_id, if_expires_in=60)
 
     res = transfer_client.submit_delete(delete_data)
     display(

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 
 import click
 
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import ENDPOINT_PLUS_OPTPATH, command
+from globus_cli.parsing import ENDPOINT_PLUS_OPTPATH, command, local_user_option
 from globus_cli.termio import Field, display, formatters, is_verbose, outformat_is_text
 
 
@@ -122,16 +123,18 @@ $ globus ls $ep_id:/share/godata/ --filter '~*.txt'  # done with --filter, bette
         "this should behave like a non-recursive `ls`"
     ),
 )
+@local_user_option
 @LoginManager.requires_login("transfer")
 def ls_command(
     *,
     login_manager: LoginManager,
-    endpoint_plus_path,
-    recursive_depth_limit,
-    recursive,
-    long_output,
-    show_hidden,
-    filter_val,
+    endpoint_plus_path: tuple[uuid.UUID, str | None],
+    recursive_depth_limit: int,
+    recursive: bool,
+    long_output: bool,
+    show_hidden: bool,
+    filter_val: str | None,
+    local_user: str | None,
 ):
     """
     List the contents of a directory on an endpoint. If no path is given, the default
@@ -180,6 +183,8 @@ def ls_command(
     ls_params: dict[str, t.Any] = {"show_hidden": int(show_hidden)}
     if path:
         ls_params["path"] = path
+    if local_user:
+        ls_params["local_user"] = local_user
 
     # this char has special meaning in the LS API's filter clause
     # can't be part of the pattern (but we don't support globbing across

--- a/src/globus_cli/commands/mkdir.py
+++ b/src/globus_cli/commands/mkdir.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
+import uuid
+
 import click
 
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command
+from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command, local_user_option
 from globus_cli.termio import TextMode, display
 
 
@@ -18,8 +22,14 @@ $ mkdir ep_id:~/testfolder
 """,
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
+@local_user_option
 @LoginManager.requires_login("transfer")
-def mkdir_command(*, login_manager: LoginManager, endpoint_plus_path):
+def mkdir_command(
+    *,
+    login_manager: LoginManager,
+    endpoint_plus_path: tuple[uuid.UUID, str],
+    local_user: str | None,
+):
     """Make a directory on an endpoint at the given path.
 
     {AUTOMATIC_ACTIVATION}
@@ -31,5 +41,5 @@ def mkdir_command(*, login_manager: LoginManager, endpoint_plus_path):
     transfer_client = login_manager.get_transfer_client()
     autoactivate(transfer_client, endpoint_id, if_expires_in=60)
 
-    res = transfer_client.operation_mkdir(endpoint_id, path=path)
+    res = transfer_client.operation_mkdir(endpoint_id, path=path, local_user=local_user)
     display(res, text_mode=TextMode.text_raw, response_key="message")

--- a/src/globus_cli/commands/rename.py
+++ b/src/globus_cli/commands/rename.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import click
 
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import command, endpoint_id_arg
+from globus_cli.parsing import command, endpoint_id_arg, local_user_option
 from globus_cli.termio import TextMode, display
 
 
@@ -20,8 +22,16 @@ $ globus rename $ep_id:~/tempdir $ep_id:~/project-foo
 @endpoint_id_arg
 @click.argument("source", metavar="SOURCE_PATH")
 @click.argument("destination", metavar="DEST_PATH")
+@local_user_option
 @LoginManager.requires_login("transfer")
-def rename_command(*, login_manager: LoginManager, endpoint_id, source, destination):
+def rename_command(
+    *,
+    login_manager: LoginManager,
+    endpoint_id: str,
+    source: str,
+    destination: str,
+    local_user: str | None,
+):
     """Rename a file or directory on an endpoint.
 
     The old path must be an existing file or directory. The new path must not yet
@@ -36,6 +46,6 @@ def rename_command(*, login_manager: LoginManager, endpoint_id, source, destinat
     autoactivate(transfer_client, endpoint_id, if_expires_in=60)
 
     res = transfer_client.operation_rename(
-        endpoint_id, oldpath=source, newpath=destination
+        endpoint_id, oldpath=source, newpath=destination, local_user=local_user
     )
     display(res, text_mode=TextMode.text_raw, response_key="message")

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import datetime
+import uuid
+
 import click
 import globus_sdk
 
@@ -6,6 +11,7 @@ from globus_cli.parsing import (
     ENDPOINT_PLUS_REQPATH,
     command,
     delete_and_rm_options,
+    local_user_option,
     synchronous_task_wait_options,
     task_submission_options,
 )
@@ -37,27 +43,29 @@ $ globus rm $ep_id:~/mydir --recursive
 @task_submission_options
 @delete_and_rm_options(supports_batch=False, default_enable_globs=True)
 @synchronous_task_wait_options
+@local_user_option
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
 @LoginManager.requires_login("transfer")
 def rm_command(
     *,
     login_manager: LoginManager,
-    ignore_missing,
-    star_silent,
-    recursive,
-    enable_globs,
-    endpoint_plus_path,
-    label,
-    submission_id,
-    dry_run,
-    deadline,
-    skip_activation_check,
-    notify,
-    meow,
-    heartbeat,
-    polling_interval,
-    timeout,
-    timeout_exit_code,
+    ignore_missing: bool,
+    star_silent: bool,
+    recursive: bool,
+    enable_globs: bool,
+    endpoint_plus_path: tuple[uuid.UUID, str],
+    label: str | None,
+    submission_id: str | None,
+    dry_run: bool,
+    deadline: datetime.datetime | None,
+    skip_activation_check: bool,
+    notify: dict[str, bool],
+    local_user: str | None,
+    meow: bool,
+    heartbeat: bool,
+    polling_interval: int,
+    timeout: int | None,
+    timeout_exit_code: int,
 ):
     """
     Submit a Delete Task to delete a single path, and then block and wait for it to
@@ -87,6 +95,7 @@ def rm_command(
         recursive=recursive,
         submission_id=submission_id,
         deadline=deadline,
+        local_user=local_user,
         additional_fields={
             "ignore_missing": ignore_missing,
             "skip_activation_check": skip_activation_check,
@@ -112,7 +121,7 @@ def rm_command(
     delete_data.add_item(path)
 
     if dry_run:
-        display(delete_data, response_key="DATA", fields=[Field("Path", "path")])
+        display(delete_data.data, response_key="DATA", fields=[Field("Path", "path")])
         # exit safely
         return
 

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -84,10 +84,6 @@ def rm_command(
 
     transfer_client = login_manager.get_transfer_client()
 
-    # attempt to activate unless --skip-activation-check is given
-    if not skip_activation_check:
-        autoactivate(transfer_client, endpoint_id, if_expires_in=60)
-
     delete_data = globus_sdk.DeleteData(
         transfer_client,
         endpoint_id,
@@ -124,6 +120,10 @@ def rm_command(
         display(delete_data.data, response_key="DATA", fields=[Field("Path", "path")])
         # exit safely
         return
+
+    # attempt to activate unless --skip-activation-check is given
+    if not skip_activation_check:
+        autoactivate(transfer_client, endpoint_id, if_expires_in=60)
 
     # Print task submission to stderr so that `-Fjson` is still correctly
     # respected, as it will be by `task wait`

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -192,6 +192,22 @@ fi
         "options having priority."
     ),
 )
+@click.option(
+    "--source-local-user",
+    help=(
+        "Optional value passed to the source's identity mapping specifying which local "
+        "user account to map to. Only usable with Globus Connect Server v5 mapped "
+        "collections."
+    ),
+)
+@click.option(
+    "--destination-local-user",
+    help=(
+        "Optional value passed to the destination's identity mapping specifying which "
+        "local user account to map to. Only usable with Globus Connect Server v5 "
+        "mapped collections."
+    ),
+)
 @click.option("--perf-cc", type=int, hidden=True)
 @click.option("--perf-p", type=int, hidden=True)
 @click.option("--perf-pp", type=int, hidden=True)
@@ -225,6 +241,8 @@ def transfer_command(
     perf_p: int | None,
     perf_pp: int | None,
     perf_udt: bool | None,
+    source_local_user: str | None,
+    destination_local_user: str | None,
 ) -> None:
     """
     Copy a file or directory from one endpoint to another as an asynchronous
@@ -353,6 +371,8 @@ def transfer_command(
         fail_on_quota_errors=fail_on_quota_errors,
         skip_activation_check=skip_activation_check,
         delete_destination_extra=delete,
+        source_local_user=source_local_user,
+        destination_local_user=destination_local_user,
         additional_fields={**perf_opts, **notify},
     )
 

--- a/src/globus_cli/parsing/__init__.py
+++ b/src/globus_cli/parsing/__init__.py
@@ -18,6 +18,7 @@ from .param_types import (
 )
 from .shared_options import (
     delete_and_rm_options,
+    local_user_option,
     no_local_server_option,
     security_principal_opts,
     synchronous_task_wait_options,
@@ -81,4 +82,5 @@ __all__ = [
     "skip_source_errors_option",
     "verify_checksum_option",
     "endpointish_params",
+    "local_user_option",
 ]

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -357,3 +357,17 @@ def no_local_server_option(f):
             "remote connection."
         ),
     )(f)
+
+
+def local_user_option(f: C) -> C:
+    """
+    Option for setting the mapped local user used across multiple Transfer commands
+    """
+    return click.option(
+        "--local-user",
+        help=(
+            "Optional value passed to identity mapping specifying which local user "
+            "account to map to. Only usable with Globus Connect Server v5 mapped "
+            "collections."
+        ),
+    )(f)

--- a/tests/files/api_fixtures/ls_results.yaml
+++ b/tests/files/api_fixtures/ls_results.yaml
@@ -257,3 +257,36 @@ transfer:
         "symlink_supported": true,
         "total": 1
       }
+  - path: /operation/endpoint/ddb59aef-6d04-11e5-ba46-22000b92c6ec/ls
+    query_params:
+      path: "/~/"
+      show_hidden: 0
+      local_user: "my-user"
+    json:
+      {
+        "DATA": [
+          {
+            "DATA_TYPE": "file",
+            "group": "root",
+            "last_modified": "2020-09-23 18:53:12+00:00",
+            "link_group": null,
+            "link_last_modified": null,
+            "link_size": null,
+            "link_target": null,
+            "link_user": null,
+            "name": "file1.txt",
+            "permissions": "0644",
+            "size": 4,
+            "type": "file",
+            "user": "my-user"
+          },
+        ],
+        "DATA_TYPE": "file_list",
+        "absolute_path": null,
+        "endpoint": "ddb59aef-6d04-11e5-ba46-22000b92c6ec",
+        "length": 1,
+        "path": "/~/",
+        "rename_supported": true,
+        "symlink_supported": true,
+        "total": 1
+      }

--- a/tests/files/api_fixtures/transfer_activate_success.yaml
+++ b/tests/files/api_fixtures/transfer_activate_success.yaml
@@ -1,6 +1,7 @@
 metadata:
   endpoint_id: "ddb59aef-6d04-11e5-ba46-22000b92c6ec"
   go_ep2_id: "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
+  sdk_endpoint_id: "00000000-0000-0000-0005-4925541e7725"
 
 
 transfer:
@@ -9,6 +10,10 @@ transfer:
     # exact data doesn't matter, just not the failure code
     json: {"code": "AutoActivated.BogusCode"}
   - path: /endpoint/ddb59af0-6d04-11e5-ba46-22000b92c6ec/autoactivate
+    method: post
+    # exact data doesn't matter, just not the failure code
+    json: {"code": "AutoActivated.BogusCode"}
+  - path: /endpoint/00000000-0000-0000-0005-4925541e7725/autoactivate
     method: post
     # exact data doesn't matter, just not the failure code
     json: {"code": "AutoActivated.BogusCode"}

--- a/tests/functional/task/test_task_submit.py
+++ b/tests/functional/task/test_task_submit.py
@@ -127,7 +127,6 @@ def test_delete_local_user(run_line, go_ep1_id):
     confirms --local-user is present in delete dry-run output
     """
     load_response_set("cli.get_submission_id")
-    load_response_set("cli.transfer_activate_success")
 
     result = run_line(
         f"globus delete -F json --dry-run -r --local-user my-user {go_ep1_id}:/"
@@ -142,7 +141,6 @@ def test_rm_local_user(run_line, go_ep1_id):
     confirms --local-user is present in rm dry-run output
     """
     load_response_set("cli.get_submission_id")
-    load_response_set("cli.transfer_activate_success")
 
     result = run_line(
         f"globus rm -F json --dry-run -r --local-user my-user {go_ep1_id}:/"

--- a/tests/functional/task/test_task_submit.py
+++ b/tests/functional/task/test_task_submit.py
@@ -102,3 +102,51 @@ def test_exlude_recursive_batch_file(run_line, go_ep1_id, go_ep2_id, tmp_path):
         "--include and --exclude can only be used with --recursive transfers"
         in result.stderr
     )
+
+
+def test_transfer_local_user_opts(run_line, go_ep1_id, go_ep2_id):
+    """
+    confirms --source-local-user and --destination-local-user are present in
+    transfer dry-run output
+    """
+    load_response_set("cli.get_submission_id")
+
+    result = run_line(
+        "globus transfer -F json --dry-run -r "
+        "--source-local-user src-user --destination-local-user dst-user "
+        f"{go_ep1_id}:/ {go_ep1_id}:/"
+    )
+
+    json_output = json.loads(result.output)
+    assert json_output["source_local_user"] == "src-user"
+    assert json_output["destination_local_user"] == "dst-user"
+
+
+def test_delete_local_user(run_line, go_ep1_id):
+    """
+    confirms --local-user is present in delete dry-run output
+    """
+    load_response_set("cli.get_submission_id")
+    load_response_set("cli.transfer_activate_success")
+
+    result = run_line(
+        f"globus delete -F json --dry-run -r --local-user my-user {go_ep1_id}:/"
+    )
+
+    json_output = json.loads(result.output)
+    assert json_output["local_user"] == "my-user"
+
+
+def test_rm_local_user(run_line, go_ep1_id):
+    """
+    confirms --local-user is present in rm dry-run output
+    """
+    load_response_set("cli.get_submission_id")
+    load_response_set("cli.transfer_activate_success")
+
+    result = run_line(
+        f"globus rm -F json --dry-run -r --local-user my-user {go_ep1_id}:/"
+    )
+
+    json_output = json.loads(result.output)
+    assert json_output["local_user"] == "my-user"

--- a/tests/functional/test_ls.py
+++ b/tests/functional/test_ls.py
@@ -56,3 +56,13 @@ def test_recursive_json(run_line, go_ep1_id):
     result = run_line(f"globus ls -r -F json {go_ep1_id}:/share")
     assert '"DATA":' in result.output
     assert '"name": "godata/file1.txt"' in result.output
+
+
+def test_local_user(run_line, go_ep1_id):
+    """
+    Confirms --local-user is passed to query params
+    """
+    load_response_set("cli.transfer_activate_success")
+    load_response_set("cli.ls_results")
+    result = run_line(f"globus ls {go_ep1_id}:/~/ -F json --local-user my-user")
+    assert '"user": "my-user"' in result.output

--- a/tests/functional/test_mkdir.py
+++ b/tests/functional/test_mkdir.py
@@ -1,0 +1,31 @@
+import json
+
+import globus_sdk
+from globus_sdk._testing import get_last_request, load_response, load_response_set
+
+
+def test_simple_mkdir_success(run_line):
+    """
+    Just confirm that args make it through the command successfully and we render the
+    message as output.
+    """
+    load_response_set("cli.transfer_activate_success")
+    meta = load_response(globus_sdk.TransferClient.operation_mkdir).metadata
+    endpoint_id = meta["endpoint_id"]
+
+    result = run_line(f"globus mkdir {endpoint_id}:foo/")
+    assert "The directory was created successfully" in result.output
+
+
+def test_local_user(run_line):
+    """
+    Confirms --local-user makes it to the request body
+    """
+    load_response_set("cli.transfer_activate_success")
+    meta = load_response(globus_sdk.TransferClient.operation_mkdir).metadata
+    endpoint_id = meta["endpoint_id"]
+
+    run_line(f"globus mkdir {endpoint_id}:foo/ --local-user my-user")
+
+    sent_data = json.loads(get_last_request().body)
+    assert sent_data["local_user"] == "my-user"

--- a/tests/functional/test_rename.py
+++ b/tests/functional/test_rename.py
@@ -1,4 +1,6 @@
-from globus_sdk._testing import load_response_set
+import json
+
+from globus_sdk._testing import get_last_request, load_response_set
 
 
 def test_simple_rename_success(run_line, go_ep1_id):
@@ -11,3 +13,16 @@ def test_simple_rename_success(run_line, go_ep1_id):
 
     result = run_line(f"globus rename {go_ep1_id} foo/bar /baz/buzz")
     assert "File or directory renamed successfully" in result.output
+
+
+def test_local_user(run_line, go_ep1_id):
+    """
+    Confirms --local-user makes it to the request body
+    """
+    load_response_set("cli.transfer_activate_success")
+    load_response_set("cli.rename_result")
+
+    run_line(f"globus rename {go_ep1_id} foo/bar /baz/buzz --local-user my-user")
+
+    sent_data = json.loads(get_last_request().body)
+    assert sent_data["local_user"] == "my-user"


### PR DESCRIPTION
For https://app.shortcut.com/globus/story/20504/cli-options-commands-to-support-choosing-local-user-for-data-access

Primary changes are the new `--local-user` options across several commands, and corresponding `--source-local-user` and `--destination-local-user` on `globus transfer`

I added type annotations to all the commands modified that were missing them, and found a small bug where `globus rm` was trying to output the full `DeleteData` object as `dry_run` output rather than `DeleteData.data`

I had mentioned that we might consider making these hidden options due to some GCS/Transfer error handling in some cases, per conversation with @ranantha  those cases aren't common enough to warrant hiding things here.