### PR TITLE
Improve error handling for a malformed `--batch`

### DIFF
--- a/changelog.d/20230606_233129_sirosen_fix_handling_bad_batch.md
+++ b/changelog.d/20230606_233129_sirosen_fix_handling_bad_batch.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Error reporting for parsing errors during `--batch` processing has been
+  improved to better indicate the source of the error

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -159,7 +159,7 @@ def delete_command(
             """
             delete_data.add_item(str(path))
 
-        utils.shlex_process_stream(process_batch_line, batch)
+        utils.shlex_process_stream(process_batch_line, batch, "--batch")
     else:
         if not star_silent and enable_globs and path.endswith("*"):
             # not intuitive, but `click.confirm(abort=True)` prints to stdout

--- a/src/globus_cli/services/transfer/data.py
+++ b/src/globus_cli/services/transfer/data.py
@@ -37,7 +37,7 @@ def add_batch_to_transfer_data(
             recursive=recursive,
         )
 
-    shlex_process_stream(process_batch_line, batch)
+    shlex_process_stream(process_batch_line, batch, "--batch")
 
 
 def display_name_or_cname(ep_doc: dict | globus_sdk.GlobusHTTPResponse) -> str:

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -174,8 +174,8 @@ def shlex_process_stream(
                     process_command.invoke(ctx)
             except click.ClickException as error:
                 click.echo(
-                    f"error encountered processing '{name}' at "
-                    f"{stream.name}:{lineno}:",
+                    f"error encountered processing '{name}' in "
+                    f"{stream.name} at line {lineno}:",
                     err=True,
                 )
                 click.echo(

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -147,7 +147,9 @@ class PagingWrapper:
         return converter
 
 
-def shlex_process_stream(process_command: click.Command, stream: t.TextIO) -> None:
+def shlex_process_stream(
+    process_command: click.Command, stream: t.TextIO, name: str
+) -> None:
     """
     Use shlex to process stdin line-by-line.
     Also prints help text.
@@ -161,14 +163,22 @@ def shlex_process_stream(process_command: click.Command, stream: t.TextIO) -> No
     # use readlines() rather than implicit file read line looping to force
     # python to properly capture EOF (otherwise, EOF acts as a flush and
     # things get weird)
-    for line in stream.readlines():
+    for lineno, line in enumerate(stream.readlines()):
         # get the argument vector:
         # do a shlex split to handle quoted paths with spaces in them
         # also lets us have comments with #
         argv = shlex.split(line, comments=True)
         if argv:
             try:
-                process_command.main(args=argv)
-            except SystemExit as e:
-                if e.code != 0:
-                    raise
+                with process_command.make_context(f"<process {name}>", argv) as ctx:
+                    process_command.invoke(ctx)
+            except click.ClickException as error:
+                click.echo(
+                    f"error encountered processing '{name}' at "
+                    f"{stream.name}:{lineno}:",
+                    err=True,
+                )
+                click.echo(
+                    click.style(f"  {error.format_message()}", fg="yellow"), err=True
+                )
+                click.get_current_context().exit(2)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,8 +1,12 @@
+import unittest.mock
+
+import click
 import pytest
 
 from globus_cli.utils import (
     format_list_of_words,
     format_plural_str,
+    shlex_process_stream,
     unquote_cmdprompt_single_quotes,
 )
 
@@ -38,3 +42,55 @@ def test_format_plural_str():
 )
 def test_unquote_cmdprompt_squote(arg, expect):
     assert unquote_cmdprompt_single_quotes(arg) == expect
+
+
+def test_shlex_process_stream_success():
+    @click.command
+    def outer_main():
+        pass
+
+    values = []
+
+    @click.command
+    @click.argument("bar")
+    def foo(bar):
+        values.append(bar)
+
+    text_like = unittest.mock.Mock()
+    text_like.readlines.return_value = ["alpha\n", "beta  # gamma\n"]
+    text_like.name = "alphabet.txt"
+
+    with outer_main.make_context("main", []):
+        shlex_process_stream(foo, text_like, "data")
+    assert values == ["alpha", "beta"]
+
+
+def test_shlex_process_stream_error_handling(capsys):
+    @click.command
+    def outer_main():
+        pass
+
+    values = []
+
+    @click.command
+    @click.argument("bar")
+    def foo(bar):
+        values.append(bar)
+
+    text_like = unittest.mock.Mock()
+    text_like.readlines.return_value = ["alpha beta\n"]
+    text_like.name = "alphabet.txt"
+
+    with pytest.raises(click.exceptions.Exit) as excinfo:
+        with outer_main.make_context("main", []):
+            shlex_process_stream(foo, text_like, "data")
+
+    assert excinfo.value.exit_code == 2
+    captured = capsys.readouterr()
+    assert (
+        """\
+error encountered processing 'data' at alphabet.txt:0:
+  Got unexpected extra argument (beta)
+"""
+        in captured.err
+    )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -89,7 +89,7 @@ def test_shlex_process_stream_error_handling(capsys):
     captured = capsys.readouterr()
     assert (
         """\
-error encountered processing 'data' at alphabet.txt:0:
+error encountered processing 'data' in alphabet.txt at line 0:
   Got unexpected extra argument (beta)
 """
         in captured.err

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -45,13 +45,13 @@ def test_unquote_cmdprompt_squote(arg, expect):
 
 
 def test_shlex_process_stream_success():
-    @click.command
+    @click.command()
     def outer_main():
         pass
 
     values = []
 
-    @click.command
+    @click.command()
     @click.argument("bar")
     def foo(bar):
         values.append(bar)
@@ -66,13 +66,13 @@ def test_shlex_process_stream_success():
 
 
 def test_shlex_process_stream_error_handling(capsys):
-    @click.command
+    @click.command()
     def outer_main():
         pass
 
     values = []
 
-    @click.command
+    @click.command()
     @click.argument("bar")
     def foo(bar):
         values.append(bar)


### PR DESCRIPTION
Batch input parsing via the shlex subcommand parsing method did not create a new click context and allowed the default `ClickException.show()` call in command execution to run. As a result, errors were rendered in a confusing way, showing 'globus' as the command name and showing the failed parse as belonging to it. This confuses the fact that this is a parse from an internal subcommand invocation.

To resolve, the following changes are made:
- shlex_process_stream now requires a new argument, the "name" to use for the parse in progress in case of failure
- Invocations are done by manually constructing the subcommand context and calling `invoke()`, rather than via `main()`. This gives us better control over failures
- Errors are explicitly caught, emitted in a custom format, and then converted to an `Exit(2)`

Tests for the above exercise the happy-path and sad-path cases and verify that the behavior fo shlex_process_stream itself is as expected.

Resolves #786

---

I also tested this manually. Here's an example error in the new code:
```
$ globus transfer --batch tmp.txt ddb59aef-6d04-11e5-ba46-22000b92c6ec ddb59af0-6d04-11e5-ba46-22000b92c6ec
error encountered processing '--batch' at tmp.txt:0:
  Got unexpected extra argument (bar.txt)
```
and the same prior to this change:
```
$ globus transfer --batch tmp.txt ddb59aef-6d04-11e5-ba46-22000b92c6ec ddb59af0-6d04-11e5-ba46-22000b92c6ec
Usage: globus [OPTIONS] SOURCE_PATH DEST_PATH
Try 'globus --help' for help.

Error: Got unexpected extra argument (bar.txt)
```

For context, the file contents are:
```
$ cat tmp.txt 
file1.txt foo.txt bar.txt
```