### PR TITLE
Expand annotation checking

### DIFF
--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+import typing as t
 import uuid
 
 import click
 
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import command, endpoint_id_arg
+from globus_cli.parsing import AnnotatedParamType, command, endpoint_id_arg
 from globus_cli.termio import TextMode, display
 
 
-class SubscriptionIdType(click.ParamType):
+class SubscriptionIdType(AnnotatedParamType):
+    def get_type_annotation(self, param: click.Parameter) -> type:
+        return t.cast(type, t.Union[str, None])
+
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
     ):
@@ -29,7 +33,7 @@ class SubscriptionIdType(click.ParamType):
 @click.argument("SUBSCRIPTION_ID", type=SubscriptionIdType())
 @LoginManager.requires_login("transfer")
 def set_endpoint_subscription_id(
-    *, login_manager: LoginManager, endpoint_id: str, subscription_id: str | None
+    *, login_manager: LoginManager, endpoint_id: uuid.UUID, subscription_id: str | None
 ) -> None:
     """
     Set an endpoint's subscription ID.

--- a/src/globus_cli/commands/rename.py
+++ b/src/globus_cli/commands/rename.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 import click
 
 from globus_cli.login_manager import LoginManager
@@ -27,7 +29,7 @@ $ globus rename $ep_id:~/tempdir $ep_id:~/project-foo
 def rename_command(
     *,
     login_manager: LoginManager,
-    endpoint_id: str,
+    endpoint_id: uuid.UUID,
     source: str,
     destination: str,
     local_user: str | None,

--- a/src/globus_cli/parsing/__init__.py
+++ b/src/globus_cli/parsing/__init__.py
@@ -4,6 +4,7 @@ from .param_classes import AnnotatedOption, one_use_option
 from .param_types import (
     ENDPOINT_PLUS_OPTPATH,
     ENDPOINT_PLUS_REQPATH,
+    AnnotatedParamType,
     CommaDelimitedList,
     IdentityType,
     JSONStringOrFile,
@@ -49,6 +50,7 @@ __all__ = [
     # param types
     "ENDPOINT_PLUS_OPTPATH",
     "ENDPOINT_PLUS_REQPATH",
+    "AnnotatedParamType",
     "CommaDelimitedList",
     "IdentityType",
     "JSONStringOrFile",

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -13,7 +13,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.collection.delete",
     "globus_cli.commands.collection.list",
     "globus_cli.commands.collection.show",
-    "globus_cli.commands.delete",
     "globus_cli.commands.endpoint.deactivate",
     "globus_cli.commands.endpoint.delete",
     "globus_cli.commands.endpoint.local_id",
@@ -39,10 +38,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.list_commands",
     "globus_cli.commands.login",
     "globus_cli.commands.logout",
-    "globus_cli.commands.ls",
-    "globus_cli.commands.mkdir",
-    "globus_cli.commands.rename",
-    "globus_cli.commands.rm",
 )
 
 _ALL_NON_GROUP_COMMANDS: tuple[click.Command, ...] = (

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -29,13 +29,11 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.server.list",
     "globus_cli.commands.endpoint.server.show",
     "globus_cli.commands.endpoint.server.update",
-    "globus_cli.commands.endpoint.set_subscription_id",
     "globus_cli.commands.endpoint.show",
     "globus_cli.commands.endpoint.storage_gateway.list",
     "globus_cli.commands.flows.list",
     "globus_cli.commands.flows.start",
     "globus_cli.commands.get_identities",
-    "globus_cli.commands.list_commands",
     "globus_cli.commands.login",
     "globus_cli.commands.logout",
 )


### PR DESCRIPTION
Recently a few more commands got annotated. Expand annotation checking to cover them.

I also made some minor changes to exported names from `globus_cli.parsing` to support this in `set-subscription-id`