### PR TITLE
Refine the release doc and tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,15 @@ reference:
 test:
 	tox
 
-.PHONY: showvars prepare-release release
+.PHONY: showvars prepare-release tag-release
 showvars:
 	@echo "CLI_VERSION=$(CLI_VERSION)"
 prepare-release:
 	tox -e prepare-release
 	$(EDITOR) changelog.adoc
-release:
+tag-release:
 	git tag -s "$(CLI_VERSION)" -m "v$(CLI_VERSION)"
-	tox -e publish-release
+	-git push $(shell git rev-parse --abbrev-ref @{push} | cut -d '/' -f1) refs/tags/$(CLI_VERSION)
 
 .PHONY: update-dependencies
 update-dependencies:

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -1,24 +1,23 @@
-Releasing a Version
--------------------
+= Releasing
 
-To perform a release, the following steps should be followed:
+== Prereqs
 
-Setup:
-
-  - Make sure you have a pypi account
-  - Setup your credentials for twine (the pypi upload tool)
-      https://github.com/pypa/twine[twine docs for detail]
   - Make sure you have a gpg key setup for use with git.
       https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work[git-scm.com guide for detail]
 
-Do it:
+== Procedure
 
-  - update the version in `src/globus_cli/version.py`
-  - `make prepare-release` to update version and changelog
-  - Add and commit the result with
-    `git commit -m 'Bump version and changelog for release'`
-  - `make release` to build dists, upload via twine, and tag the release
-  - push the newly created version tag to GitHub
+  - Make sure your repo is on `main` and up to date; `git checkout main; git pull`
+  - Read `changelog.d/` and decide if the release is MINOR or PATCH
+  - Update the version in `src/globus_cli/version.py`
+  - Update version and changelog; `make prepare-release`
+  - Add changed files;
+      `git add changelog.d/ changelog.adoc src/globus_cli/version.py`
+  - Commit; `git commit -m 'Bump version and changelog for release'`
+  - Push to main; `git push origin main`
+  - Tag the release; `make tag-release`
+      _This will run a workflow to publish to test-pypi_
   - Create a GitHub release with a copy of the changelog
+      _This will run a workflow to publish to pypi_
   - Ensure that `docs.globus.org` gets updated with new docs/changelog
       Procedure is set in that repo.

--- a/changelog.d/post-fix-changelog.py
+++ b/changelog.d/post-fix-changelog.py
@@ -8,7 +8,11 @@ import argparse
 import re
 
 MD_H1_PATTERN = re.compile(r"^(#) (.+)$", re.MULTILINE)
+MD_H2_PATTERN = re.compile(r"^(##) (.+)$", re.MULTILINE)
 MD_H3_PATTERN = re.compile(r"^(###) (.+)$", re.MULTILINE)
+SCRIV_LINK_PATTERN = re.compile(
+    r"\n<a id='changelog\-\d+\.\d+\.\d+'></a>\n", re.MULTILINE
+)
 
 
 def process_file(filename):
@@ -16,7 +20,8 @@ def process_file(filename):
         content = f.read()
 
     content = MD_H1_PATTERN.sub(r"== \2", content)
-    content = MD_H3_PATTERN.sub(r"\2:", content)
+    content = MD_H2_PATTERN.sub(r"\2:", content)
+    content = SCRIV_LINK_PATTERN.sub("\n", content)
 
     with open(filename, "w") as f:
         f.write(content)
@@ -28,6 +33,9 @@ def main():
     )
     parser.add_argument("FILES", nargs="*")
     args = parser.parse_args()
+
+    if not args.FILES:
+        process_file("changelog.adoc")
 
     for filename in args.FILES:
         process_file(filename)


### PR DESCRIPTION
- Release doc has been updated to show the current requirements and procedures for doing a release
- `make release` is replaced with `make tag-release`
- `make tag-release` pushes the tag (same as globus-sdk)
- Fixes to the changelog fixer, including removal of the scriv links
- Make the changelog fixer target `changelog.adoc` when run with no args