### PR TITLE
Allow the --public flag on GCP via 'endpoint update' and 'gcp create mapped'

### DIFF
--- a/changelog.d/20230620_101149_sirosen_allow_public_flag_on_gcp.md
+++ b/changelog.d/20230620_101149_sirosen_allow_public_flag_on_gcp.md
@@ -1,3 +1,8 @@
+### Enhancements
+
+* `globus gcp create mapped` now has an option `--public` for creating public
+  GCP Mapped Collections
+
 ### Bugfixes
 
 * `globus endpoint create` and `globus endpoint update` now allow the use of

--- a/changelog.d/20230620_101149_sirosen_allow_public_flag_on_gcp.md
+++ b/changelog.d/20230620_101149_sirosen_allow_public_flag_on_gcp.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* `globus endpoint create` and `globus endpoint update` now allow the use of
+  `--public/--private` with GCP Mapped Collections

--- a/src/globus_cli/commands/endpoint/_common.py
+++ b/src/globus_cli/commands/endpoint/_common.py
@@ -22,14 +22,8 @@ def validate_endpoint_create_and_update_params(
     """
     # options only allowed for GCSv4 endpoints
     if entity_type != EntityType.GCSV4_HOST:
-        # catch params with two option flags
-        if params.get("public") is False:
-            raise click.UsageError(
-                "Option --private only allowed for Globus Connect Server endpoints"
-            )
         # catch any params only usable with GCS
         for option in [
-            "public",
             "myproxy_dn",
             "myproxy_server",
             "oauth_server",

--- a/src/globus_cli/commands/gcp/create/mapped.py
+++ b/src/globus_cli/commands/gcp/create/mapped.py
@@ -16,6 +16,7 @@ from ._common import deprecated_verify_option
     "--subscription-id",
     help="Set the collection as managed with the given subscription ID",
 )
+@click.option("--public", is_flag=True, help="Set the collection to be public.")
 @deprecated_verify_option
 @LoginManager.requires_login("transfer")
 def mapped_command(
@@ -36,6 +37,7 @@ def mapped_command(
     disable_verify: bool | None,
     user_message: str | None | ExplicitNullType,
     user_message_link: str | None | ExplicitNullType,
+    public: bool,
 ) -> None:
     """
     Create a new Globus Connect Personal Mapped Collection.
@@ -69,6 +71,7 @@ def mapped_command(
         default_directory=default_directory,
         force_encryption=force_encryption,
         subscription_id=subscription_id,
+        public=public,
         user_message=user_message,
         user_message_link=user_message_link,
         **verify,

--- a/tests/functional/endpoint/test_endpoint_create.py
+++ b/tests/functional/endpoint/test_endpoint_create.py
@@ -2,8 +2,7 @@ import json
 import re
 
 import pytest
-import responses
-from globus_sdk._testing import load_response_set
+from globus_sdk._testing import get_last_request, load_response_set
 
 
 def test_gcp_creation(run_line):
@@ -122,6 +121,7 @@ def test_general_options(run_line, ep_type, type_opts, go_ep1_id):
             "val": None,
             "expected": True,
         },
+        {"opt": "--private", "key": "public", "val": "", "expected": False},
     ]
     if ep_type == "server":
         option_dicts.extend(
@@ -132,7 +132,6 @@ def test_general_options(run_line, ep_type, type_opts, go_ep1_id):
                     "key": "myproxy_server",
                     "val": "srv.example.com",
                 },
-                {"opt": "--private", "key": "public", "val": "", "expected": False},
                 {
                     "opt": "--location",
                     "key": "location",
@@ -156,7 +155,7 @@ def test_general_options(run_line, ep_type, type_opts, go_ep1_id):
     run_line(" ".join(line))
 
     # get and confirm values which were sent as JSON
-    sent_data = json.loads(responses.calls[-1].request.body)
+    sent_data = json.loads(get_last_request().body)
     for item in option_dicts:
         assert item["expected"] == sent_data[item["key"]]
 
@@ -174,8 +173,6 @@ def test_invalid_gcs_only_options(run_line, ep_type, type_opts, go_ep1_id):
     Confirms invalid options are caught at the CLI level rather than API
     """
     options = [
-        "--public",
-        "--private",
         "--myproxy-dn /dn",
         "--myproxy-server mpsrv.example.com",
         "--oauth-server oasrv.example.com",

--- a/tests/functional/endpoint/test_endpoint_update.py
+++ b/tests/functional/endpoint/test_endpoint_update.py
@@ -2,8 +2,7 @@ import json
 import uuid
 
 import pytest
-import responses
-from globus_sdk._testing import load_response_set
+from globus_sdk._testing import get_last_request, load_response_set
 
 # options with option value and expected value
 # if expected value is not set, it will be copied from the option value
@@ -118,7 +117,7 @@ for optdict in _OPTION_DICTS.values():
                 "location",
             ],
         ),
-        ("personal", ["display_name", "description", "null_default_dir"]),
+        ("personal", ["private", "display_name", "description", "null_default_dir"]),
     ],
 )
 def test_general_options(run_line, ep_type, options):
@@ -145,7 +144,7 @@ def test_general_options(run_line, ep_type, options):
     run_line(line)
 
     # get and confirm values which were sent as JSON
-    sent_data = json.loads(responses.calls[-1].request.body)
+    sent_data = json.loads(get_last_request().body)
     for item in option_dicts:
         assert item["expected"] == sent_data[item["key"]]
 
@@ -164,8 +163,6 @@ def test_invalid_gcs_only_options(run_line, ep_type):
     else:
         raise NotImplementedError
     options = [
-        "--public",
-        "--private",
         "--myproxy-dn /dn",
         "--myproxy-server mpsrv.example.com",
         "--oauth-server oasrv.example.com",


### PR DESCRIPTION
Primarily, this change is removing the restriction that forbids the use of `--public/--private` on GCP host endpoints and updating tests to match the behavior.

A new feature is included in that `globus gcp create mapped` did not have a `--public/--private` option, so it now has a `--public` option only (the default is private).

## Changelog

### Enhancements

* `globus gcp create mapped` now has an option `--public` for creating public GCP Mapped Collections

### Bugfixes

* `globus endpoint create` and `globus endpoint update` now allow the use of `--public/--private` with GCP Mapped Collections