### PR TITLE
Remove `cryptography` upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         # these are dependencies of the SDK, but they are used directly in the CLI
         # declare them here in case the underlying lib ever changes
         "requests>=2.19.1,<3.0.0",
-        "cryptography>=3.3.1,<37",
+        "cryptography>=3.3.1",
         # depend on the latest version of typing-extensions on python versions which do
         # not have all of the typing features we use
         'typing_extensions>=4.0;python_version<"3.11"',


### PR DESCRIPTION
Prompted by #806, we don't need to be capping `cryptography` anymore (and besides, our upper bound is out of date).

I don't think this belongs in the more widely distributed changelog, so I'll update that issue to make sure @xylar is informed directly when we do our next release.