### PR TITLE
Rewrite the test output matching utilities to be simpler to use

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -291,8 +291,13 @@ network calls recorded:
 
 
 def _assert_matches(text, text_name, match):
-    if isinstance(match, str) or isinstance(match, re.Pattern):
+    if isinstance(match, (str, re.Pattern, tuple)):
         match = [match]
+    elif not isinstance(match, list):
+        raise NotImplementedError(
+            "match_{out,err} got unexpected arg type: {type(match)}"
+        )
+
     match = [_convert_match_tuple(m) for m in match]
 
     compiled_matches = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,36 +199,6 @@ def cli_runner():
     return CliRunner(mix_stderr=False)
 
 
-class OutputMatcher:
-    r"""
-    A helper for running regex matches and optionally doing literal checking of match
-    groups against expected strings. This can be attached to run_line by passing
-    "matcher=True".
-
-    Runs regex matches in multiline mode, operating on the first match.
-    If no match is found, it will raise an error.
-
-    Usage:
-
-    >>> res, matcher = run_line(..., matcher=True)
-    >>> matcher.check(r"^Foo:\s+(\w+)$", groups=["FooValue"])
-    """
-
-    def __init__(self, result):
-        self._result = result
-
-    def check(self, regex, groups=None, err=False) -> None:
-        pattern = re.compile(regex, flags=re.MULTILINE)
-        groups = groups or []
-        data = self._result.stderr if err else self._result.output
-
-        m = pattern.search(data)
-        if not m:
-            raise ValueError(f"Did not find a match for '{regex}' in {data}")
-        for i, x in enumerate(groups, 1):
-            assert m.group(i) == x
-
-
 @pytest.fixture
 def run_line(cli_runner, request, patch_tokenstorage):
     """
@@ -245,7 +215,6 @@ def run_line(cli_runner, request, patch_tokenstorage):
         stdin=None,
         match_out=None,
         match_err=None,
-        matcher=False,
     ):
         from globus_cli import main
 
@@ -283,8 +252,6 @@ network calls recorded:
             _assert_matches(result.stdout, "stdout", match_out)
         if match_err is not None:
             _assert_matches(result.stderr, "stderr", match_err)
-        if matcher:
-            return result, OutputMatcher(result)
         return result
 
     return func

--- a/tests/functional/collection/test_collection_show.py
+++ b/tests/functional/collection/test_collection_show.py
@@ -11,7 +11,7 @@ def test_collection_show(run_line, add_gcs_login):
 
     run_line(
         f"globus collection show {cid}",
-        match_out=[
+        search_stdout=[
             ("Display Name", "Happy Fun Collection Name"),
             ("Owner", username),
             ("ID", cid),
@@ -30,7 +30,7 @@ def test_collection_show_private_policies(run_line, add_gcs_login):
 
     run_line(
         f"globus collection show --include-private-policies {cid}",
-        match_out=[
+        search_stdout=[
             ("Display Name", "Happy Fun Collection Name"),
             ("Owner", username),
             ("ID", cid),

--- a/tests/functional/collection/test_collection_show.py
+++ b/tests/functional/collection/test_collection_show.py
@@ -9,13 +9,16 @@ def test_collection_show(run_line, add_gcs_login):
     epid = meta["endpoint_id"]
     add_gcs_login(epid)
 
-    _result, matcher = run_line(f"globus collection show {cid}", matcher=True)
-
-    matcher.check(r"^Display Name:\s+(.*)$", groups=["Happy Fun Collection Name"])
-    matcher.check(r"^Owner:\s+(.*)$", groups=[username])
-    matcher.check(r"^ID:\s+(.*)$", groups=[cid])
-    matcher.check(r"^Collection Type:\s+(.*)$", groups=["mapped"])
-    matcher.check(r"^Connector:\s+(.*)$", groups=["POSIX"])
+    run_line(
+        f"globus collection show {cid}",
+        match_out=[
+            ("Display Name", "Happy Fun Collection Name"),
+            ("Owner", username),
+            ("ID", cid),
+            ("Collection Type", "mapped"),
+            ("Connector", "POSIX"),
+        ],
+    )
 
 
 def test_collection_show_private_policies(run_line, add_gcs_login):
@@ -25,21 +28,19 @@ def test_collection_show_private_policies(run_line, add_gcs_login):
     epid = meta["endpoint_id"]
     add_gcs_login(epid)
 
-    _result, matcher = run_line(
-        f"globus collection show --include-private-policies {cid}", matcher=True
-    )
-
-    matcher.check(r"^Display Name:\s+(.*)$", groups=["Happy Fun Collection Name"])
-    matcher.check(r"^Owner:\s+(.*)$", groups=[username])
-    matcher.check(r"^ID:\s+(.*)$", groups=[cid])
-    matcher.check(r"^Collection Type:\s+(.*)$", groups=["mapped"])
-    matcher.check(r"^Connector:\s+(.*)$", groups=["POSIX"])
-
-    matcher.check(r"Root Path:\s+(.*)$", groups=["/"])
-    matcher.check(
-        r"^Sharing Path Restrictions:\s+(.*)$",
-        groups=[
-            '{"DATA_TYPE": "path_restrictions#1.0.0", "none": ["/"], "read": ["/projects"], "read_write": ["$HOME"]}',  # noqa: E501
+    run_line(
+        f"globus collection show --include-private-policies {cid}",
+        match_out=[
+            ("Display Name", "Happy Fun Collection Name"),
+            ("Owner", username),
+            ("ID", cid),
+            ("Collection Type", "mapped"),
+            ("Connector", "POSIX"),
+            ("Root Path", "/"),
+            (
+                "Sharing Path Restrictions",
+                '{"DATA_TYPE": "path_restrictions#1.0.0", "none": ["/"], "read": ["/projects"], "read_write": ["$HOME"]}',  # noqa: E501
+            ),
         ],
     )
 

--- a/tests/functional/search/test_errors.py
+++ b/tests/functional/search/test_errors.py
@@ -10,7 +10,7 @@ def test_notfound_error(run_line):
     run_line(
         ["globus", "search", "query", index_id, "-q", "*"],
         assert_exit_code=1,
-        match_err=[
+        search_stderr=[
             ("code", "NotFound.NoSuchIndex"),
             f'There is no search index named "{index_id}"',
         ],
@@ -40,7 +40,7 @@ def test_validation_error(run_line, tmp_path):
     run_line(
         ["globus", "search", "ingest", index_id, str(doc)],
         assert_exit_code=1,
-        match_err=[
+        search_stderr=[
             ("code", "BadRequest.ValidationError"),
             "Missing data for required field.",
         ],

--- a/tests/functional/search/test_errors.py
+++ b/tests/functional/search/test_errors.py
@@ -7,13 +7,14 @@ def test_notfound_error(run_line):
     meta = load_response_set("cli.search").metadata
     index_id = meta["error_index_id"]
 
-    result, matcher = run_line(
+    run_line(
         ["globus", "search", "query", index_id, "-q", "*"],
         assert_exit_code=1,
-        matcher=True,
+        match_err=[
+            ("code", "NotFound.NoSuchIndex"),
+            f'There is no search index named "{index_id}"',
+        ],
     )
-    matcher.check(r"^code:\s+([\w\.]+)$", groups=["NotFound.NoSuchIndex"], err=True)
-    assert f'There is no search index named "{index_id}"' in result.stderr
 
 
 def test_validation_error(run_line, tmp_path):
@@ -36,13 +37,11 @@ def test_validation_error(run_line, tmp_path):
     doc = tmp_path / "doc.json"
     doc.write_text(json.dumps(data))
 
-    result, matcher = run_line(
+    run_line(
         ["globus", "search", "ingest", index_id, str(doc)],
         assert_exit_code=1,
-        matcher=True,
+        match_err=[
+            ("code", "BadRequest.ValidationError"),
+            "Missing data for required field.",
+        ],
     )
-    matcher.check(
-        r"^code:\s+([\w\.]+)$", groups=["BadRequest.ValidationError"], err=True
-    )
-    matcher.check(r"^location:\s+(\w+)$", groups=["json"], err=True)
-    assert "Missing data for required field" in result.stderr

--- a/tests/functional/search/test_index.py
+++ b/tests/functional/search/test_index.py
@@ -1,3 +1,5 @@
+import re
+
 from globus_sdk._testing import load_response_set
 
 
@@ -21,17 +23,17 @@ def test_index_show(run_line):
     meta = load_response_set("cli.search").metadata
     index_id = meta["index_id"]
 
-    result, matcher = run_line(
-        ["globus", "search", "index", "show", index_id], matcher=True
+    run_line(
+        ["globus", "search", "index", "show", index_id],
+        match_out=("Index ID", index_id),
     )
-    matcher.check(r"^Index ID:\s+([\w-]+)$", groups=[index_id])
 
 
 def test_index_create(run_line):
     meta = load_response_set("cli.search").metadata
     index_id = meta["index_id"]
 
-    result, matcher = run_line(
+    run_line(
         [
             "globus",
             "search",
@@ -40,14 +42,15 @@ def test_index_create(run_line):
             "example_cookery",
             "Example index of Cookery",
         ],
-        matcher=True,
+        match_out=("Index ID", index_id),
     )
-    matcher.check(r"^Index ID:\s+([\w-]+)$", groups=[index_id])
 
 
 def test_index_delete(run_line):
     meta = load_response_set("cli.search").metadata
     index_id = meta["index_id"]
 
-    result = run_line(f"globus search index delete {index_id}")
-    assert f"Index {index_id} is now marked for deletion." in result.output
+    run_line(
+        f"globus search index delete {index_id}",
+        match_out=f"Index {re.escape(index_id)} is now marked for deletion.",
+    )

--- a/tests/functional/search/test_index.py
+++ b/tests/functional/search/test_index.py
@@ -1,5 +1,3 @@
-import re
-
 from globus_sdk._testing import load_response_set
 
 
@@ -25,7 +23,7 @@ def test_index_show(run_line):
 
     run_line(
         ["globus", "search", "index", "show", index_id],
-        match_out=("Index ID", index_id),
+        search_stdout=("Index ID", index_id),
     )
 
 
@@ -42,7 +40,7 @@ def test_index_create(run_line):
             "example_cookery",
             "Example index of Cookery",
         ],
-        match_out=("Index ID", index_id),
+        search_stdout=("Index ID", index_id),
     )
 
 
@@ -52,5 +50,5 @@ def test_index_delete(run_line):
 
     run_line(
         f"globus search index delete {index_id}",
-        match_out=f"Index {re.escape(index_id)} is now marked for deletion.",
+        search_stdout=f"Index {index_id} is now marked for deletion.",
     )

--- a/tests/functional/search/test_ingest.py
+++ b/tests/functional/search/test_ingest.py
@@ -50,7 +50,7 @@ def test_gingest_document(run_line, tmp_path, datatype_field, search_ingest_resp
 
     run_line(
         ["globus", "search", "ingest", index_id, str(doc)],
-        match_out=[
+        search_stdout=[
             ("Acknowledged", "True"),
             ("Task ID", task_id),
         ],
@@ -86,7 +86,7 @@ def test_auto_wrap_document(run_line, tmp_path, datatype, search_ingest_response
 
     run_line(
         ["globus", "search", "ingest", index_id, str(doc)],
-        match_out=[
+        search_stdout=[
             ("Acknowledged", "True"),
             ("Task ID", task_id),
         ],
@@ -113,7 +113,7 @@ def test_auto_wrap_document_rejects_bad_doctype(
     run_line(
         ["globus", "search", "ingest", index_id, str(doc)],
         assert_exit_code=2,
-        match_err="Unsupported datatype: 'NoSuchDocumentType'",
+        search_stderr="Unsupported datatype: 'NoSuchDocumentType'",
     )
 
 
@@ -127,5 +127,5 @@ def test_ingest_rejects_non_object_data(run_line, tmp_path, search_ingest_respon
     run_line(
         ["globus", "search", "ingest", index_id, str(doc)],
         assert_exit_code=2,
-        match_err="Ingest document must be a JSON object",
+        search_stderr="Ingest document must be a JSON object",
     )

--- a/tests/functional/search/test_ingest.py
+++ b/tests/functional/search/test_ingest.py
@@ -1,14 +1,36 @@
 import json
+import uuid
 
 import pytest
 import responses
-from globus_sdk._testing import load_response_set
+from globus_sdk._testing import RegisteredResponse, load_response
+
+
+@pytest.fixture
+def search_ingest_response():
+    task_id = str(uuid.uuid1())
+    index_id = str(uuid.uuid1())
+    return load_response(
+        RegisteredResponse(
+            service="search",
+            path=f"/v1/index/{index_id}/ingest",
+            method="POST",
+            json={
+                "acknowledged": True,
+                "task_id": task_id,
+            },
+            metadata={
+                "index_id": index_id,
+                "task_id": task_id,
+            },
+        )
+    )
 
 
 @pytest.mark.parametrize("datatype_field", [None, "GIngest"])
-def test_gingest_document(run_line, tmp_path, datatype_field):
-    meta = load_response_set("cli.search").metadata
-    index_id = meta["index_id"]
+def test_gingest_document(run_line, tmp_path, datatype_field, search_ingest_response):
+    index_id = search_ingest_response.metadata["index_id"]
+    task_id = search_ingest_response.metadata["task_id"]
 
     data = {
         "ingest_type": "GMetaEntry",
@@ -26,11 +48,13 @@ def test_gingest_document(run_line, tmp_path, datatype_field):
     doc = tmp_path / "doc.json"
     doc.write_text(json.dumps(data))
 
-    result, matcher = run_line(
-        ["globus", "search", "ingest", index_id, str(doc)], matcher=True
+    run_line(
+        ["globus", "search", "ingest", index_id, str(doc)],
+        match_out=[
+            ("Acknowledged", "True"),
+            ("Task ID", task_id),
+        ],
     )
-    matcher.check(r"^Acknowledged:\s+(\w+)$", groups=["True"])
-    matcher.check(r"^Task ID:\s+([\w-]+)$")
 
     sent = responses.calls[-1].request
     assert sent.method == "POST"
@@ -39,9 +63,9 @@ def test_gingest_document(run_line, tmp_path, datatype_field):
 
 
 @pytest.mark.parametrize("datatype", ["GMetaEntry", "GMetaList"])
-def test_auto_wrap_document(run_line, tmp_path, datatype):
-    meta = load_response_set("cli.search").metadata
-    index_id = meta["index_id"]
+def test_auto_wrap_document(run_line, tmp_path, datatype, search_ingest_response):
+    index_id = search_ingest_response.metadata["index_id"]
+    task_id = search_ingest_response.metadata["task_id"]
 
     entry_data = {
         "@datatype": "GMetaEntry",
@@ -60,11 +84,13 @@ def test_auto_wrap_document(run_line, tmp_path, datatype):
     doc = tmp_path / "doc.json"
     doc.write_text(json.dumps(data))
 
-    result, matcher = run_line(
-        ["globus", "search", "ingest", index_id, str(doc)], matcher=True
+    run_line(
+        ["globus", "search", "ingest", index_id, str(doc)],
+        match_out=[
+            ("Acknowledged", "True"),
+            ("Task ID", task_id),
+        ],
     )
-    matcher.check(r"^Acknowledged:\s+(\w+)$", groups=["True"])
-    matcher.check(r"^Task ID:\s+([\w-]+)$")
 
     sent = responses.calls[-1].request
     assert sent.method == "POST"
@@ -74,30 +100,32 @@ def test_auto_wrap_document(run_line, tmp_path, datatype):
     assert sent_body["ingest_data"] == data
 
 
-def test_auto_wrap_document_rejects_bad_doctype(run_line, tmp_path):
-    meta = load_response_set("cli.search").metadata
-    index_id = meta["index_id"]
+def test_auto_wrap_document_rejects_bad_doctype(
+    run_line, tmp_path, search_ingest_response
+):
+    index_id = search_ingest_response.metadata["index_id"]
 
     data = {"@datatype": "NoSuchDocumentType"}
 
     doc = tmp_path / "doc.json"
     doc.write_text(json.dumps(data))
 
-    result = run_line(
-        ["globus", "search", "ingest", index_id, str(doc)], assert_exit_code=2
+    run_line(
+        ["globus", "search", "ingest", index_id, str(doc)],
+        assert_exit_code=2,
+        match_err="Unsupported datatype: 'NoSuchDocumentType'",
     )
-    assert "Unsupported datatype: 'NoSuchDocumentType'" in result.stderr
 
 
-def test_ingest_rejects_non_object_data(run_line, tmp_path):
-    meta = load_response_set("cli.search").metadata
-    index_id = meta["index_id"]
+def test_ingest_rejects_non_object_data(run_line, tmp_path, search_ingest_response):
+    index_id = search_ingest_response.metadata["index_id"]
 
     data = ["foo", "bar"]
     doc = tmp_path / "doc.json"
     doc.write_text(json.dumps(data))
 
-    result = run_line(
-        ["globus", "search", "ingest", index_id, str(doc)], assert_exit_code=2
+    run_line(
+        ["globus", "search", "ingest", index_id, str(doc)],
+        assert_exit_code=2,
+        match_err="Ingest document must be a JSON object",
     )
-    assert "Ingest document must be a JSON object" in result.stderr


### PR DESCRIPTION
The overall goal here was to replace `matcher=True` (which changes the return type and produces an `OutputMatcher`. Awkward!) with something that feels more similar to the `match=...` behavior in `pytest.raises` and `pytest.warns`, in which you pass a regex.

I encourage commit-by-commit reading for this PR.
The commits are done in small units to show the evolution of a replacement in which `run_line` now accepts `match_out=...` and `match_err=...` for regex matching.
First the new helpers are introduced, then rolled out across the tests, and then finally `OutputMatcher` is dropped and the new helpers are refined a little.

I've included a bit of a "bonus" feature here which is particularly helpful for us. `match_out=("Foo", "bar")` is allowed as a shorthand for the regex which matches `^Foo:\s+bar$`. That aligns well with our colon-delimited output.

I couldn't find a better way to capture pytest verbosity than recording it during `pytest_configure`, but I'm open to refining that more.