### PR TITLE
Apply annotation checking to 'endpoint server add'

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -146,9 +146,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.server._common]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.endpoint.server.add]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.server.delete]
 disallow_untyped_defs = false
 

--- a/src/globus_cli/commands/endpoint/server/_common.py
+++ b/src/globus_cli/commands/endpoint/server/_common.py
@@ -5,6 +5,9 @@ import typing as t
 
 import click
 
+from globus_cli.parsing import AnnotatedOption
+from globus_cli.types import TupleType
+
 
 def server_id_arg(f):
     return click.argument("server_id")(f)
@@ -93,6 +96,14 @@ def server_add_and_update_opts(f: t.Callable | None = None, *, add=False):
         f = click.option(
             f"--{adjective}-data-ports",
             callback=port_range_callback,
+            cls=AnnotatedOption,
+            # mypy flags this as an unexpected number of arguments to a TypeAlias, but
+            # TupleType aliases t.Tuple/tuple which is variadic
+            # TypeVarTuple will make this more possible to support, but it's
+            # "experimental" in mypy at this time
+            type_annotation=TupleType[  # type: ignore[type-arg]
+                t.Optional[int], t.Optional[int]
+            ],
             help="Indicate to firewall administrators at other sites how to "
             "allow {} traffic {} this server {} their own. Specify as "
             "either 'unspecified', 'unrestricted', or as range of "

--- a/src/globus_cli/commands/endpoint/server/add.py
+++ b/src/globus_cli/commands/endpoint/server/add.py
@@ -1,8 +1,18 @@
+from __future__ import annotations
+
+import sys
+import uuid
+
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import TextMode, display
 
 from ._common import server_add_and_update_opts
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @command(
@@ -23,14 +33,14 @@ $ globus endpoint server add $ep_id --hostname gridftp.example.org
 def server_add(
     *,
     login_manager: LoginManager,
-    endpoint_id,
-    subject,
-    port,
-    scheme,
-    hostname,
-    incoming_data_ports,
-    outgoing_data_ports,
-):
+    endpoint_id: uuid.UUID,
+    subject: str | None,
+    port: int,
+    scheme: Literal["gsiftp", "ftp"],
+    hostname: str,
+    incoming_data_ports: tuple[int | None, int | None],
+    outgoing_data_ports: tuple[int | None, int | None],
+) -> None:
     """
     Add a server to an endpoint.
 

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -23,7 +23,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.permission.update",
     "globus_cli.commands.endpoint.role.create",
     "globus_cli.commands.endpoint.search",
-    "globus_cli.commands.endpoint.server.add",
     "globus_cli.commands.endpoint.server.delete",
     "globus_cli.commands.endpoint.server.list",
     "globus_cli.commands.endpoint.server.show",

--- a/tox.ini
+++ b/tox.ini
@@ -64,8 +64,8 @@ base_python =
    python3.11
    python3.10
 deps =
-    click==8.1.3
-    mypy==1.3.0
+    click
+    mypy
     types-jwt
     types-requests
     types-jmespath


### PR DESCRIPTION
I came in to do some cleanup and resume the slow tide of updates needed to get our type checking "clean".

- Remove this module from the mypy.ini exemptions
- Remove the module from click type checking exemptions
- Update `tox.ini` to have unpinned `click` and latest `mypy`
- Update types to pass, including the addition of an AnnotatedOption usage for one of the `endpoint server` options