### PR TITLE
Implement first version of 'flows run resume'

### DIFF
--- a/changelog.d/20230719_160535_sirosen_implement_run_resume.md
+++ b/changelog.d/20230719_160535_sirosen_implement_run_resume.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add `globus flows run resume` for resuming a *run* of a *flow*

--- a/src/globus_cli/commands/flows/run/__init__.py
+++ b/src/globus_cli/commands/flows/run/__init__.py
@@ -7,6 +7,7 @@ from globus_cli.parsing import group
         "show": (".show", "show_command"),
         "update": (".update", "update_command"),
         "delete": (".delete", "delete_command"),
+        "resume": (".resume", "resume_command"),
     },
 )
 def run_command() -> None:

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import uuid
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command, run_id_arg
+from globus_cli.termio import Field, TextMode, display, formatters
+
+
+@command("resume")
+@run_id_arg
+@LoginManager.requires_login("flows")
+def resume_command(login_manager: LoginManager, run_id: uuid.UUID) -> None:
+    """
+    Resume a run
+    """
+    flows_client = login_manager.get_flows_client()
+    run_doc = flows_client.get_run(run_id)
+    flow_id = run_doc["flow_id"]
+
+    specific_flow_client = login_manager.get_specific_flow_client(flow_id)
+
+    fields = [
+        Field("Run ID", "run_id"),
+        Field("Flow ID", "flow_id"),
+        Field("Flow Title", "flow_title"),
+        Field("Status", "status"),
+        Field("Run Label", "label"),
+        Field("Run Tags", "tags", formatter=formatters.Array),
+        Field("Started At", "start_time", formatter=formatters.Date),
+    ]
+
+    res = specific_flow_client.resume_run(run_id)
+    display(res, fields=fields, text_mode=TextMode.text_record)

--- a/tests/functional/flows/test_resume_run.py
+++ b/tests/functional/flows/test_resume_run.py
@@ -1,0 +1,44 @@
+from globus_sdk._testing import RegisteredResponse, load_response
+
+
+def test_resume_run_text_output(run_line, add_flow_login):
+    # get fields for resume_run
+    response = load_response("flows.resume_run")
+    meta = response.metadata
+    response_payload = response.json
+    flow_id = meta["flow_id"]
+    run_id = meta["run_id"]
+    tags = response_payload["tags"]
+    label = response_payload["label"]
+    status = response_payload["status"]
+    flow_title = response_payload["flow_title"]
+
+    # setup a GET /runs/{run_id} mock
+    # it only needs to return a matching flow_id
+    # (NB: the mock for 'flows.get_run' does not have the same run_id)
+    load_response(
+        RegisteredResponse(
+            service="flows",
+            method="get",
+            path=f"/runs/{run_id}",
+            json={
+                "flow_id": flow_id,
+            },
+        )
+    )
+
+    # setup the login mock for that flow_id as well, so that we can
+    # get a SpecificFlowClient for this flow
+    add_flow_login(flow_id)
+
+    run_line(
+        ["globus", "flows", "run", "resume", run_id],
+        search_stdout=[
+            ("Flow ID", flow_id),
+            ("Run ID", run_id),
+            ("Run Tags", ",".join(tags)),
+            ("Run Label", label),
+            ("Status", status),
+            ("Flow Title", flow_title),
+        ],
+    )


### PR DESCRIPTION
This command makes the resume call with no additional steps or checks.

A relatively simple test runs the command against some expected mocks and verifies that it runs to completion. The new `search_stdout=...` checker is used to check for several expected output fields.