### PR TITLE
Update search usage to avoid "beta" APIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "globus-sdk==3.23.0",
+        "globus-sdk==3.24.0",
         "click>=8.0.0,<9",
         "jmespath==1.0.1",
         "packaging>=17.0",

--- a/src/globus_cli/commands/search/index/create.py
+++ b/src/globus_cli/commands/search/index/create.py
@@ -14,11 +14,10 @@ from .._common import INDEX_FIELDS
 def create_command(
     *, login_manager: LoginManager, display_name: str, description: str
 ) -> None:
-    """(BETA) Create a new Index"""
-    index_doc = {"display_name": display_name, "description": description}
+    """Create a new Index"""
     search_client = login_manager.get_search_client()
     display(
-        search_client.post("/beta/index", data=index_doc),
+        search_client.create_index(display_name=display_name, description=description),
         text_mode=TextMode.text_record,
         fields=INDEX_FIELDS,
     )

--- a/src/globus_cli/commands/search/index/delete.py
+++ b/src/globus_cli/commands/search/index/delete.py
@@ -9,10 +9,10 @@ from globus_cli.termio import display
 @LoginManager.requires_login("search")
 @click.argument("INDEX_ID")
 def delete_command(*, login_manager: LoginManager, index_id: str) -> None:
-    """(BETA) Delete a Search Index"""
+    """Delete a Search Index"""
     search_client = login_manager.get_search_client()
     display(
-        search_client.delete(f"/beta/index/{index_id}"),
+        search_client.delete_index(index_id),
         simple_text=f"Index {index_id} is now marked for deletion.\n"
         "It will be fully deleted after cleanup steps complete.",
     )

--- a/tests/files/api_fixtures/search.yaml
+++ b/tests/files/api_fixtures/search.yaml
@@ -336,31 +336,6 @@ search:
         "status": "open",
         "subscription_id": null
       }
-  - path: /beta/index
-    method: POST
-    json:
-      {
-        "@datatype": "GSearchIndex",
-        "@version": "2017-09-01",
-        "creation_date": "2018-04-20 19:23:46",
-        "description": "Example index of Cookery",
-        "display_name": "example_cookery",
-        "id": "6f831ac8-4c41-4812-b383-6fb04f8b9f9f",
-        "is_trial": false,
-        "max_size_in_mb": 1,
-        "num_entries": 0,
-        "num_subjects": 0,
-        "size_in_mb": 0,
-        "status": "open",
-        "subscription_id": null
-      }
-  - path: /beta/index/6f831ac8-4c41-4812-b383-6fb04f8b9f9f
-    method: DELETE
-    json:
-      {
-        "acknowledged": true,
-        "index_id": "6f831ac8-4c41-4812-b383-6fb04f8b9f9f"
-      }
   - path: /v1/index_list
     json:
       {

--- a/tests/functional/search/test_index.py
+++ b/tests/functional/search/test_index.py
@@ -1,4 +1,4 @@
-from globus_sdk._testing import load_response_set
+from globus_sdk._testing import load_response, load_response_set
 
 
 def test_index_list(run_line):
@@ -28,7 +28,7 @@ def test_index_show(run_line):
 
 
 def test_index_create(run_line):
-    meta = load_response_set("cli.search").metadata
+    meta = load_response("search.create_index").metadata
     index_id = meta["index_id"]
 
     run_line(
@@ -45,7 +45,7 @@ def test_index_create(run_line):
 
 
 def test_index_delete(run_line):
-    meta = load_response_set("cli.search").metadata
+    meta = load_response("search.delete_index").metadata
     index_id = meta["index_id"]
 
     run_line(

--- a/tox.ini
+++ b/tox.ini
@@ -64,8 +64,7 @@ base_python =
    python3.11
    python3.10
 deps =
-    click
-    mypy
+    mypy==1.4.1
     types-jwt
     types-requests
     types-jmespath


### PR DESCRIPTION
This moves us from `/beta/` APIs to `/v1/` APIs by moving to the dedicated SDK methods.
A dependency update is necessary to get the latest SDK release here.