### PR TITLE
Update to globus-sdk v3.25.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "globus-sdk==3.24.0",
+        "globus-sdk==3.25.0",
         "click>=8.0.0,<9",
         "jmespath==1.0.1",
         "packaging>=17.0",


### PR DESCRIPTION
This picks up globus/globus-sdk-python#790, which is a nice internal fix but which I don't think is worthy of any public changelog note here.

We had a conversation in which we agreed to use the SDK default of 0.5s for leeway from that fix, rather than passing an explicit value here.