### PR TITLE
Improve annotation coverage for Flows commands

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -167,21 +167,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.update]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.flows]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.flows.delete]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.flows.list]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.flows.show]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.flows.start]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.gcp]
 disallow_untyped_defs = false
 

--- a/src/globus_cli/commands/flows/__init__.py
+++ b/src/globus_cli/commands/flows/__init__.py
@@ -14,5 +14,5 @@ from globus_cli.parsing import group
         "run": (".run", "run_command"),
     },
 )
-def flows_command():
+def flows_command() -> None:
     """Interact with the Globus Flows service"""

--- a/src/globus_cli/commands/flows/delete.py
+++ b/src/globus_cli/commands/flows/delete.py
@@ -10,7 +10,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
 @command("delete", short_help="Delete a flow")
 @flow_id_arg
 @LoginManager.requires_login("flows")
-def delete_command(login_manager: LoginManager, flow_id: uuid.UUID):
+def delete_command(login_manager: LoginManager, flow_id: uuid.UUID) -> None:
     """
     Delete a flow
     """

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import sys
+
 import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import Field, display, formatters
 from globus_cli.utils import PagingWrapper
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 
@@ -33,10 +40,13 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 @LoginManager.requires_login("flows")
 def list_command(
     login_manager: LoginManager,
-    filter_role: str | None,
+    filter_role: Literal[
+        "flow_viewer", "flow_starter", "flow_administrator", "flow_owner"
+    ]
+    | None,
     filter_fulltext: str | None,
     limit: int,
-):
+) -> None:
     """
     List flows
     """

--- a/src/globus_cli/commands/flows/show.py
+++ b/src/globus_cli/commands/flows/show.py
@@ -10,7 +10,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
 @command("show")
 @flow_id_arg
 @LoginManager.requires_login("flows")
-def show_command(login_manager: LoginManager, flow_id: uuid.UUID):
+def show_command(login_manager: LoginManager, flow_id: uuid.UUID) -> None:
     """
     Show a flow
     """

--- a/src/globus_cli/commands/flows/start.py
+++ b/src/globus_cli/commands/flows/start.py
@@ -84,10 +84,10 @@ def start_command(
     flow_id: uuid.UUID,
     input_document: ParsedJSONData | None,
     label: str | None,
-    managers: tuple[str],
-    monitors: tuple[str],
-    tags: tuple[str],
-):
+    managers: tuple[str, ...],
+    monitors: tuple[str, ...],
+    tags: tuple[str, ...],
+) -> None:
     """
     Start a flow.
 

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -29,8 +29,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.server.update",
     "globus_cli.commands.endpoint.show",
     "globus_cli.commands.endpoint.storage_gateway.list",
-    "globus_cli.commands.flows.list",
-    "globus_cli.commands.flows.start",
     "globus_cli.commands.get_identities",
     "globus_cli.commands.login",
     "globus_cli.commands.logout",


### PR DESCRIPTION
- Remove mypy.ini allow rules for `flows` command modules
- Remove exemptions from the click parameter type checker for these commands
- Correct some minor annotations (e.g. `tuple[str]` -> `tuple[str, ...]`)

No runtime changes were made unless you count a conditional import of `Literal` from `typing_extensions`.