### PR TITLE
Replace use of the SDK paginator table with 'wrap'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,16 @@ repos:
       entry: ./changelog.d/post-fix-changelog.py
       language: python
       files: ^changelog\.adoc$
+    - id: reject-paginator-table-usage
+      name: "Require use of 'Paginator.wrap()' not 'client.paginated.foo'"
+      types: [python]
+      language: pygrep
+      # look for either
+      #     x = client.paginated.foo(...)
+      # or
+      #     x = (
+      #         client
+      #         .paginated
+      #         .foo(...)
+      #     )
+      entry: '(\.paginated\.)|(^\s+\.paginated$)'

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import click
+from globus_sdk.paging import Paginator
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
@@ -103,8 +104,9 @@ def endpoint_search(
     if owner_id:
         owner_id = auth_client.maybe_lookup_identity_id(owner_id)
 
+    paginator = Paginator.wrap(transfer_client.endpoint_search)
     search_iterator = PagingWrapper(
-        transfer_client.paginated.endpoint_search(
+        paginator(
             filter_fulltext=filter_fulltext,
             filter_scope=filter_scope,
             filter_owner_id=owner_id,

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import click
+from globus_sdk.paging import Paginator
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
@@ -41,8 +42,9 @@ def list_command(
     List flows
     """
     flows_client = login_manager.get_flows_client()
+    paginator = Paginator.wrap(flows_client.list_flows)
     flow_iterator = PagingWrapper(
-        flows_client.paginated.list_flows(
+        paginator(
             filter_role=filter_role,
             filter_fulltext=filter_fulltext,
             orderby="updated_at DESC",

--- a/src/globus_cli/commands/task/cancel.py
+++ b/src/globus_cli/commands/task/cancel.py
@@ -4,6 +4,7 @@ import typing as t
 import uuid
 
 import click
+from globus_sdk.paging import Paginator
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
@@ -72,9 +73,10 @@ def cancel_task(*, login_manager: LoginManager, all: bool, task_id: uuid.UUID) -
     transfer_client = login_manager.get_transfer_client()
 
     if all:
+        paginator = Paginator.wrap(transfer_client.task_list)
         task_ids = [
             task_row["task_id"]
-            for task_row in transfer_client.paginated.task_list(
+            for task_row in paginator(
                 query_params={
                     "filter": "type:TRANSFER,DELETE/status:ACTIVE,INACTIVE",
                     "fields": "task_id",

--- a/src/globus_cli/commands/task/event_list.py
+++ b/src/globus_cli/commands/task/event_list.py
@@ -5,6 +5,7 @@ import typing as t
 import uuid
 
 import click
+from globus_sdk.paging import Paginator
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
@@ -109,8 +110,9 @@ def task_event_list(
     else:
         filter_string = ""
 
+    paginator = Paginator.wrap(transfer_client.task_event_list)
     event_iterator = PagingWrapper(
-        transfer_client.paginated.task_event_list(
+        paginator(
             task_id,
             # TODO: convert to `filter=filter_string` when SDK support is added
             query_params={"filter": filter_string},

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -7,6 +7,7 @@ import typing as t
 import uuid
 
 import click
+from globus_sdk.paging import Paginator
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import AnnotatedOption, command
@@ -232,8 +233,9 @@ def task_list(
     )
 
     transfer_client = login_manager.get_transfer_client()
+    paginator = Paginator.wrap(transfer_client.task_list)
     task_iterator = PagingWrapper(
-        transfer_client.paginated.task_list(
+        paginator(
             query_params={
                 "filter": filter_string[:-1],  # remove trailing /
                 "orderby": "request_time DESC",

--- a/src/globus_cli/commands/task/show.py
+++ b/src/globus_cli/commands/task/show.py
@@ -4,6 +4,7 @@ import uuid
 
 import click
 import globus_sdk
+from globus_sdk.paging import Paginator
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, mutex_option_group
@@ -66,7 +67,8 @@ def print_successful_transfers(
 ) -> None:
     from globus_cli.services.transfer import iterable_response_to_dict
 
-    res = client.paginated.task_successful_transfers(task_id).items()
+    paginator = Paginator.wrap(client.task_successful_transfers)
+    res = paginator(task_id).items()
     display(
         res,
         fields=SUCCESSFULL_TRANSFER_FIELDS,
@@ -77,7 +79,8 @@ def print_successful_transfers(
 def print_skipped_errors(client: globus_sdk.TransferClient, task_id: uuid.UUID) -> None:
     from globus_cli.services.transfer import iterable_response_to_dict
 
-    res = client.paginated.task_skipped_errors(task_id).items()
+    paginator = Paginator.wrap(client.task_skipped_errors)
+    res = paginator(task_id).items()
     display(
         res,
         fields=SKIPPED_PATHS_FIELDS,


### PR DESCRIPTION
The paginator table attached to client objects provides a convenient syntax for accessing paginators which wrap the relevant underlying client methods.

However, it is not presently possible to explain it to type checkers that this is a type-manipulating proxy over the client class. The paginator table is just one valid syntax for accessing a Paginator object built from the method being paginated. The paginator building is actually done by `Paginator.wrap`, which inspects the method for special pagination attributes and dispatches to its relevant subclass.

The major advantage of `Paginator.wrap()` is that it preserves type annotation information correctly, returning a paginator object parametrized over the return type of the underlying method.

As a result, we should prefer `Paginator.wrap` for mypy-checked code, and [the current SDK docs even have a note to this effect](https://globus-sdk-python.readthedocs.io/en/stable/core/paging.html#typed-paginators-with-paginator-wrap).

In order to ensure the move is done everywhere and holds into the future, add a pygrep hook which looks for access to a `.paginated` attribute. If this runs into false positives in the future, it could be replaced with an AST-based lint or something else more sophisticated, but on the current codebase it is fully accurate.

The change can be verified to be effective by introducing unuspported arguments and seeing that `mypy` catches them. For example:

```diff
-    res = paginator(task_id).items()
+    res = paginator(task_id, foo=bar).items()
```

is flagged:

```
$ mypy src/
src/globus_cli/commands/task/show.py:71: error: Unexpected keyword argument "foo"  [call-arg]
```

Such a check was not possible via the paginator-table interface (the `.paginated` attribute).