### PR TITLE
Improve type annotations for 'collection' commands

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -110,18 +110,6 @@ disallow_untyped_defs = false
 # command modules
 # listed separately to preserve the readability of the above config
 
-[mypy-globus_cli.commands.collection.delete]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.collection.list]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.collection.show]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.collection.update]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.delete]
 disallow_untyped_defs = false
 

--- a/src/globus_cli/commands/collection/delete.py
+++ b/src/globus_cli/commands/collection/delete.py
@@ -1,3 +1,5 @@
+import uuid
+
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import collection_id_arg, command
 from globus_cli.termio import TextMode, display
@@ -6,7 +8,7 @@ from globus_cli.termio import TextMode, display
 @command("delete", short_help="Delete an existing Collection")
 @collection_id_arg
 @LoginManager.requires_login("transfer")
-def collection_delete(*, login_manager: LoginManager, collection_id):
+def collection_delete(*, login_manager: LoginManager, collection_id: uuid.UUID) -> None:
     """
     Delete an existing Collection. This requires the administrator role on the
     Endpoint.

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 import click
 import globus_sdk
 
@@ -74,8 +76,11 @@ PRIVATE_FIELDS: list[Field] = [
 )
 @LoginManager.requires_login("auth", "transfer")
 def collection_show(
-    *, login_manager: LoginManager, include_private_policies, collection_id
-):
+    *,
+    login_manager: LoginManager,
+    include_private_policies: bool,
+    collection_id: uuid.UUID,
+) -> None:
     """
     Display a Mapped or Guest Collection
     """

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -27,7 +27,9 @@ _MULTI_USE_OPTION_STR = "Give this option multiple times in a single command"
 
 
 class _FullDataField(Field):
-    def get_value(self, data):
+    # NB: 'data' is a UnpackingGCSResponse, but that type isn't exported by `globus_sdk`
+    # rather than digging through internal package paths, just use `t.Any` here
+    def get_value(self, data: t.Any) -> t.Any:
         return super().get_value(data.full_data)
 
 

--- a/tests/click_types.py
+++ b/tests/click_types.py
@@ -52,6 +52,10 @@ def _type_from_param_type(param_obj: click.Parameter) -> type:
     """
     param_type = param_obj.type
 
+    # globus-cli types
+    if isinstance(param_type, AnnotatedParamType):
+        return param_type.get_type_annotation(param_obj)
+
     # click types
     if type(param_type) in _CLICK_STATIC_TYPE_MAP:
         return _CLICK_STATIC_TYPE_MAP[type(param_type)]
@@ -67,10 +71,6 @@ def _type_from_param_type(param_obj: click.Parameter) -> type:
                 )
         else:
             return str
-
-    # globus-cli types
-    if isinstance(param_type, AnnotatedParamType):
-        return param_type.get_type_annotation(param_obj)
 
     raise NotImplementedError(f"unsupported parameter type: {param_type}")
 

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -9,9 +9,6 @@ from globus_cli.reflect import iter_all_commands
 from tests.click_types import check_has_correct_annotations_for_click_args
 
 _SKIP_MODULES = (
-    "globus_cli.commands.collection.delete",
-    "globus_cli.commands.collection.list",
-    "globus_cli.commands.collection.show",
     "globus_cli.commands.endpoint.deactivate",
     "globus_cli.commands.endpoint.delete",
     "globus_cli.commands.endpoint.local_id",


### PR DESCRIPTION
Four basic changes are made here. The first two are relatively standard:
1. Remove mypy.ini ignore rules for 'collection' commands
2. Remove click type checking exemptions for 'collection' commands

The next two are tweaks to get the custom ChoiceSlugified type used in the collection list command to pass the click-type-checker.

3. Change precedence order on the click type checker to prefer AnnotatedParamType.get_type_annotation over any recognized built-in click types

This ensures that a type which inherits from a click type can set an explicit annotation and have that value checked instead of the "normal" type for click deduction.

4. Implement `get_type_annotation` for ChoiceSlugified to normalize the choice values

The goal of the ChoiceSlugified type is to present 'foo-bar' as the CLI interface for passing 'foo_bar'. It normalizes `-_` to `-` to match the internal choice, then re-norms `-` to `_` as its output. Therefore, a command accepting this parameter type should expect `_`-normed strings as inputs. That is exactly what the new `get_type_annotation` method implements.

In addition to the various type-checking changes, there is a very minor runtime change in that one command which accepted non-UUID endpoint-id values (any string) now requires UUID values by means of the common `endpoint_id_arg` decorator.