### PR TITLE
Add type annotations to the login manager subpackage

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,12 +17,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.exception_handling.registry]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.login_manager._old_config]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.login_manager.manager]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.parsing.command_state]
 disallow_untyped_defs = false
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,19 +20,7 @@ disallow_untyped_defs = false
 [mypy-globus_cli.login_manager._old_config]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.login_manager.client_login]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.login_manager.errors]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.login_manager.local_server]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.login_manager.manager]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.login_manager.utils]
 disallow_untyped_defs = false
 
 [mypy-globus_cli.parsing.command_state]

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -232,8 +232,8 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
     @click.option("--no-retry", is_flag=True, help="Disable built-in request retries")
     @mutex_option_group("--body", "--body-file")
     def service_command(
-        *,
         login_manager: LoginManager,
+        *,
         method: Literal["HEAD", "GET", "PUT", "POST", "PATCH", "DELETE"],
         path: str,
         query_param: tuple[tuple[str, str], ...],

--- a/src/globus_cli/commands/bookmark/create.py
+++ b/src/globus_cli/commands/bookmark/create.py
@@ -38,8 +38,8 @@ $ globus bookmark create \
 @click.argument("bookmark_name")
 @LoginManager.requires_login("transfer")
 def bookmark_create(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_plus_path: tuple[uuid.UUID, str],
     bookmark_name: str,
 ) -> None:

--- a/src/globus_cli/commands/bookmark/delete.py
+++ b/src/globus_cli/commands/bookmark/delete.py
@@ -24,7 +24,7 @@ $ globus bookmark delete "Bookmark Name"
 )
 @click.argument("bookmark_id_or_name")
 @LoginManager.requires_login("transfer")
-def bookmark_delete(*, login_manager: LoginManager, bookmark_id_or_name: str) -> None:
+def bookmark_delete(login_manager: LoginManager, *, bookmark_id_or_name: str) -> None:
     """
     Delete one bookmark, given its ID or name.
     """

--- a/src/globus_cli/commands/bookmark/list.py
+++ b/src/globus_cli/commands/bookmark/list.py
@@ -48,7 +48,7 @@ $ globus bookmark list --jmespath='DATA[*].[name, endpoint_id]' --format=unix
     short_help="List your bookmarks",
 )
 @LoginManager.requires_login("transfer")
-def bookmark_list(*, login_manager: LoginManager) -> None:
+def bookmark_list(login_manager: LoginManager) -> None:
     """List all bookmarks for the current user"""
     from globus_cli.services.transfer import iterable_response_to_dict
 

--- a/src/globus_cli/commands/bookmark/rename.py
+++ b/src/globus_cli/commands/bookmark/rename.py
@@ -26,7 +26,7 @@ $ globus bookmark rename oldname newname
 @click.argument("new_bookmark_name")
 @LoginManager.requires_login("transfer")
 def bookmark_rename(
-    *, login_manager: LoginManager, bookmark_id_or_name: str, new_bookmark_name: str
+    login_manager: LoginManager, *, bookmark_id_or_name: str, new_bookmark_name: str
 ) -> None:
     """Change a bookmark's name"""
     transfer_client = login_manager.get_transfer_client()

--- a/src/globus_cli/commands/bookmark/show.py
+++ b/src/globus_cli/commands/bookmark/show.py
@@ -32,7 +32,7 @@ $ globus ls "$(globus bookmark show BOOKMARK_NAME)"
 )
 @click.argument("bookmark_id_or_name")
 @LoginManager.requires_login("transfer")
-def bookmark_show(*, login_manager: LoginManager, bookmark_id_or_name: str) -> None:
+def bookmark_show(login_manager: LoginManager, *, bookmark_id_or_name: str) -> None:
     """
     Given a single bookmark ID or bookmark name, show the bookmark details. By default,
     when the format is TEXT, this will display the endpoint ID and path in

--- a/src/globus_cli/commands/collection/delete.py
+++ b/src/globus_cli/commands/collection/delete.py
@@ -8,7 +8,7 @@ from globus_cli.termio import TextMode, display
 @command("delete", short_help="Delete an existing Collection")
 @collection_id_arg
 @LoginManager.requires_login("transfer")
-def collection_delete(*, login_manager: LoginManager, collection_id: uuid.UUID) -> None:
+def collection_delete(login_manager: LoginManager, *, collection_id: uuid.UUID) -> None:
     """
     Delete an existing Collection. This requires the administrator role on the
     Endpoint.

--- a/src/globus_cli/commands/collection/list.py
+++ b/src/globus_cli/commands/collection/list.py
@@ -90,8 +90,8 @@ created-by-me:
 )
 @LoginManager.requires_login("auth", "transfer")
 def collection_list(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     include_private_policies: bool,
     filters: tuple[

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -76,8 +76,8 @@ PRIVATE_FIELDS: list[Field] = [
 )
 @LoginManager.requires_login("auth", "transfer")
 def collection_show(
-    *,
     login_manager: LoginManager,
+    *,
     include_private_policies: bool,
     collection_id: uuid.UUID,
 ) -> None:

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -126,8 +126,8 @@ class _FullDataField(Field):
 @mutex_option_group("--enable-https", "--disable-https")
 @LoginManager.requires_login("auth", "transfer")
 def collection_update(
-    *,
     login_manager: LoginManager,
+    *,
     collection_id: uuid.UUID,
     display_name: str | None,
     description: str | None | ExplicitNullType,

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -76,8 +76,8 @@ $ globus task wait "$task_id"
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_OPTPATH)
 @LoginManager.requires_login("transfer")
 def delete_command(
-    *,
     login_manager: LoginManager,
+    *,
     batch: t.TextIO | None,
     ignore_missing: bool,
     star_silent: bool,

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -113,8 +113,8 @@ $ globus endpoint activate $ep_id --myproxy -U username
 @mutex_option_group("--web", "--myproxy", "--delegate-proxy")
 @LoginManager.requires_login("transfer")
 def endpoint_activate(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     myproxy: bool,
     myproxy_username: str | None,

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -67,8 +67,8 @@ GCP_FIELDS = [Field("Setup Key", "globus_connect_setup_key")]
 @mutex_option_group("--shared", "--server", "--personal")
 @LoginManager.requires_login("transfer")
 def endpoint_create(
-    *,
     login_manager: LoginManager,
+    *,
     personal: bool,
     server: bool,
     shared: tuple[uuid.UUID, str] | None,

--- a/src/globus_cli/commands/endpoint/deactivate.py
+++ b/src/globus_cli/commands/endpoint/deactivate.py
@@ -17,7 +17,7 @@ $ globus endpoint deactivate $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login("transfer")
-def endpoint_deactivate(*, login_manager: LoginManager, endpoint_id: str) -> None:
+def endpoint_deactivate(login_manager: LoginManager, *, endpoint_id: str) -> None:
     """
     Remove the credential previously assigned to an endpoint via
     'globus endpoint activate' or any other form of endpoint activation

--- a/src/globus_cli/commands/endpoint/delete.py
+++ b/src/globus_cli/commands/endpoint/delete.py
@@ -16,7 +16,7 @@ $ globus endpoint delete $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login("transfer")
-def endpoint_delete(*, login_manager: LoginManager, endpoint_id: str) -> None:
+def endpoint_delete(login_manager: LoginManager, *, endpoint_id: str) -> None:
     """Delete a given endpoint.
 
     WARNING: Deleting an endpoint will permanently disable any existing shared

--- a/src/globus_cli/commands/endpoint/is_activated.py
+++ b/src/globus_cli/commands/endpoint/is_activated.py
@@ -84,8 +84,8 @@ fi
 )
 @LoginManager.requires_login("transfer")
 def endpoint_is_activated(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     until: int | None,
     absolute_time: bool,

--- a/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
+++ b/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
@@ -15,7 +15,7 @@ $ globus endpoint my-shared-endpoint-list $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login("transfer")
-def my_shared_endpoint_list(*, login_manager: LoginManager, endpoint_id: str) -> None:
+def my_shared_endpoint_list(login_manager: LoginManager, *, endpoint_id: str) -> None:
     """
     Show a list of all shared endpoints hosted on the target endpoint for which the user
     has the "administrator" or "access_manager" effective roles.

--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -47,8 +47,8 @@ $ globus endpoint permission create $ep_id:/ --permissions rw --identity go@glob
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
 @LoginManager.requires_login("auth", "transfer")
 def create_command(
-    *,
     login_manager: LoginManager,
+    *,
     principal,
     permissions,
     endpoint_plus_path,

--- a/src/globus_cli/commands/endpoint/permission/delete.py
+++ b/src/globus_cli/commands/endpoint/permission/delete.py
@@ -19,7 +19,7 @@ $ globus endpoint permission delete $ep_id $rule_id
 @endpoint_id_arg
 @click.argument("rule_id")
 @LoginManager.requires_login("transfer")
-def delete_command(*, login_manager: LoginManager, endpoint_id, rule_id):
+def delete_command(login_manager: LoginManager, *, endpoint_id, rule_id):
     """
     Delete an existing access control rule, removing whatever permissions it previously
     granted users on the endpoint.

--- a/src/globus_cli/commands/endpoint/permission/list.py
+++ b/src/globus_cli/commands/endpoint/permission/list.py
@@ -21,7 +21,7 @@ $ globus endpoint permission list $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login("auth", "transfer")
-def list_command(*, login_manager: LoginManager, endpoint_id: uuid.UUID):
+def list_command(login_manager: LoginManager, *, endpoint_id: uuid.UUID):
     """List all rules in an endpoint's access control list."""
     transfer_client = login_manager.get_transfer_client()
     auth_client = login_manager.get_auth_client()

--- a/src/globus_cli/commands/endpoint/permission/show.py
+++ b/src/globus_cli/commands/endpoint/permission/show.py
@@ -25,7 +25,7 @@ $ globus endpoint permission show $ep_id $rule_id
 @endpoint_id_arg
 @click.argument("rule_id")
 @LoginManager.requires_login("auth", "transfer")
-def show_command(*, login_manager: LoginManager, endpoint_id: uuid.UUID, rule_id: str):
+def show_command(login_manager: LoginManager, *, endpoint_id: uuid.UUID, rule_id: str):
     """
     Show detailed information about a single access control rule on an endpoint.
     """

--- a/src/globus_cli/commands/endpoint/permission/update.py
+++ b/src/globus_cli/commands/endpoint/permission/update.py
@@ -27,7 +27,7 @@ $ globus endpoint permission update $ep_id $rule_id --permissions r
     help="Permissions to add. Read-Only or Read/Write",
 )
 @LoginManager.requires_login("transfer")
-def update_command(*, login_manager: LoginManager, permissions, rule_id, endpoint_id):
+def update_command(login_manager: LoginManager, *, permissions, rule_id, endpoint_id):
     """
     Update an existing access control rule's permissions.
 

--- a/src/globus_cli/commands/endpoint/role/create.py
+++ b/src/globus_cli/commands/endpoint/role/create.py
@@ -45,8 +45,8 @@ $ globus endpoint role create 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
 )
 @LoginManager.requires_login("auth", "transfer")
 def role_create(
-    *,
     login_manager: LoginManager,
+    *,
     role: Literal[
         "administrator", "access_manager", "activity_manager", "activity_monitor"
     ],

--- a/src/globus_cli/commands/endpoint/role/delete.py
+++ b/src/globus_cli/commands/endpoint/role/delete.py
@@ -25,7 +25,7 @@ $ globus endpoint role delete 'ddb59aef-6d04-11e5-ba46-22000b92c6ec' \
 @role_id_arg
 @LoginManager.requires_login("transfer")
 def role_delete(
-    *, login_manager: LoginManager, role_id: str, endpoint_id: uuid.UUID
+    login_manager: LoginManager, *, role_id: str, endpoint_id: uuid.UUID
 ) -> None:
     """
     Remove a role from an endpoint.

--- a/src/globus_cli/commands/endpoint/role/list.py
+++ b/src/globus_cli/commands/endpoint/role/list.py
@@ -31,7 +31,7 @@ $ globus endpoint role list 'ddb59aef-6d04-11e5-ba46-22000b92c6ec'
 )
 @endpoint_id_arg
 @LoginManager.requires_login("auth", "transfer")
-def role_list(*, login_manager: LoginManager, endpoint_id: uuid.UUID) -> None:
+def role_list(login_manager: LoginManager, *, endpoint_id: uuid.UUID) -> None:
     """
     List the assigned roles on an endpoint.
 

--- a/src/globus_cli/commands/endpoint/role/show.py
+++ b/src/globus_cli/commands/endpoint/role/show.py
@@ -34,7 +34,7 @@ $ globus endpoint role show EP_ID ROLE_ID
 @role_id_arg
 @LoginManager.requires_login("auth", "transfer")
 def role_show(
-    *, login_manager: LoginManager, endpoint_id: uuid.UUID, role_id: str
+    login_manager: LoginManager, *, endpoint_id: uuid.UUID, role_id: str
 ) -> None:
     """
     Show full info for a role on an endpoint.

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -69,8 +69,8 @@ $ globus endpoint search --filter-scope my-endpoints
 @click.argument("filter_fulltext", required=False)
 @LoginManager.requires_login("auth", "transfer")
 def endpoint_search(
-    *,
     login_manager: LoginManager,
+    *,
     filter_fulltext: str | None,
     limit: int,
     filter_owner_id: str | None,

--- a/src/globus_cli/commands/endpoint/server/add.py
+++ b/src/globus_cli/commands/endpoint/server/add.py
@@ -31,8 +31,8 @@ $ globus endpoint server add $ep_id --hostname gridftp.example.org
 @server_add_opts
 @LoginManager.requires_login("transfer")
 def server_add(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     subject: str | None,
     port: int,

--- a/src/globus_cli/commands/endpoint/server/delete.py
+++ b/src/globus_cli/commands/endpoint/server/delete.py
@@ -78,7 +78,7 @@ $ globus endpoint server delete $ep_id $server_id
 @click.argument("server")
 @LoginManager.requires_login("transfer")
 def server_delete(
-    *, login_manager: LoginManager, endpoint_id: uuid.UUID, server: str
+    login_manager: LoginManager, *, endpoint_id: uuid.UUID, server: str
 ) -> None:
     """
     Delete a server belonging to an endpoint.

--- a/src/globus_cli/commands/endpoint/server/list.py
+++ b/src/globus_cli/commands/endpoint/server/list.py
@@ -31,7 +31,7 @@ $ globus endpoint server list $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login("transfer")
-def server_list(*, login_manager: LoginManager, endpoint_id: uuid.UUID) -> None:
+def server_list(login_manager: LoginManager, *, endpoint_id: uuid.UUID) -> None:
     """List all servers belonging to an endpoint."""
     transfer_client = login_manager.get_transfer_client()
     # raises usage error on shares for us

--- a/src/globus_cli/commands/endpoint/server/show.py
+++ b/src/globus_cli/commands/endpoint/server/show.py
@@ -67,7 +67,7 @@ $ globus endpoint server show $ep_id $server_id
 @server_id_arg
 @LoginManager.requires_login("transfer")
 def server_show(
-    *, login_manager: LoginManager, endpoint_id: uuid.UUID, server_id: str
+    login_manager: LoginManager, *, endpoint_id: uuid.UUID, server_id: str
 ) -> None:
     """
     Display information about a server belonging to an endpoint.

--- a/src/globus_cli/commands/endpoint/server/update.py
+++ b/src/globus_cli/commands/endpoint/server/update.py
@@ -33,8 +33,8 @@ $ globus endpoint server update $ep_id $server_id --scheme ftp
 @server_id_arg
 @LoginManager.requires_login("transfer")
 def server_update(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     server_id: str,
     subject: str | None,

--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -33,7 +33,7 @@ class SubscriptionIdType(AnnotatedParamType):
 @click.argument("SUBSCRIPTION_ID", type=SubscriptionIdType())
 @LoginManager.requires_login("transfer")
 def set_endpoint_subscription_id(
-    *, login_manager: LoginManager, endpoint_id: uuid.UUID, subscription_id: str | None
+    login_manager: LoginManager, *, endpoint_id: uuid.UUID, subscription_id: str | None
 ) -> None:
     """
     Set an endpoint's subscription ID.

--- a/src/globus_cli/commands/endpoint/show.py
+++ b/src/globus_cli/commands/endpoint/show.py
@@ -39,7 +39,7 @@ GCP_FIELDS = STANDARD_FIELDS + [
 @click.option("--skip-endpoint-type-check", is_flag=True, hidden=True)
 @LoginManager.requires_login("transfer")
 def endpoint_show(
-    *, login_manager: LoginManager, endpoint_id: str, skip_endpoint_type_check: bool
+    login_manager: LoginManager, *, endpoint_id: str, skip_endpoint_type_check: bool
 ) -> None:
     """Display a detailed endpoint definition"""
     transfer_client = login_manager.get_transfer_client()

--- a/src/globus_cli/commands/endpoint/storage_gateway/list.py
+++ b/src/globus_cli/commands/endpoint/storage_gateway/list.py
@@ -19,8 +19,8 @@ STANDARD_FIELDS = [
 )
 @LoginManager.requires_login("auth", "transfer")
 def storage_gateway_list(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id,
 ):
     """

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -38,8 +38,8 @@ else:
 @mutex_option_group("--default-directory", "--no-default-directory")
 @LoginManager.requires_login("transfer")
 def endpoint_update(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     contact_email: str | None | ExplicitNullType,
     contact_info: str | None | ExplicitNullType,

--- a/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
@@ -17,8 +17,8 @@ from globus_cli.termio import display
 @click.argument("user_credential_json", type=JSONStringOrFile())
 @LoginManager.requires_login("auth", "transfer")
 def from_json(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     user_credential_json: ParsedJSONData,
 ) -> None:

--- a/src/globus_cli/commands/endpoint/user_credential/create/posix.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/posix.py
@@ -16,8 +16,8 @@ from .._common import user_credential_create_and_update_params
 @user_credential_create_and_update_params(create=True)
 @LoginManager.requires_login("auth", "transfer")
 def posix(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     storage_gateway: uuid.UUID,
     globus_identity: str,

--- a/src/globus_cli/commands/endpoint/user_credential/create/s3.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/s3.py
@@ -19,8 +19,8 @@ from .._common import user_credential_create_and_update_params
 @click.argument("s3_secret_key")
 @LoginManager.requires_login("auth", "transfer")
 def s3(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     storage_gateway: uuid.UUID,
     globus_identity: str,

--- a/src/globus_cli/commands/endpoint/user_credential/delete.py
+++ b/src/globus_cli/commands/endpoint/user_credential/delete.py
@@ -12,8 +12,8 @@ from ._common import user_credential_id_arg
 @user_credential_id_arg()
 @LoginManager.requires_login("auth", "transfer")
 def user_credential_delete(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     user_credential_id: uuid.UUID,
 ) -> None:

--- a/src/globus_cli/commands/endpoint/user_credential/list.py
+++ b/src/globus_cli/commands/endpoint/user_credential/list.py
@@ -22,8 +22,8 @@ from globus_cli.termio import Field, TextMode, display, formatters
 )
 @LoginManager.requires_login("auth", "transfer")
 def user_credential_list(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     storage_gateway: uuid.UUID | None,
 ) -> None:

--- a/src/globus_cli/commands/endpoint/user_credential/show.py
+++ b/src/globus_cli/commands/endpoint/user_credential/show.py
@@ -12,8 +12,8 @@ from ._common import user_credential_id_arg
 @user_credential_id_arg()
 @LoginManager.requires_login("auth", "transfer")
 def user_credential_show(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     user_credential_id: uuid.UUID,
 ) -> None:

--- a/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
@@ -20,8 +20,8 @@ from .._common import user_credential_id_arg
 @click.argument("user_credential_json", type=JSONStringOrFile())
 @LoginManager.requires_login("auth", "transfer")
 def from_json(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     user_credential_id: uuid.UUID,
     user_credential_json: ParsedJSONData,

--- a/src/globus_cli/commands/flows/create.py
+++ b/src/globus_cli/commands/flows/create.py
@@ -39,6 +39,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 @LoginManager.requires_login("flows")
 def create_command(
     login_manager: LoginManager,
+    *,
     title: str,
     definition: ParsedJSONData,
     input_schema: ParsedJSONData | None,

--- a/src/globus_cli/commands/flows/delete.py
+++ b/src/globus_cli/commands/flows/delete.py
@@ -10,7 +10,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
 @command("delete", short_help="Delete a flow")
 @flow_id_arg
 @LoginManager.requires_login("flows")
-def delete_command(login_manager: LoginManager, flow_id: uuid.UUID) -> None:
+def delete_command(login_manager: LoginManager, *, flow_id: uuid.UUID) -> None:
     """
     Delete a flow
     """

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -41,6 +41,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 @LoginManager.requires_login("flows")
 def list_command(
     login_manager: LoginManager,
+    *,
     filter_role: Literal[
         "flow_viewer", "flow_starter", "flow_administrator", "flow_owner"
     ]

--- a/src/globus_cli/commands/flows/run/delete.py
+++ b/src/globus_cli/commands/flows/run/delete.py
@@ -10,7 +10,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
 @command("delete", short_help="Delete a run")
 @run_id_arg
 @LoginManager.requires_login("flows")
-def delete_command(login_manager: LoginManager, run_id: uuid.UUID) -> None:
+def delete_command(login_manager: LoginManager, *, run_id: uuid.UUID) -> None:
     """
     Delete a run
     """

--- a/src/globus_cli/commands/flows/run/show.py
+++ b/src/globus_cli/commands/flows/run/show.py
@@ -18,7 +18,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
 )
 @LoginManager.requires_login("flows")
 def show_command(
-    login_manager: LoginManager, run_id: uuid.UUID, include_flow_description: bool
+    login_manager: LoginManager, *, run_id: uuid.UUID, include_flow_description: bool
 ) -> None:
     """
     Show a run

--- a/src/globus_cli/commands/flows/run/update.py
+++ b/src/globus_cli/commands/flows/run/update.py
@@ -49,6 +49,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
 @LoginManager.requires_login("flows")
 def update_command(
     login_manager: LoginManager,
+    *,
     run_id: uuid.UUID,
     label: str | None = None,
     run_monitors: list[str] | None = None,

--- a/src/globus_cli/commands/flows/show.py
+++ b/src/globus_cli/commands/flows/show.py
@@ -10,7 +10,7 @@ from globus_cli.termio import Field, TextMode, display, formatters
 @command("show")
 @flow_id_arg
 @LoginManager.requires_login("flows")
-def show_command(login_manager: LoginManager, flow_id: uuid.UUID) -> None:
+def show_command(login_manager: LoginManager, *, flow_id: uuid.UUID) -> None:
     """
     Show a flow
     """

--- a/src/globus_cli/commands/flows/start.py
+++ b/src/globus_cli/commands/flows/start.py
@@ -81,6 +81,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 @LoginManager.requires_login("flows")
 def start_command(
     login_manager: LoginManager,
+    *,
     flow_id: uuid.UUID,
     input_document: ParsedJSONData | None,
     label: str | None,

--- a/src/globus_cli/commands/flows/update.py
+++ b/src/globus_cli/commands/flows/update.py
@@ -106,8 +106,9 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 )
 @LoginManager.requires_login("flows")
 def update_command(
-    flow_id: uuid.UUID,
     login_manager: LoginManager,
+    *,
+    flow_id: uuid.UUID,
     title: str | None,
     definition: ParsedJSONData | None,
     input_schema: ParsedJSONData | None,

--- a/src/globus_cli/commands/gcp/create/guest.py
+++ b/src/globus_cli/commands/gcp/create/guest.py
@@ -22,8 +22,8 @@ from ._common import deprecated_verify_option
 @deprecated_verify_option
 @LoginManager.requires_login("transfer")
 def guest_command(
-    *,
     login_manager: LoginManager,
+    *,
     display_name: str,
     host_gcp_path: tuple[uuid.UUID, str],
     contact_email: str | None | ExplicitNullType,

--- a/src/globus_cli/commands/gcp/create/mapped.py
+++ b/src/globus_cli/commands/gcp/create/mapped.py
@@ -20,8 +20,8 @@ from ._common import deprecated_verify_option
 @deprecated_verify_option
 @LoginManager.requires_login("transfer")
 def mapped_command(
-    *,
     login_manager: LoginManager,
+    *,
     display_name: str,
     description: str | None | ExplicitNullType,
     info_link: str | None | ExplicitNullType,

--- a/src/globus_cli/commands/gcp/update/guest.py
+++ b/src/globus_cli/commands/gcp/update/guest.py
@@ -17,8 +17,8 @@ from globus_cli.termio import TextMode, display
 )
 @LoginManager.requires_login("transfer")
 def guest_command(
-    *,
     login_manager: LoginManager,
+    *,
     collection_id: uuid.UUID,
     display_name: str | None,
     contact_email: str | None | ExplicitNullType,

--- a/src/globus_cli/commands/gcp/update/mapped.py
+++ b/src/globus_cli/commands/gcp/update/mapped.py
@@ -25,8 +25,8 @@ from globus_cli.termio import TextMode, display
 )
 @LoginManager.requires_login("transfer")
 def mapped_command(
-    *,
     login_manager: LoginManager,
+    *,
     collection_id: uuid.UUID,
     display_name: str | None,
     description: str | None | ExplicitNullType,

--- a/src/globus_cli/commands/get_identities.py
+++ b/src/globus_cli/commands/get_identities.py
@@ -37,7 +37,7 @@ $ globus get-identities --verbose go@globusid.org clitester1a@globusid.org \
 )
 @click.option("--provision", hidden=True, is_flag=True)
 @LoginManager.requires_login("auth")
-def get_identities_command(*, login_manager: LoginManager, values, provision):
+def get_identities_command(login_manager: LoginManager, *, values, provision):
     """
     Lookup Globus Auth Identities given one or more uuids
     and/or usernames.

--- a/src/globus_cli/commands/group/create.py
+++ b/src/globus_cli/commands/group/create.py
@@ -12,7 +12,7 @@ from globus_cli.termio import display
 @click.option("--description", help="Description for the group")
 @LoginManager.requires_login("groups")
 def group_create(
-    *, login_manager: LoginManager, name: str, description: str | None
+    login_manager: LoginManager, *, name: str, description: str | None
 ) -> None:
     """Create a new group"""
     groups_client = login_manager.get_groups_client()

--- a/src/globus_cli/commands/group/delete.py
+++ b/src/globus_cli/commands/group/delete.py
@@ -11,8 +11,8 @@ from ._common import group_id_arg
 @command("delete")
 @LoginManager.requires_login("groups")
 def group_delete(
-    *,
     login_manager: LoginManager,
+    *,
     group_id: uuid.UUID,
 ) -> None:
     """Delete a group"""

--- a/src/globus_cli/commands/group/invite/accept.py
+++ b/src/globus_cli/commands/group/invite/accept.py
@@ -21,7 +21,7 @@ from ._common import build_invite_actions, get_invite_formatter
 )
 @LoginManager.requires_login("groups")
 def invite_accept(
-    *, group_id: uuid.UUID, identity: ParsedIdentity | None, login_manager: LoginManager
+    login_manager: LoginManager, *, group_id: uuid.UUID, identity: ParsedIdentity | None
 ) -> None:
     """
     Accept an invitation to a group

--- a/src/globus_cli/commands/group/invite/decline.py
+++ b/src/globus_cli/commands/group/invite/decline.py
@@ -21,7 +21,7 @@ from ._common import build_invite_actions, get_invite_formatter
 )
 @LoginManager.requires_login("groups")
 def invite_decline(
-    *, group_id: uuid.UUID, identity: ParsedIdentity | None, login_manager: LoginManager
+    login_manager: LoginManager, *, group_id: uuid.UUID, identity: ParsedIdentity | None
 ) -> None:
     """
     Decline an invitation to a group

--- a/src/globus_cli/commands/group/join.py
+++ b/src/globus_cli/commands/group/join.py
@@ -32,11 +32,11 @@ JOIN_USER_FIELDS = [
 )
 @LoginManager.requires_login("groups")
 def group_join(
+    login_manager: LoginManager,
     *,
     group_id: uuid.UUID,
     identity: ParsedIdentity | None,
     request: bool,
-    login_manager: LoginManager,
 ) -> None:
     """
     Join a group in which you are not a member.

--- a/src/globus_cli/commands/group/leave.py
+++ b/src/globus_cli/commands/group/leave.py
@@ -42,10 +42,10 @@ def group_leave_formatter(data: globus_sdk.GlobusHTTPResponse) -> None:
 )
 @LoginManager.requires_login("groups")
 def group_leave(
+    login_manager: LoginManager,
     *,
     group_id: uuid.UUID,
     identity: ParsedIdentity | None,
-    login_manager: LoginManager,
 ) -> None:
     """
     Leave a group in which you are a member.

--- a/src/globus_cli/commands/group/list.py
+++ b/src/globus_cli/commands/group/list.py
@@ -7,7 +7,7 @@ from ._common import SESSION_ENFORCEMENT_FIELD
 
 @command("list", short_help="List groups you belong to")
 @LoginManager.requires_login("groups")
-def group_list(*, login_manager: LoginManager) -> None:
+def group_list(login_manager: LoginManager) -> None:
     """List all groups for the current user"""
     groups_client = login_manager.get_groups_client()
 

--- a/src/globus_cli/commands/group/member/add.py
+++ b/src/globus_cli/commands/group/member/add.py
@@ -33,8 +33,8 @@ ADD_USER_FIELDS = [
 )
 @LoginManager.requires_login("groups")
 def member_add(
-    *,
     login_manager: LoginManager,
+    *,
     group_id: uuid.UUID,
     user: ParsedIdentity,
     role: Literal["member", "manager", "admin"],

--- a/src/globus_cli/commands/group/member/approve.py
+++ b/src/globus_cli/commands/group/member/approve.py
@@ -20,7 +20,7 @@ APPROVED_USER_FIELDS = [
 @click.argument("user", type=IdentityType())
 @LoginManager.requires_login("groups")
 def member_approve(
-    *, group_id: uuid.UUID, user: ParsedIdentity, login_manager: LoginManager
+    login_manager: LoginManager, *, group_id: uuid.UUID, user: ParsedIdentity
 ) -> None:
     """
     Approve a pending member to join a group, changing their status from 'invited'

--- a/src/globus_cli/commands/group/member/invite.py
+++ b/src/globus_cli/commands/group/member/invite.py
@@ -38,8 +38,8 @@ INVITED_USER_FIELDS = [
 )
 @LoginManager.requires_login("groups")
 def member_invite(
-    *,
     login_manager: LoginManager,
+    *,
     group_id: uuid.UUID,
     user: ParsedIdentity,
     provision_identity: bool,

--- a/src/globus_cli/commands/group/member/list.py
+++ b/src/globus_cli/commands/group/member/list.py
@@ -25,8 +25,8 @@ def _str2field(fieldname: str) -> Field:
 @command("list")
 @LoginManager.requires_login("groups")
 def member_list(
-    *,
     login_manager: LoginManager,
+    *,
     group_id: uuid.UUID,
     fields: list[str] | None,
 ) -> None:

--- a/src/globus_cli/commands/group/member/reject.py
+++ b/src/globus_cli/commands/group/member/reject.py
@@ -20,7 +20,7 @@ REJECTED_USER_FIELDS = [
 @click.argument("user", type=IdentityType())
 @LoginManager.requires_login("groups")
 def member_reject(
-    *, group_id: uuid.UUID, user: ParsedIdentity, login_manager: LoginManager
+    login_manager: LoginManager, *, group_id: uuid.UUID, user: ParsedIdentity
 ) -> None:
     """
     Reject a pending member from a group.

--- a/src/globus_cli/commands/group/member/remove.py
+++ b/src/globus_cli/commands/group/member/remove.py
@@ -20,7 +20,7 @@ REMOVED_USER_FIELDS = [
 @click.argument("user", type=IdentityType())
 @LoginManager.requires_login("groups")
 def member_remove(
-    *, group_id: uuid.UUID, user: ParsedIdentity, login_manager: LoginManager
+    login_manager: LoginManager, *, group_id: uuid.UUID, user: ParsedIdentity
 ) -> None:
     """
     Remove a member from a group.

--- a/src/globus_cli/commands/group/set_policies.py
+++ b/src/globus_cli/commands/group/set_policies.py
@@ -65,8 +65,8 @@ else:
 @command("set-policies")
 @LoginManager.requires_login("groups")
 def group_set_policies(
-    *,
     login_manager: LoginManager,
+    *,
     group_id: uuid.UUID,
     high_assurance: bool | None,
     authentication_timeout: int | None,

--- a/src/globus_cli/commands/group/show.py
+++ b/src/globus_cli/commands/group/show.py
@@ -10,11 +10,7 @@ from ._common import SESSION_ENFORCEMENT_FIELD, group_id_arg
 @group_id_arg
 @command("show")
 @LoginManager.requires_login("groups")
-def group_show(
-    *,
-    login_manager: LoginManager,
-    group_id: uuid.UUID,
-) -> None:
+def group_show(login_manager: LoginManager, *, group_id: uuid.UUID) -> None:
     """Show a group definition"""
     groups_client = login_manager.get_groups_client()
 

--- a/src/globus_cli/commands/group/update.py
+++ b/src/globus_cli/commands/group/update.py
@@ -17,8 +17,8 @@ from ._common import group_id_arg
 @click.option("--description", help="Description for the group")
 @LoginManager.requires_login("groups")
 def group_update(
-    *,
     login_manager: LoginManager,
+    *,
     group_id: uuid.UUID,
     name: str | None,
     description: str | None,

--- a/src/globus_cli/commands/logout.py
+++ b/src/globus_cli/commands/logout.py
@@ -55,7 +55,7 @@ flow.
     default=False,
 )
 @LoginManager.requires_login()
-def logout_command(*, login_manager: LoginManager, ignore_errors: bool) -> None:
+def logout_command(login_manager: LoginManager, *, ignore_errors: bool) -> None:
     """
     Logout of the Globus CLI
 

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -126,8 +126,8 @@ $ globus ls $ep_id:/share/godata/ --filter '~*.txt'  # done with --filter, bette
 @local_user_option
 @LoginManager.requires_login("transfer")
 def ls_command(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_plus_path: tuple[uuid.UUID, str | None],
     recursive_depth_limit: int,
     recursive: bool,

--- a/src/globus_cli/commands/mkdir.py
+++ b/src/globus_cli/commands/mkdir.py
@@ -25,8 +25,8 @@ $ mkdir ep_id:~/testfolder
 @local_user_option
 @LoginManager.requires_login("transfer")
 def mkdir_command(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_plus_path: tuple[uuid.UUID, str],
     local_user: str | None,
 ):

--- a/src/globus_cli/commands/rename.py
+++ b/src/globus_cli/commands/rename.py
@@ -27,8 +27,8 @@ $ globus rename $ep_id:~/tempdir $ep_id:~/project-foo
 @local_user_option
 @LoginManager.requires_login("transfer")
 def rename_command(
-    *,
     login_manager: LoginManager,
+    *,
     endpoint_id: uuid.UUID,
     source: str,
     destination: str,

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -47,8 +47,8 @@ $ globus rm $ep_id:~/mydir --recursive
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
 @LoginManager.requires_login("transfer")
 def rm_command(
-    *,
     login_manager: LoginManager,
+    *,
     ignore_missing: bool,
     star_silent: bool,
     recursive: bool,

--- a/src/globus_cli/commands/search/delete_by_query.py
+++ b/src/globus_cli/commands/search/delete_by_query.py
@@ -33,8 +33,8 @@ from ._common import index_id_arg
 @mutex_option_group("-q", "--query-document")
 @LoginManager.requires_login("search")
 def delete_by_query_command(
-    *,
     login_manager: LoginManager,
+    *,
     index_id: uuid.UUID,
     q: str | None,
     query_document: ParsedJSONData | None,

--- a/src/globus_cli/commands/search/index/create.py
+++ b/src/globus_cli/commands/search/index/create.py
@@ -12,7 +12,7 @@ from .._common import INDEX_FIELDS
 @click.argument("DISPLAY_NAME")
 @click.argument("DESCRIPTION")
 def create_command(
-    *, login_manager: LoginManager, display_name: str, description: str
+    login_manager: LoginManager, *, display_name: str, description: str
 ) -> None:
     """Create a new Index"""
     search_client = login_manager.get_search_client()

--- a/src/globus_cli/commands/search/index/delete.py
+++ b/src/globus_cli/commands/search/index/delete.py
@@ -8,7 +8,7 @@ from globus_cli.termio import display
 @command("delete")
 @LoginManager.requires_login("search")
 @click.argument("INDEX_ID")
-def delete_command(*, login_manager: LoginManager, index_id: str) -> None:
+def delete_command(login_manager: LoginManager, *, index_id: str) -> None:
     """Delete a Search Index"""
     search_client = login_manager.get_search_client()
     display(

--- a/src/globus_cli/commands/search/index/list.py
+++ b/src/globus_cli/commands/search/index/list.py
@@ -11,7 +11,7 @@ INDEX_LIST_FIELDS = INDEX_FIELDS + [
 
 @command("list")
 @LoginManager.requires_login("search")
-def list_command(*, login_manager: LoginManager) -> None:
+def list_command(login_manager: LoginManager) -> None:
     """List indices where you have some permissions"""
     search_client = login_manager.get_search_client()
     display(

--- a/src/globus_cli/commands/search/index/role/create.py
+++ b/src/globus_cli/commands/search/index/role/create.py
@@ -34,12 +34,12 @@ else:
 )
 @LoginManager.requires_login("auth", "search")
 def create_command(
+    login_manager: LoginManager,
     *,
     index_id: uuid.UUID,
     role_name: str,
     principal: str,
     principal_type: Literal["identity", "group"] | None,
-    login_manager: LoginManager,
 ) -> None:
     """
     Create a role (requires admin or owner)

--- a/src/globus_cli/commands/search/index/role/delete.py
+++ b/src/globus_cli/commands/search/index/role/delete.py
@@ -14,10 +14,10 @@ from ..._common import index_id_arg
 @click.argument("ROLE_ID")
 @LoginManager.requires_login("search")
 def delete_command(
+    login_manager: LoginManager,
     *,
     index_id: uuid.UUID,
     role_id: str,
-    login_manager: LoginManager,
 ) -> None:
     """Delete a role (requires admin or owner)"""
     search_client = login_manager.get_search_client()

--- a/src/globus_cli/commands/search/index/role/list.py
+++ b/src/globus_cli/commands/search/index/role/list.py
@@ -10,7 +10,7 @@ from ..._common import index_id_arg, resolved_principals_field
 @command("list")
 @index_id_arg
 @LoginManager.requires_login("auth", "search")
-def list_command(*, login_manager: LoginManager, index_id: uuid.UUID) -> None:
+def list_command(login_manager: LoginManager, *, index_id: uuid.UUID) -> None:
     """List roles on an index (requires admin)"""
     search_client = login_manager.get_search_client()
     auth_client = login_manager.get_auth_client()

--- a/src/globus_cli/commands/search/index/show.py
+++ b/src/globus_cli/commands/search/index/show.py
@@ -10,7 +10,7 @@ from .._common import INDEX_FIELDS, index_id_arg
 @command("show")
 @index_id_arg
 @LoginManager.requires_login("search")
-def show_command(*, login_manager: LoginManager, index_id: uuid.UUID) -> None:
+def show_command(login_manager: LoginManager, *, index_id: uuid.UUID) -> None:
     """Display information about an index"""
     search_client = login_manager.get_search_client()
     display(

--- a/src/globus_cli/commands/search/ingest.py
+++ b/src/globus_cli/commands/search/ingest.py
@@ -14,7 +14,7 @@ from ._common import index_id_arg
 @click.argument("DOCUMENT", type=JSONStringOrFile())
 @LoginManager.requires_login("search")
 def ingest_command(
-    *, login_manager: LoginManager, index_id: uuid.UUID, document: ParsedJSONData
+    login_manager: LoginManager, *, index_id: uuid.UUID, document: ParsedJSONData
 ) -> None:
     """
     Submit a Globus Search 'GIngest' document, to be indexed in a Globus Search Index.

--- a/src/globus_cli/commands/search/query.py
+++ b/src/globus_cli/commands/search/query.py
@@ -60,8 +60,8 @@ def _print_subjects(data: dict[str, JsonValue]) -> None:
 @mutex_option_group("-q", "--query-document")
 @LoginManager.requires_login("search")
 def query_command(
-    *,
     login_manager: LoginManager,
+    *,
     index_id: uuid.UUID,
     q: str | None,
     query_document: ParsedJSONData | None,

--- a/src/globus_cli/commands/search/subject/delete.py
+++ b/src/globus_cli/commands/search/subject/delete.py
@@ -14,10 +14,10 @@ from .._common import index_id_arg
 @click.argument("subject")
 @LoginManager.requires_login("search")
 def delete_command(
+    login_manager: LoginManager,
     *,
     index_id: uuid.UUID,
     subject: str,
-    login_manager: LoginManager,
 ) -> None:
     """Delete a subject (requires writer, admin, or owner)
 

--- a/src/globus_cli/commands/search/subject/show.py
+++ b/src/globus_cli/commands/search/subject/show.py
@@ -24,7 +24,7 @@ def _print_subject(subject_doc: "globus_sdk.GlobusHTTPResponse") -> None:
 @click.argument("subject")
 @LoginManager.requires_login("auth", "search")
 def show_command(
-    *, login_manager: LoginManager, index_id: uuid.UUID, subject: str
+    login_manager: LoginManager, *, index_id: uuid.UUID, subject: str
 ) -> None:
     """Show the data for a given subject in an index
 

--- a/src/globus_cli/commands/search/task/list.py
+++ b/src/globus_cli/commands/search/task/list.py
@@ -17,7 +17,7 @@ TASK_FIELDS = [
 @command("list", short_help="List recent Tasks for an index")
 @index_id_arg
 @LoginManager.requires_login("search")
-def list_command(*, login_manager: LoginManager, index_id: uuid.UUID) -> None:
+def list_command(login_manager: LoginManager, *, index_id: uuid.UUID) -> None:
     """List the 1000 most recent Tasks for an index"""
     search_client = login_manager.get_search_client()
     display(

--- a/src/globus_cli/commands/search/task/show.py
+++ b/src/globus_cli/commands/search/task/show.py
@@ -22,7 +22,7 @@ TASK_FIELDS = [
 @command("show")
 @task_id_arg
 @LoginManager.requires_login("search")
-def show_command(*, login_manager: LoginManager, task_id: uuid.UUID) -> None:
+def show_command(login_manager: LoginManager, *, task_id: uuid.UUID) -> None:
     """Display a Task"""
     search_client = login_manager.get_search_client()
     display(

--- a/src/globus_cli/commands/session/show.py
+++ b/src/globus_cli/commands/session/show.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import datetime
+import typing as t
 
 import globus_sdk
 
@@ -44,7 +47,7 @@ $ globus session show --format json
 """,
 )
 @LoginManager.requires_login("auth")
-def session_show(*, login_manager):
+def session_show(login_manager: LoginManager):
     """List all identities in your current CLI auth session.
 
     Lists identities that are in the session tied to the CLI's access tokens along with
@@ -56,6 +59,7 @@ def session_show(*, login_manager):
     # get a token to introspect, refreshing if necessary
     try:
         # may force a refresh if the token is expired
+        assert auth_client.authorizer
         auth_client.authorizer.get_authorization_header()
     except AttributeError:  # if we have no RefreshTokenAuthorizor
         pass
@@ -63,8 +67,8 @@ def session_show(*, login_manager):
     tokendata = adapter.get_token_data("auth.globus.org")
     # if there's no token (e.g. not logged in), stub with empty data
     if not tokendata:
-        session_info = {}
-        authentications = {}
+        session_info: dict[str, t.Any] = {}
+        authentications: dict[str, dict[str, t.Any]] = {}
     else:
         if is_client_login():
             introspect_client = get_client_login()

--- a/src/globus_cli/commands/session/update.py
+++ b/src/globus_cli/commands/session/update.py
@@ -98,8 +98,8 @@ def _update_session_params_identities_case(
 )
 @LoginManager.requires_login("auth")
 def session_update(
-    *,
     login_manager: LoginManager,
+    *,
     identities: tuple[ParsedIdentity, ...],
     no_local_server: bool,
     policies: list[str] | None,

--- a/src/globus_cli/commands/task/cancel.py
+++ b/src/globus_cli/commands/task/cancel.py
@@ -53,7 +53,7 @@ $ globus task cancel --all
     "--all", "-a", is_flag=True, help="Cancel all in-progress tasks that you own"
 )
 @LoginManager.requires_login("transfer")
-def cancel_task(*, login_manager: LoginManager, all: bool, task_id: uuid.UUID) -> None:
+def cancel_task(login_manager: LoginManager, *, all: bool, task_id: uuid.UUID) -> None:
     """
     Cancel a task you own or all tasks which you own.
 

--- a/src/globus_cli/commands/task/event_list.py
+++ b/src/globus_cli/commands/task/event_list.py
@@ -73,8 +73,8 @@ $ globus task pause-info TASK_ID --format JSON
 @click.option("--filter-non-errors", is_flag=True, help="Filter results to non errors")
 @LoginManager.requires_login("transfer")
 def task_event_list(
-    *,
     login_manager: LoginManager,
+    *,
     task_id: uuid.UUID,
     limit: int,
     filter_errors: bool,

--- a/src/globus_cli/commands/task/generate_submission_id.py
+++ b/src/globus_cli/commands/task/generate_submission_id.py
@@ -19,7 +19,7 @@ $ globus transfer --submission-id "$sub_id" ...
 """,
 )
 @LoginManager.requires_login("transfer")
-def generate_submission_id(*, login_manager: LoginManager) -> None:
+def generate_submission_id(login_manager: LoginManager) -> None:
     """
     Generate a new task submission ID for use in  `globus transfer` and `globus delete`.
     Submission IDs allow you to safely retry submission of a task in the presence of

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -170,8 +170,8 @@ globus task list --format=unix --jmespath='DATA[*].[task_id, status]' | \
 )
 @LoginManager.requires_login("transfer")
 def task_list(
-    *,
     login_manager: LoginManager,
+    *,
     limit: int,
     filter_task_id: tuple[uuid.UUID, ...],
     filter_type: Literal["TRANSFER", "DELETE"] | None,

--- a/src/globus_cli/commands/task/pause_info.py
+++ b/src/globus_cli/commands/task/pause_info.py
@@ -88,7 +88,7 @@ $ globus task pause-info TASK_ID --format JSON
 )
 @task_id_arg()
 @LoginManager.requires_login("transfer")
-def task_pause_info(*, login_manager: LoginManager, task_id: uuid.UUID) -> None:
+def task_pause_info(login_manager: LoginManager, *, task_id: uuid.UUID) -> None:
     """
     Show messages from activity managers who have explicitly paused the given
     in-progress task and list any active pause rules that apply to it.

--- a/src/globus_cli/commands/task/show.py
+++ b/src/globus_cli/commands/task/show.py
@@ -174,8 +174,8 @@ $ globus task show TASK_ID
 @mutex_option_group("--successful-transfers", "--skipped-errors")
 @LoginManager.requires_login("transfer")
 def show_task(
-    *,
     login_manager: LoginManager,
+    *,
     successful_transfers: bool,
     skipped_errors: bool,
     task_id: uuid.UUID,

--- a/src/globus_cli/commands/task/update.py
+++ b/src/globus_cli/commands/task/update.py
@@ -32,8 +32,8 @@ $ globus task update TASK_ID --label 'my task updated by me' \
 @click.option("--deadline", help="New Deadline for the task")
 @LoginManager.requires_login("transfer")
 def update_task(
-    *,
     login_manager: LoginManager,
+    *,
     deadline: str | None,
     label: str | None,
     task_id: uuid.UUID,

--- a/src/globus_cli/commands/task/wait.py
+++ b/src/globus_cli/commands/task/wait.py
@@ -40,8 +40,8 @@ $ globus task wait --polling-interval 300 TASK_ID
 @synchronous_task_wait_options
 @LoginManager.requires_login("transfer")
 def task_wait(
-    *,
     login_manager: LoginManager,
+    *,
     meow: bool,
     heartbeat: bool,
     polling_interval: int,

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -97,8 +97,8 @@ def resolve_start_time(start: datetime.datetime | None) -> datetime.datetime:
 )
 @LoginManager.requires_login("auth", "timer", "transfer")
 def transfer_command(
-    *,
     login_manager: LoginManager,
+    *,
     name: str | None,
     source: tuple[uuid.UUID, str | None],
     destination: tuple[uuid.UUID, str | None],

--- a/src/globus_cli/commands/timer/delete.py
+++ b/src/globus_cli/commands/timer/delete.py
@@ -12,7 +12,7 @@ from ._common import DELETED_JOB_FORMAT_FIELDS
 @command("delete", short_help="Delete a timer job")
 @click.argument("JOB_ID", type=click.UUID)
 @LoginManager.requires_login("timer")
-def delete_command(*, login_manager: LoginManager, job_id: uuid.UUID) -> None:
+def delete_command(login_manager: LoginManager, *, job_id: uuid.UUID) -> None:
     """
     Delete a Timer job.
 

--- a/src/globus_cli/commands/timer/list.py
+++ b/src/globus_cli/commands/timer/list.py
@@ -7,7 +7,7 @@ from ._common import JOB_FORMAT_FIELDS
 
 @command("list", short_help="List your jobs")
 @LoginManager.requires_login("timer")
-def list_command(*, login_manager: LoginManager) -> None:
+def list_command(login_manager: LoginManager) -> None:
     """
     List your Timer jobs.
     """

--- a/src/globus_cli/commands/timer/show.py
+++ b/src/globus_cli/commands/timer/show.py
@@ -12,7 +12,7 @@ from ._common import JOB_FORMAT_FIELDS
 @command("show", short_help="Display a Timer job")
 @click.argument("JOB_ID", type=click.UUID)
 @LoginManager.requires_login("timer")
-def show_command(*, login_manager: LoginManager, job_id: uuid.UUID) -> None:
+def show_command(login_manager: LoginManager, *, job_id: uuid.UUID) -> None:
     """
     Display information about a particular job.
     """

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -215,8 +215,8 @@ fi
 @mutex_option_group("--recursive", "--external-checksum")
 @LoginManager.requires_login("transfer")
 def transfer_command(
-    *,
     login_manager: LoginManager,
+    *,
     batch: t.TextIO | None,
     sync_level: Literal["exists", "size", "mtime", "checksum"] | None,
     recursive: bool,

--- a/src/globus_cli/commands/whoami.py
+++ b/src/globus_cli/commands/whoami.py
@@ -49,7 +49,7 @@ $ globus whoami --linked-identities
     help="Also show identities linked to the currently logged-in primary identity.",
 )
 @LoginManager.requires_login("auth")
-def whoami_command(*, login_manager: LoginManager, linked_identities: bool) -> None:
+def whoami_command(login_manager: LoginManager, *, linked_identities: bool) -> None:
     """
     Display information for the currently logged-in user.
     """

--- a/src/globus_cli/login_manager/_old_config.py
+++ b/src/globus_cli/login_manager/_old_config.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import os
+import typing as t
 from configparser import ConfigParser
 
 import globus_sdk
@@ -6,17 +9,17 @@ import globus_sdk
 GLOBUS_ENV = os.environ.get("GLOBUS_SDK_ENVIRONMENT")
 
 
-def _get_old_conf_path():
+def _get_old_conf_path() -> str:
     return os.path.expanduser("~/.globus.cfg")
 
 
-def _old_conf_parser():
+def _old_conf_parser() -> ConfigParser:
     conf = ConfigParser()
     conf.read(_get_old_conf_path())
     return conf
 
 
-def _token_conf_keys():
+def _token_conf_keys() -> t.Iterator[str]:
     for k in [
         "auth_refresh_token",
         "auth_access_token",
@@ -27,14 +30,14 @@ def _token_conf_keys():
         yield (f"{GLOBUS_ENV}_{k}" if GLOBUS_ENV else k)
 
 
-def _old_tokens_to_revoke(conf):
+def _old_tokens_to_revoke(conf: ConfigParser) -> t.Iterator[str]:
     for key in _token_conf_keys():
         tokenstr = conf.get("cli", key, fallback=None)
         if tokenstr:
             yield tokenstr
 
 
-def _get_client_creds(conf):
+def _get_client_creds(conf: ConfigParser) -> tuple[str, str] | None:
     id_key, secret_key = ("client_id", "client_secret")
     if GLOBUS_ENV:
         id_key, secret_key = (f"{GLOBUS_ENV}_client_id", f"{GLOBUS_ENV}_client_secret")
@@ -45,7 +48,7 @@ def _get_client_creds(conf):
     return None
 
 
-def invalidate_old_config(auth_client):
+def invalidate_old_config(auth_client: globus_sdk.AuthClient) -> None:
     # revoke any old config-stored tokens (logout)
     # and delete old client creds
     conf = _old_conf_parser()

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -93,7 +93,7 @@ def do_local_server_auth_flow(
     if isinstance(auth_code, LocalServerError):
         click.echo(f"Authorization failed: {auth_code}", err=True)
         click.get_current_context().exit(1)
-    elif isinstance(auth_code, Exception):
+    elif isinstance(auth_code, BaseException):
         click.echo(
             f"Authorization failed with unexpected error:\n{auth_code}",
             err=True,

--- a/src/globus_cli/login_manager/errors.py
+++ b/src/globus_cli/login_manager/errors.py
@@ -7,7 +7,11 @@ from .scopes import CLI_SCOPE_REQUIREMENTS
 
 class MissingLoginError(ValueError):
     def __init__(
-        self, missing_servers: t.Sequence[str], *, assume_gcs=False, assume_flow=False
+        self,
+        missing_servers: t.Sequence[str],
+        *,
+        assume_gcs: bool = False,
+        assume_flow: bool = False,
     ):
         self.missing_servers = missing_servers
         self.assume_gcs = assume_gcs
@@ -37,7 +41,7 @@ class MissingLoginError(ValueError):
         )
         super().__init__(self.message)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
 

--- a/src/globus_cli/login_manager/utils.py
+++ b/src/globus_cli/login_manager/utils.py
@@ -1,5 +1,5 @@
 import os
 
 
-def is_remote_session():
-    return os.environ.get("SSH_TTY", os.environ.get("SSH_CONNECTION"))
+def is_remote_session() -> bool:
+    return bool(os.environ.get("SSH_TTY", os.environ.get("SSH_CONNECTION")))

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -256,7 +256,7 @@ def test_gcs_error_message(patched_tokenstorage):
 
 def test_client_login_two_requirements(client_login):
     @LoginManager.requires_login("transfer", "auth")
-    def dummy_command(*, login_manager):
+    def dummy_command(login_manager):
         transfer_client = login_manager.get_transfer_client()
         auth_client = login_manager.get_auth_client()
 
@@ -284,7 +284,7 @@ def test_client_login_gcs(client_login, add_gcs_login):
         add_gcs_login(gcs_id)
 
         @LoginManager.requires_login("transfer")
-        def dummy_command(*, login_manager, collection_id):
+        def dummy_command(login_manager, *, collection_id):
             gcs_client = login_manager.get_gcs_client(collection_id=collection_id)
 
             assert isinstance(


### PR DESCRIPTION
This was done in two commits because the second part has a surprising and outsized impact.
The first commit just applies some simple annotations in a few modules.

The second commit's full message is reproduced below.

---

[Type annotate LoginManager and accommodate typing](https://github.com/globus/globus-cli/commit/5d6ccc263d938f88d419089c0e78a7371bb5eb48)

```
Most of the annotation changes have no broad impact.
However, one change in particular is nefariously tricky:
`requires_login`.

This is a decorator factory which needs to be annotated in a way to
indicate that it adds an argument. ParamSpec and typing do not support
annotating the behavior we have today, in which the decorator adds the
`login_manager` keyword argument. The closest possible phrasing is to
use ParamSpec+Concatenate to indicate that we pass it as the first
positional argument. Therefore, *change the runtime logic to use this
pattern* and apply the ParamSpec-based annotations needed to validate
this in all commands.

In all cases where `login_manager` is passed via `requires_login`,
move it to be the only positional argument and annotate all other
command parameters as keyword-only, using the `*` separator. This also
uniformizes several commands which had drifted away from the preferred
style of keyword-only argument declarations.

The final detail on this change is that `mypy` has recently
experienced a regression in the handling of ParamSpecs under complex
scenarios like decorator factories. There is at least one potential
fix in progress, but it is unclear when it might release as it does
not appear to be ready for the upcoming v1.5 release.
However, `mypy` *does* correctly understand the actual type of such a
decorator factory -- this can be tested with `reveal_type` -- so we
can use this feature but with a type-ignore in a relatively
critical-looking location (the return value of the decorator
factory).

In addition to these changes, applying this change to
`session show` resulted in some other annotation issues being flagged
by mypy, so those are fixed here as well.
```