### PR TITLE
Increase JWT leeway for decode_id_token to 64s

### DIFF
--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -33,6 +33,9 @@ def test_login_validates_token(
 
 
 class MockToken:
+    def __init__(self, uuid_value: int = 1) -> None:
+        self._uuid_value = uuid_value
+
     by_resource_server = {
         "auth.globus.org": _mock_token_response_data(
             "auth.globus.org",
@@ -45,8 +48,8 @@ class MockToken:
         ),
     }
 
-    def decode_id_token(self, uuid_value: int = 1):
-        return {"sub": str(uuid.UUID(int=uuid_value))}
+    def decode_id_token(self, *args, **kwargs):
+        return {"sub": str(uuid.UUID(int=self._uuid_value))}
 
 
 def test_login_gcs_different_identity(


### PR DESCRIPTION
See also https://github.com/globus/globus-cli/issues/820#issuecomment-1658749506

We set the default to 0.5s and said we'd adjust if any users got back to us and said it wasn't enough. This is us adjusting.

---

A detailed comment explains why this value was chosen. One test which declared an incorrect interface for a fake object has been fixed, as it started failing when `jwt_params` was passed.