### PR TITLE
Implement 'flows run list'

### DIFF
--- a/changelog.d/20230731_171256_sirosen_implement_run_list.md
+++ b/changelog.d/20230731_171256_sirosen_implement_run_list.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add `globus flows run list` for listing runs visible to the current user

--- a/src/globus_cli/commands/flows/run/__init__.py
+++ b/src/globus_cli/commands/flows/run/__init__.py
@@ -5,6 +5,7 @@ from globus_cli.parsing import group
     "run",
     lazy_subcommands={
         "show": (".show", "show_command"),
+        "list": (".list", "list_command"),
         "update": (".update", "update_command"),
         "delete": (".delete", "delete_command"),
         "resume": (".resume", "resume_command"),

--- a/src/globus_cli/commands/flows/run/list.py
+++ b/src/globus_cli/commands/flows/run/list.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import uuid
+
+import click
+from globus_sdk.paging import Paginator
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import Field, display
+from globus_cli.utils import PagingWrapper
+
+
+@command("list")
+@click.option(
+    "--filter-flow-id",
+    help=(
+        "Filter results to runs with a particular flow ID or flow IDs. "
+        "This option may be specified multiple times to filter by multiple "
+        "flow IDs."
+    ),
+    multiple=True,
+    type=click.UUID,
+)
+@click.option(
+    "--limit",
+    default=25,
+    show_default=True,
+    metavar="N",
+    type=click.IntRange(1),
+    help="The maximum number of results to return.",
+)
+@LoginManager.requires_login("flows")
+def list_command(
+    login_manager: LoginManager, *, limit: int, filter_flow_id: tuple[uuid.UUID, ...]
+) -> None:
+    """
+    List runs
+
+    Enumerates runs visible to the current user, potentially filtered by the ID of
+    the flow which was used to start the run.
+    """
+
+    flows_client = login_manager.get_flows_client()
+
+    paginator = Paginator.wrap(flows_client.list_runs)
+    run_iterator = PagingWrapper(
+        paginator(filter_flow_id=filter_flow_id).items(),
+        json_conversion_key="runs",
+        limit=limit,
+    )
+
+    fields = [
+        Field("Run ID", "run_id"),
+        Field("Flow Title", "flow_title"),
+        Field("Run Label", "label"),
+        Field("Status", "status"),
+    ]
+
+    display(run_iterator, fields=fields, json_converter=run_iterator.json_converter)

--- a/tests/functional/flows/test_list_runs.py
+++ b/tests/functional/flows/test_list_runs.py
@@ -1,0 +1,76 @@
+import uuid
+
+import pytest
+from globus_sdk._testing import load_response
+
+
+def test_list_runs_simple(run_line):
+    meta = load_response("flows.list_runs").metadata
+    first_run_id = meta["first_run_id"]
+
+    result = run_line(["globus", "flows", "run", "list"])
+    output_lines = result.output.split("\n")
+    assert len(output_lines) >= 4
+
+    header_line = output_lines[0]
+    header_row = [item.strip() for item in header_line.split(" | ")]
+    assert header_row == ["Run ID", "Flow Title", "Run Label", "Status"]
+
+    first_line = output_lines[2]
+    first_row = first_line.split(" | ")
+    assert first_row[0] == first_run_id
+
+
+def test_list_runs_filter_by_flow_id(run_line):
+    meta = load_response("flows.list_runs", case="filter_flow_id").metadata
+    flow_ids_to_use = meta["by_flow_id"].keys()
+
+    # first test on each flow_id individually
+    for flow_id in flow_ids_to_use:
+        expect_num_results = meta["by_flow_id"][flow_id]["num"]
+        result = run_line(
+            ["globus", "flows", "run", "list", "--filter-flow-id", flow_id]
+        )
+        output_lines = result.output.split("\n")
+
+        # allow for two header rows + final newline
+        assert len(output_lines) == expect_num_results + 3
+
+    # then combine them all into one filter and test again
+    combined_filter_args = []
+    for flow_id in flow_ids_to_use:
+        combined_filter_args.extend(["--filter-flow-id", flow_id])
+    result = run_line(["globus", "flows", "run", "list", *combined_filter_args])
+    output_lines = result.output.split("\n")
+
+    header_line = output_lines[0]
+    header_row = [item.strip() for item in header_line.split(" | ")]
+    assert header_row == ["Run ID", "Flow Title", "Run Label", "Status"]
+
+    # trim header and final newline, compare against all of the filtered results
+    lines = output_lines[2:-1]
+    assert len(lines) == sum(data["num"] for data in meta["by_flow_id"].values())
+
+
+@pytest.mark.parametrize("limit_delta", [-5, 0, 5])
+def test_list_runs_paginated_response(run_line, limit_delta):
+    meta = load_response("flows.list_runs", case="paginated").metadata
+
+    # limit results to a number with a potential delta from the number of items
+    # this helps exercise the CLI's limiting behavior
+    limit = meta["total_items"] + limit_delta
+    result = run_line(["globus", "flows", "run", "list", "--limit", str(limit)])
+    output_lines = result.output.split("\n")
+    # two header lines + final newline
+    assert len(output_lines) == min(limit, meta["total_items"]) + 3
+
+    header_line = output_lines[0]
+    header_row = [item.strip() for item in header_line.split(" | ")]
+    assert header_row == ["Run ID", "Flow Title", "Run Label", "Status"]
+
+    for line in output_lines[2:-1]:
+        row = line.split(" | ")
+        try:
+            uuid.UUID(row[0])
+        except ValueError:
+            pytest.fail(f"Run ID is not a valid UUID: {row[0]}")


### PR DESCRIPTION
Introduce a command implementation with the following characteristics:
- supports pagination + `--limit`
- accepts `--filter-flow-id` as a multiple option
- tests against the available data from `globus_sdk._testing`

---

edit: I changed some tests at the last minute and didn't check my work, so I had to do a quick amend here.