### PR TITLE
Convert Transfer Timer consent check to use trees

### DIFF
--- a/src/globus_cli/services/auth.py
+++ b/src/globus_cli/services/auth.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
+import typing as t
 import uuid
 
 import globus_sdk
+import globus_sdk.scopes
 
 
 def _is_uuid(s):
@@ -40,3 +44,66 @@ class CustomAuthClient(globus_sdk.AuthClient):
 
     def lookup_identity_name(self, identity_id):
         return self._lookup_identity_field(id_id=identity_id, field="username")
+
+    def get_consents(self, identity_id) -> ConsentForestResponse:
+        """
+        Get the consent for a given identity_id
+        """
+        return ConsentForestResponse(
+            self.get(f"/v2/api/identities/{identity_id}/consents")
+        )
+
+
+class ConsentForestResponse(globus_sdk.GlobusHTTPResponse):
+    @property
+    def consents(self) -> list[dict[str, t.Any]]:
+        return t.cast("list[dict[str, t.Any]]", self.data["consents"])
+
+    def top_level_consents(self) -> list[dict[str, t.Any]]:
+        return [c for c in self.consents if len(c["dependency_path"]) == 1]
+
+    def get_child_consents(self, consent: dict[str, t.Any]) -> list[dict[str, t.Any]]:
+        path_length = len(consent["dependency_path"]) + 1
+        return [
+            c
+            for c in self.consents
+            if len(c["dependency_path"]) == path_length
+            and c["dependency_path"][:-1] == consent["dependency_path"]
+        ]
+
+    def contains_scopes(
+        self, scope_trees: list[globus_sdk.scopes.MutableScope]
+    ) -> bool:
+        """
+        Determine whether or not a user's consents contains the given scope trees.
+        """
+        top_level_by_name = _map_consents_by_name(self.top_level_consents())
+
+        for scope in scope_trees:
+            if scope.scope_string not in top_level_by_name:
+                return False
+
+        trees_to_match = [
+            (
+                top_level_by_name[s.scope_string],
+                s,
+            )
+            for s in scope_trees
+        ]
+
+        while trees_to_match:
+            consent, scope = trees_to_match.pop()
+            child_consents = _map_consents_by_name(self.get_child_consents(consent))
+            for dependency in scope.dependencies:
+                if dependency.scope_string not in child_consents:
+                    return False
+                trees_to_match.append(
+                    (child_consents[dependency.scope_string], dependency)
+                )
+        return True
+
+
+def _map_consents_by_name(
+    consents: list[dict[str, t.Any]]
+) -> dict[str, dict[str, t.Any]]:
+    return {c["scope_name"]: c for c in consents}


### PR DESCRIPTION
Rather than doing explicit matching down the desirable path in the `timer create transfer` command, produce a MutableScope tree with the correct path and match it against the consent graph (forest) returned by the consents API.

Because the tree-like structure of MutableScope objects mirrors those which will come from the experimental scope parser in the SDK, this conversion serves as preliminary verification that we can match a subforest against the consent graph and find matching or non-matching paths.

For the initial implementation, the match is purely boolean in nature, finding only whether or not a scope was present. In the future, this could be made to return a list of mismatches or other meaningful diff data.

In service of these changes, the CustomAuthClient class now supports calling the consents API and returning a ConsentForestResponse object. The ConsentForestResponse is where the tree matching functionality resides, although it could easily be moved.

`tests/functional/timer/test_transfer_create.py` already tests this functionality in several interesting modes and confirms that it will work sufficiently for that use-case.

---

Brief aside: I originally wrote this to produce a nested scope string and use the experimental parser. The result worked, but I realized I could port it to work on released SDK versions so long as I used a `MutableScope` object instead of a string.
Supporting both in the future should be pretty easy.

I'd like this to be reviewable and mergeable ahead of scope parsing.