### PR TITLE
Add a `globus flows run cancel` command

### DIFF
--- a/changelog.d/20230807_074501_ada_implement_run_cancel.md
+++ b/changelog.d/20230807_074501_ada_implement_run_cancel.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add `globus flows run cancel` for canceling a *run* of a *flow*

--- a/src/globus_cli/commands/flows/run/__init__.py
+++ b/src/globus_cli/commands/flows/run/__init__.py
@@ -9,6 +9,7 @@ from globus_cli.parsing import group
         "update": (".update", "update_command"),
         "delete": (".delete", "delete_command"),
         "resume": (".resume", "resume_command"),
+        "cancel": (".cancel", "cancel_command"),
     },
 )
 def run_command() -> None:

--- a/src/globus_cli/commands/flows/run/cancel.py
+++ b/src/globus_cli/commands/flows/run/cancel.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import uuid
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command, run_id_arg
+from globus_cli.termio import Field, TextMode, display, formatters
+
+
+@command("cancel", short_help="Cancel a run")
+@run_id_arg
+@LoginManager.requires_login("flows")
+def cancel_command(login_manager: LoginManager, *, run_id: uuid.UUID) -> None:
+    """
+    Cancel a run
+    """
+
+    flows_client = login_manager.get_flows_client()
+
+    fields = [
+        Field("Flow ID", "flow_id"),
+        Field("Flow Title", "flow_title"),
+        Field("Run ID", "run_id"),
+        Field("Run Label", "label"),
+        Field("Started At", "start_time", formatter=formatters.Date),
+        Field("Completed At", "completion_time", formatter=formatters.Date),
+        Field("Status", "status"),
+    ]
+
+    res = flows_client.cancel_run(run_id)
+    display(res, fields=fields, text_mode=TextMode.text_record)

--- a/tests/functional/flows/test_cancel_run.py
+++ b/tests/functional/flows/test_cancel_run.py
@@ -1,0 +1,19 @@
+from globus_sdk._testing import load_response
+
+
+def test_cancel_run_text_output(run_line):
+    cancel_response = load_response("flows.cancel_run")
+    run_id = cancel_response.metadata["run_id"]
+
+    result = run_line(f"globus flows run cancel {run_id}")
+    # Verify all fields are present.
+    for fieldname in (
+        "Flow ID",
+        "Flow Title",
+        "Run ID",
+        "Run Label",
+        "Started At",
+        "Completed At",
+        "Status",
+    ):
+        assert fieldname in result.output


### PR DESCRIPTION
## Notes

Manually tested on an active run as well as a completed run (which the service also reports as a success).

## Sample

```shell
> RUN_ID=$(globus flows start 1c277566-2e6f-425e-b831-26d683db4201 --format json | jq -r ".run_id"); globus flows run cancel $RUN_ID
Flow ID:      1c277566-2e6f-425e-b831-26d683db4201
Flow Title:   slow hello worlds
Run ID:       bcc2be65-3dad-44c4-953e-8f7ba6d07e6b
Run Label:    None
Started At:   2023-08-07 07:58:54
Completed At: 2023-08-07 07:58:55
Status:       FAILED
```