### PR TITLE
Add null-checking in read_well_known_config

### DIFF
--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -262,14 +262,7 @@ def _derive_needed_scopes(
     needs_data_access: list[str],
 ) -> list[str]:
     # read the identity ID stored from the login flow
-    # we will semi-gracefully handle the case of the data having been damaged/corrupted
-    user_data = read_well_known_config("auth_user_data")
-    if user_data is None:
-        raise RuntimeError(
-            "Identity ID was unexpectedly not visible in storage. "
-            "A new login should fix the issue. "
-            "Consider using `globus login --force`"
-        )
+    user_data = read_well_known_config("auth_user_data", allow_null=False)
     user_identity_id = user_data["sub"]
 
     # get the user's Globus CLI consents


### PR DESCRIPTION
A new parameter, `allow_null=False` can be passed to handle the null data case when loading configs. Currently only used in one location (timer creation), this will also be available for other activities in the future (e.g. run resume).

---

This commit is one of the parts I found I needed in my other work and which I've extracted here for simpler review.