### PR TITLE
Implement complex run resume using experimental SDK components

### DIFF
--- a/changelog.d/20230808_165447_sirosen_complex_run_resume.md
+++ b/changelog.d/20230808_165447_sirosen_complex_run_resume.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* Improve `globus flows run resume` to be capable of detecting missing consents and prompt
+  for reauthentication via `globus session consent`. The consent check can also
+  be skipped with `--skip-inactive-reason-check`.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "globus-sdk==3.25.0",
+        "globus-sdk==3.26.0",
         "click>=8.0.0,<9",
         "jmespath==1.0.1",
         "packaging>=17.0",

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -1,16 +1,36 @@
 from __future__ import annotations
 
+import typing as t
 import uuid
 
-from globus_cli.login_manager import LoginManager
+import click
+
+from globus_cli.login_manager import LoginManager, read_well_known_config
 from globus_cli.parsing import command, run_id_arg
 from globus_cli.termio import Field, TextMode, display, formatters
+from globus_cli.utils import CLIAuthRequirementsError
+
+# NB: GARE parsing requires other SDK components and therefore needs to be deferred to
+# avoid the performance impact of non-lazy imports
+if t.TYPE_CHECKING:
+    from globus_sdk.experimental.auth_requirements_error import (
+        GlobusAuthRequirementsError,
+    )
 
 
 @command("resume")
 @run_id_arg
-@LoginManager.requires_login("flows")
-def resume_command(login_manager: LoginManager, run_id: uuid.UUID) -> None:
+@click.option(
+    "--skip-inactive-reason-check",
+    is_flag=True,
+    default=False,
+    help='Skip the check of the run\'s "inactive reason", which is used to determine '
+    "what action is required to resume the run.",
+)
+@LoginManager.requires_login("auth", "flows")
+def resume_command(
+    login_manager: LoginManager, *, run_id: uuid.UUID, skip_inactive_reason_check: bool
+) -> None:
     """
     Resume a run
     """
@@ -19,6 +39,17 @@ def resume_command(login_manager: LoginManager, run_id: uuid.UUID) -> None:
     flow_id = run_doc["flow_id"]
 
     specific_flow_client = login_manager.get_specific_flow_client(flow_id)
+
+    if not skip_inactive_reason_check:
+        gare = _get_inactive_reason(run_doc)
+        if gare is not None and gare.authorization_parameters.required_scopes:
+            if not _has_required_consent(
+                login_manager, gare.authorization_parameters.required_scopes
+            ):
+                raise CLIAuthRequirementsError(
+                    "This run is missing a necessary consent in order to resume.",
+                    required_scopes=gare.authorization_parameters.required_scopes,
+                )
 
     fields = [
         Field("Run ID", "run_id"),
@@ -32,3 +63,30 @@ def resume_command(login_manager: LoginManager, run_id: uuid.UUID) -> None:
 
     res = specific_flow_client.resume_run(run_id)
     display(res, fields=fields, text_mode=TextMode.text_record)
+
+
+def _get_inactive_reason(
+    run_doc: dict[str, t.Any]
+) -> GlobusAuthRequirementsError | None:
+    from globus_sdk.experimental.auth_requirements_error import (
+        to_auth_requirements_error,
+    )
+
+    if not run_doc.get("status") == "INACTIVE":
+        return None
+
+    details = run_doc.get("details")
+    if not isinstance(details, dict):
+        return None
+
+    return to_auth_requirements_error(details)
+
+
+def _has_required_consent(
+    login_manager: LoginManager, required_scopes: list[str]
+) -> bool:
+    auth_client = login_manager.get_auth_client()
+    user_data = read_well_known_config("auth_user_data", allow_null=False)
+    user_identity_id = user_data["sub"]
+    consents = auth_client.get_consents(user_identity_id)
+    return consents.contains_scopes(required_scopes)

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -9,6 +9,7 @@ import globus_sdk
 from globus_cli.endpointish import WrongEntityTypeError
 from globus_cli.login_manager import MissingLoginError
 from globus_cli.termio import PrintableErrorField, write_error_info
+from globus_cli.utils import CLIAuthRequirementsError
 
 from .registry import error_handler
 
@@ -17,6 +18,21 @@ def _pretty_json(data: dict, compact=False) -> str:
     if compact:
         return json.dumps(data, separators=(",", ":"), sort_keys=True)
     return json.dumps(data, indent=2, separators=(",", ": "), sort_keys=True)
+
+
+@error_handler(
+    error_class=CLIAuthRequirementsError,
+    exit_status=4,
+)
+def handle_internal_auth_requirements(exception: CLIAuthRequirementsError) -> None:
+    if not exception.required_scopes:
+        click.secho(
+            "Fatal Error: Unsupported internal auth requirements error!",
+            bold=True,
+            fg="red",
+        )
+        click.get_current_context().exit(255)
+    _concrete_consent_required_hook(exception.message, exception.required_scopes)
 
 
 @error_handler(
@@ -75,9 +91,15 @@ def consent_required_hook(exception: globus_sdk.GlobusAPIError) -> None:
     """
     Expects an exception with a required_scopes field in its raw_json
     """
+    _concrete_consent_required_hook(
+        exception.message, exception.info.consent_required.required_scopes
+    )
+
+
+def _concrete_consent_required_hook(message: str, required_scopes: list[str]) -> None:
     # specialized message for data_access errors
     # otherwise, use more generic phrasing
-    if exception.message == "Missing required data_access consent":
+    if message == "Missing required data_access consent":
         click.echo(
             "The collection you are trying to access data on requires you to "
             "grant consent for the Globus CLI to access it."
@@ -87,9 +109,8 @@ def consent_required_hook(exception: globus_sdk.GlobusAPIError) -> None:
             "The resource you are trying to access requires you to "
             "consent to additional access for the Globus CLI."
         )
-    click.echo(f"message: {exception.message}")
+    click.echo(f"message: {message}")
 
-    required_scopes = exception.info.consent_required.required_scopes
     if not required_scopes:
         click.secho(
             "Fatal Error: ConsentRequired but no required_scopes!", bold=True, fg="red"

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -182,3 +182,15 @@ def shlex_process_stream(
                     click.style(f"  {error.format_message()}", fg="yellow"), err=True
                 )
                 click.get_current_context().exit(2)
+
+
+class CLIAuthRequirementsError(Exception):
+    """
+    A class for internally generated auth requirements
+    """
+
+    def __init__(
+        self, message: str, *, required_scopes: list[str] | None = None
+    ) -> None:
+        self.message = message
+        self.required_scopes = required_scopes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,20 +136,23 @@ def user_profile(monkeypatch):
     monkeypatch.setenv("GLOBUS_PROFILE", "test_user_profile")
 
 
+@pytest.fixture(scope="session")
+def mock_user_data():
+    # NB: this carefully matches the ID provided by our "foo_user_info" data fixture
+    # in the future, this should be adjusted such that this is the source of truth
+    # for the response mocks
+    return {"sub": "25de0aed-aa83-4600-a1be-a62a910af116"}
+
+
 @pytest.fixture
-def test_token_storage(mock_login_token_response):
+def test_token_storage(mock_login_token_response, mock_user_data):
     """Put memory-backed sqlite token storage in place for the testsuite to use."""
     mockstore = build_storage_adapter(":memory:")
     mockstore.store_config(
         "auth_client_data",
         {"client_id": "fakeClientIDString", "client_secret": "fakeClientSecret"},
     )
-    # NB: this carefully matches the ID provided by our "foo_user_info" data fixture
-    # in the future, this should be moved to a dedicated fixture providing the current
-    # user's identity ID
-    mockstore.store_config(
-        "auth_user_data", {"sub": "25de0aed-aa83-4600-a1be-a62a910af116"}
-    )
+    mockstore.store_config("auth_user_data", mock_user_data)
     mockstore.store(mock_login_token_response)
     return mockstore
 

--- a/tests/functional/flows/test_resume_run.py
+++ b/tests/functional/flows/test_resume_run.py
@@ -1,4 +1,188 @@
-from globus_sdk._testing import RegisteredResponse, load_response
+import uuid
+
+import globus_sdk
+import pytest
+from globus_sdk._testing import (
+    RegisteredResponse,
+    load_response,
+    load_response_set,
+    register_response_set,
+)
+
+
+def _urlscope(m: str, s: str) -> str:
+    return f"https://auth.globus.org/scopes/{m}/{s}"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _register_responses(mock_user_data):
+    # Note: this value must match so that the mock login data matches the responses
+    user_id = mock_user_data["sub"]
+
+    user_urn = f"urn:globus:auth:identity:{user_id}"
+    flow_id = str(uuid.uuid1())
+    run_id = str(uuid.uuid1())
+    collection_id = str(uuid.uuid1())
+    transfer_scope = globus_sdk.TransferClient.scopes.all
+    flow_scope = _urlscope(flow_id, f"flow_{flow_id.replace('-', '_')}_user")
+    data_access_scope = _urlscope(collection_id, "data_access")
+    full_data_access_scope = (
+        f"{transfer_scope}[*{_urlscope(collection_id, 'data_access')}]"
+    )
+    required_scope = f"{flow_scope}[{full_data_access_scope}]"
+
+    metadata = {
+        "user_id": user_id,
+        "flow_id": flow_id,
+        "run_id": run_id,
+        "collection_id": collection_id,
+        "required_scope": required_scope,
+    }
+
+    inactive_consent_required_body = {
+        "action_id": run_id,
+        "created_by": user_urn,
+        "details": {
+            "action_statuses": [
+                {
+                    "action_id": "1IcYClstkVzjn",
+                    "completion_time": "2023-08-07T17:24:10.681615+00:00",
+                    "creator_id": user_urn,
+                    "details": {
+                        "code": "ConsentRequired",
+                        "description": "Missing required data_access consent",
+                        "required_scope": full_data_access_scope,
+                        "resolution_url": None,
+                    },
+                    "display_status": "INACTIVE",
+                    "label": None,
+                    "manage_by": [],
+                    "monitor_by": [],
+                    "release_after": "P30D",
+                    "start_time": "2023-08-07 17:24:10.681600+00:00",
+                    "state_name": "Transfer",
+                    "status": "INACTIVE",
+                }
+            ],
+            "code": "ConsentRequired",
+            "description": "Go to Tosche Station to pick up some power converters.",
+            "required_scope": required_scope,
+            "state_name": "GetPermissionFromUncleOwen",
+        },
+        "display_status": "INACTIVE",
+        "flow_id": flow_id,
+        "flow_last_updated": "2023-08-02T17:20:17.442007+00:00",
+        "flow_title": "Convert Power",
+        "label": "you can waste time with your friends when your chores are done",
+        "manage_by": [],
+        "monitor_by": [],
+        "run_id": run_id,
+        "run_managers": [],
+        "run_monitors": [],
+        "run_owner": user_urn,
+        "start_time": "2023-08-07T17:24:03.315708+00:00",
+        "status": "INACTIVE",
+        "tags": ["tatooine"],
+        "user_role": "run_owner",
+    }
+    succeeded_body = {
+        "run_id": run_id,
+        "action_id": run_id,
+        "completion_time": "2023-08-09T17:24:03.315708+00:00",
+        "created_by": user_id,
+        "details": {
+            "code": "FlowSucceeded",
+            "description": "Got permission and went to Tosche Station",
+        },
+        "display_status": "SUCCEEDED",
+        "flow_id": flow_id,
+        "flow_last_updated": "2023-04-11T20:00:06.524930+00:00",
+        "flow_title": "Convert Power",
+        "label": "you can waste time with your friends when your chores are done",
+        "manage_by": [],
+        "monitor_by": [],
+        "run_managers": [],
+        "run_monitors": [],
+        "run_owner": user_urn,
+        "start_time": "2023-04-11T20:01:18.040416+00:00",
+        "status": "SUCCEEDED",
+        "tags": ["tatooine"],
+        "user_role": "run_owner",
+    }
+
+    register_response_set(
+        "cli.resume_run.inactive_consents_missing",
+        dict(
+            get_run=dict(
+                service="flows",
+                path=f"/runs/{run_id}",
+                json=inactive_consent_required_body,
+            ),
+            resume=dict(
+                service="flows",
+                path=f"/runs/{run_id}/resume",
+                method="POST",
+                json=succeeded_body,
+            ),
+            consents=dict(
+                service="auth",
+                path=f"/v2/api/identities/{user_id}/consents",
+                method="GET",
+                json={
+                    "consents": [
+                        {
+                            "scope_name": flow_scope,
+                            "dependency_path": [100],
+                            "id": 100,
+                        }
+                    ]
+                },
+            ),
+        ),
+        metadata=metadata,
+    )
+
+    register_response_set(
+        "cli.resume_run.inactive_consents_present",
+        dict(
+            get_run=dict(
+                service="flows",
+                path=f"/runs/{run_id}",
+                json=inactive_consent_required_body,
+            ),
+            resume=dict(
+                service="flows",
+                path=f"/runs/{run_id}/resume",
+                method="POST",
+                json=succeeded_body,
+            ),
+            consents=dict(
+                service="auth",
+                path=f"/v2/api/identities/{user_id}/consents",
+                method="GET",
+                json={
+                    "consents": [
+                        {
+                            "scope_name": flow_scope,
+                            "dependency_path": [100],
+                            "id": 100,
+                        },
+                        {
+                            "scope_name": transfer_scope,
+                            "dependency_path": [100, 101],
+                            "id": 101,
+                        },
+                        {
+                            "scope_name": data_access_scope,
+                            "dependency_path": [100, 101, 102],
+                            "id": 102,
+                        },
+                    ]
+                },
+            ),
+        ),
+        metadata=metadata,
+    )
 
 
 def test_resume_run_text_output(run_line, add_flow_login):
@@ -41,4 +225,48 @@ def test_resume_run_text_output(run_line, add_flow_login):
             ("Status", status),
             ("Flow Title", flow_title),
         ],
+    )
+
+
+def test_resume_inactive_run_missing_consent(run_line, add_flow_login):
+    # setup the response scenario
+    meta = load_response_set("cli.resume_run.inactive_consents_missing").metadata
+    flow_id = meta["flow_id"]
+    run_id = meta["run_id"]
+    required_scope = meta["required_scope"]
+
+    # setup the login mock for the flow_id as well
+    add_flow_login(flow_id)
+
+    result = run_line(["globus", "flows", "run", "resume", run_id], assert_exit_code=4)
+    assert f"globus session consent '{required_scope}'" in result.output
+
+
+def test_resume_inactive_run_consent_present(run_line, add_flow_login):
+    # setup the response scenario
+    meta = load_response_set("cli.resume_run.inactive_consents_present").metadata
+    flow_id = meta["flow_id"]
+    run_id = meta["run_id"]
+
+    # setup the login mock for the flow_id as well
+    add_flow_login(flow_id)
+
+    run_line(
+        ["globus", "flows", "run", "resume", run_id],
+        search_stdout=[("Flow ID", flow_id), ("Run ID", run_id)],
+    )
+
+
+def test_resume_inactive_run_consent_missing_but_skip_check(run_line, add_flow_login):
+    # setup the response scenario
+    meta = load_response_set("cli.resume_run.inactive_consents_missing").metadata
+    flow_id = meta["flow_id"]
+    run_id = meta["run_id"]
+
+    # setup the login mock for the flow_id as well
+    add_flow_login(flow_id)
+
+    run_line(
+        ["globus", "flows", "run", "resume", run_id, "--skip-inactive-reason-check"],
+        search_stdout=[("Flow ID", flow_id), ("Run ID", run_id)],
     )


### PR DESCRIPTION
Note that this changeset updates to SDK v3.26.0 in order to pull in the new functionality.

The src-tree changes turned out even smaller and simpler than I had hoped, although the testing is a bit verbose.

Experimental GARE parsing is used to convert from an Inactive Run document to a `required_scopes` list.
Experimental scope parsing is used to convert that `required_scopes` list to a forest.
The same subtree matching which was written for MutableScope is now used to compare the forest against the auth-response.

Prompting is done via a new mechanism.
A new internal error class is introduced for explicitly triggering the ConsentRequired handling path -- think of this as a "concrete auth requirements error" whereas the GARE parse gave us an abstract one. Note that it only supports `required_scopes` for now.

I decided to normalize `MutableScope` -> `scope_parser.Scope` in a somewhat suboptimal but very easy way by calling `parse(str(...))`, but this could be changed easily.