### PR TITLE
Add `globus flows run show-logs` command

### DIFF
--- a/changelog.d/20230810_084859_ada_sc_18432.md
+++ b/changelog.d/20230810_084859_ada_sc_18432.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add `globus flows run show-logs` for showing a *run*'s log entries

--- a/src/globus_cli/commands/flows/run/__init__.py
+++ b/src/globus_cli/commands/flows/run/__init__.py
@@ -5,6 +5,7 @@ from globus_cli.parsing import group
     "run",
     lazy_subcommands={
         "show": (".show", "show_command"),
+        "show-logs": (".show_logs", "show_logs_command"),
         "list": (".list", "list_command"),
         "update": (".update", "update_command"),
         "delete": (".delete", "delete_command"),

--- a/src/globus_cli/commands/flows/run/show_logs.py
+++ b/src/globus_cli/commands/flows/run/show_logs.py
@@ -38,8 +38,8 @@ def show_logs_command(
     *,
     run_id: uuid.UUID,
     details: bool,
-    reverse: bool | None,
-    limit: int | None,
+    reverse: bool,
+    limit: int,
 ) -> None:
     """
     List run logs entries

--- a/src/globus_cli/commands/flows/run/show_logs.py
+++ b/src/globus_cli/commands/flows/run/show_logs.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import uuid
+
+import click
+from globus_sdk.paging import Paginator
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command, run_id_arg
+from globus_cli.termio import Field, TextMode, display, print_command_hint
+from globus_cli.utils import PagingWrapper
+
+
+@command("show-logs")
+@run_id_arg
+@click.option(
+    "--details",
+    help="Include log entry details (using a text record format).",
+    is_flag=True,
+)
+@click.option(
+    "--reverse",
+    help="Reverse the order of the results.",
+    is_flag=True,
+)
+@click.option(
+    "--limit",
+    default=100,
+    show_default=True,
+    metavar="N",
+    type=click.IntRange(1),
+    help="The maximum number of results to return.",
+)
+@LoginManager.requires_login("flows")
+def show_logs_command(
+    login_manager: LoginManager,
+    *,
+    run_id: uuid.UUID,
+    details: bool,
+    reverse: bool | None,
+    limit: int | None,
+) -> None:
+    """
+    List run logs entries
+
+    Enumerates the run log entries for a given run.
+    """
+
+    flows_client = login_manager.get_flows_client()
+
+    paginator = Paginator.wrap(flows_client.get_run_logs)
+    entry_iterator = PagingWrapper(
+        paginator(run_id=run_id, reverse_order=reverse).items(),
+        limit=limit,
+        json_conversion_key="entries",
+    )
+
+    fields = [
+        Field("Time", "time"),
+        Field("Code", "code"),
+        Field("Description", "description"),
+    ]
+
+    if details:
+        # Display the log entries, including the details field, in text record format.
+        fields.append(Field("Details", "details"))
+        entry_list = list(entry_iterator)
+        for entry in entry_list:
+            entry["details"] = json.dumps(entry["details"])
+
+        display(
+            entry_list,
+            text_mode=TextMode.text_record_list,
+            fields=fields,
+        )
+    else:
+        print_command_hint(
+            "Displaying summary data. "
+            "To see details of each event, use the --details option.\n"
+        )
+        # Display the log entries in a table.
+        display(
+            entry_iterator, fields=fields, json_converter=entry_iterator.json_converter
+        )
+
+    # Check if there are more results
+    if entry_iterator.has_next():
+        print_command_hint(
+            f"\nResults hidden by the current limit of {limit}. "
+            "To see more events, set the --limit option to a higher value."
+        )

--- a/tests/functional/flows/test_run_show_logs.py
+++ b/tests/functional/flows/test_run_show_logs.py
@@ -1,7 +1,22 @@
 import datetime
 import json
 
-from globus_sdk._testing import load_response
+import pytest
+from globus_sdk._testing import load_response, load_response_set, register_response_set
+from globus_sdk._testing.data.flows.get_run_logs import (
+    PAGINATED_RUN_LOG_RESPONSES,
+    RUN_ID,
+)
+from responses.matchers import query_param_matcher
+
+EXPECTED_EVENT_CODES = [
+    "FlowStarted",
+    "FlowSucceeded",
+    "PassStarted",
+    "PassCompleted",
+    "ActionStarted",
+    "ActionCompleted",
+]
 
 
 def test_run_show_logs_table(run_line):
@@ -41,11 +56,54 @@ def test_run_show_logs_text_records(run_line):
         assert isinstance(
             datetime.datetime.fromisoformat(field_map["Time"]), datetime.datetime
         )
-        assert field_map["Code"] in [
-            "FlowStarted",
-            "FlowSucceeded",
-            "ActionStarted",
-            "ActionCompleted",
-        ]
+        assert field_map["Code"] in EXPECTED_EVENT_CODES
         assert isinstance(field_map["Description"], str)
         assert isinstance(json.loads(field_map["Details"]), dict)
+
+
+@pytest.mark.parametrize("limit", [3, 10, 12])
+def test_run_show_logs_paginated_response(run_line, limit):
+    register_response_set(
+        "get_run_logs_paginated",
+        {
+            "page0": dict(
+                service="flows",
+                method="GET",
+                path=f"/runs/{RUN_ID}/log",
+                json=PAGINATED_RUN_LOG_RESPONSES[0],
+                match=[query_param_matcher(params={"reverse_order": "False"})],
+            ),
+            "page1": dict(
+                service="flows",
+                method="GET",
+                path=f"/runs/{RUN_ID}/log",
+                json=PAGINATED_RUN_LOG_RESPONSES[1],
+                match=[
+                    query_param_matcher(
+                        params={
+                            "reverse_order": "False",
+                            "marker": PAGINATED_RUN_LOG_RESPONSES[0]["marker"],
+                        },
+                    )
+                ],
+            ),
+        },
+    )
+    load_response_set("get_run_logs_paginated")
+    run_id = RUN_ID
+
+    result = run_line(
+        ["globus", "flows", "run", "show-logs", run_id, "--limit", str(limit)]
+    )
+    output_lines = result.output.splitlines()
+
+    assert len(output_lines) == limit + 2  # num events + 2 header
+
+    header_line = output_lines[0]
+    header_items = [item.strip() for item in header_line.split("|")]
+    assert header_items == ["Time", "Code", "Description"]
+
+    for line in output_lines[2:]:
+        time, code, _ = (value.strip() for value in line.split("|"))
+        assert isinstance(datetime.datetime.fromisoformat(time), datetime.datetime)
+        assert code in EXPECTED_EVENT_CODES

--- a/tests/functional/flows/test_run_show_logs.py
+++ b/tests/functional/flows/test_run_show_logs.py
@@ -1,0 +1,51 @@
+import datetime
+import json
+
+from globus_sdk._testing import load_response
+
+
+def test_run_show_logs_table(run_line):
+    meta = load_response("flows.get_run_logs").metadata
+    run_id = meta["run_id"]
+
+    result = run_line(["globus", "flows", "run", "show-logs", run_id])
+    output_lines = result.output.splitlines()
+    assert len(output_lines) == 6  # 4 events + 2 header
+
+    header_line = output_lines[0]
+    header_items = [item.strip() for item in header_line.split("|")]
+    assert header_items == ["Time", "Code", "Description"]
+
+    first_line = output_lines[2]
+    first_row = [item.strip() for item in first_line.split("|")]
+    assert first_row == [
+        "2023-04-25T18:54:30.683000+00:00",
+        "FlowStarted",
+        "The Flow Instance started execution",
+    ]
+
+
+def test_run_show_logs_text_records(run_line):
+    meta = load_response("flows.get_run_logs").metadata
+    run_id = meta["run_id"]
+
+    result = run_line(["globus", "flows", "run", "show-logs", run_id, "--details"])
+    output_sections = [item.splitlines() for item in result.output.split("\n\n")]
+    assert len(output_sections) == 4  # 4 events
+
+    for section in output_sections:
+        assert len(section) == 4
+        field_map = {
+            k: v.strip() for k, v in [line.split(":", maxsplit=1) for line in section]
+        }
+        assert isinstance(
+            datetime.datetime.fromisoformat(field_map["Time"]), datetime.datetime
+        )
+        assert field_map["Code"] in [
+            "FlowStarted",
+            "FlowSucceeded",
+            "ActionStarted",
+            "ActionCompleted",
+        ]
+        assert isinstance(field_map["Description"], str)
+        assert isinstance(json.loads(field_map["Details"]), dict)


### PR DESCRIPTION
![image](https://github.com/globus/globus-cli/assets/107940310/510b6554-0d7e-49a6-97b0-a0fc3255d8e2)

# Notes
- I ran into a bit of difficulty getting a test written for pagination without being able to disable strict matching. I do know that pagination is working in practice against the production service, but I'll follow up with a test demonstrating this once I work out the matching issue. I do not expect any changes to the implementation.
- There are two modes: The default tabular mode and the `--details` text record mode
- Per conversation in Slack, we've agreed that `--format json` is adequate for the "piping" TAC in the associated story
- When printing details, the command manually converts the details object back to JSON to facilitate better copy/paste and/or parsing by subsequent commands. Happy to drop this if we have serious objections, but seemed like a nice affordance.