### PR TITLE
Check more exhaustively for interactive usage

### DIFF
--- a/changelog.d/20230811_075351_ada_check_even_harder_for_interactive.md
+++ b/changelog.d/20230811_075351_ada_check_even_harder_for_interactive.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* More exhaustively check for interactive usage
+  (detect sessions with alternative prompts).

--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -106,5 +106,5 @@ def term_is_interactive() -> bool:
 
     if sys.stdin.isatty():
         return True
-    
+
     return os.getenv("PS1") is not None

--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -100,4 +100,8 @@ def term_is_interactive() -> bool:
             return env
     except ValueError:
         pass
+
+    if sys.stdin.isatty():
+        return True
+
     return os.getenv("PS1") is not None


### PR DESCRIPTION
![image](https://github.com/globus/globus-cli/assets/107940310/521b440e-a372-4c25-b92b-2faf150d7a41)

# Context
The apparent root issue is that starship does not use `PS1`

# Notes
- Only additive, should only catch more cases than before
- Tests appear to fail specifically in Windows, so unsure if this causes a regression there for non-interactive use (in which case we can have this check also assert the shell is not windows) or if this is non-worrisome, in which case perhaps modify the test...