### PR TITLE
Replace last distutils usage

### DIFF
--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -127,14 +127,7 @@ class GlobusCommand(click.Command):
 
 class GlobusCommandEnvChecks(GlobusCommand):
     def invoke(self, ctx):
-        try:
-            env_interactive()
-        except ValueError as e:
-            click.echo(
-                f"couldn't parse GLOBUS_CLI_INTERACTIVE environment variable: {e}",
-                err=True,
-            )
-            click.get_current_context().exit(1)
+        env_interactive(raising=True)
         return super().invoke(ctx)
 
 

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -9,6 +9,16 @@ from globus_cli.types import DATA_CONTAINER_T
 F = t.TypeVar("F", bound=t.Callable)
 
 
+def str2bool(v: str) -> bool | None:
+    v = v.lower()
+    if v in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif v in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        return None
+
+
 def unquote_cmdprompt_single_quotes(arg: str) -> str:
     """
     remove leading and trailing single quotes from a string when


### PR DESCRIPTION
This usage made the CLI py3.12 incompatible. Remove distutils usage for string parsing and reproduce that same utility (with near-identical semantics) in globus_cli.utils.

The invalid-raise behavior is now baked into the getter with a `raising=True` flag, so that the details about the env var name are not leaked as much out of the utility.

---

I'll want to do a follow-up to start testing on 3.12-dev (rc1 just released).
It's time to start really getting ready for 3.12.