### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publish-pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -19,5 +22,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publish-test-pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -24,5 +27,4 @@ jobs:
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -27,4 +27,4 @@ jobs:
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     # descriptive info, non-critical
     description="Globus CLI",
     long_description=read_readme(),
+    long_description_content_type="text/x-rst",
     author="Stephen Rosen",
     author_email="sirosen@globus.org",
     url="https://github.com/globus/globus-cli",


### PR DESCRIPTION
Similar to the changes introduced in the SDK, this PR introduces these changes:

* Use kebab-case for `repository-url`, which resolves a deprecation warning in CD
* Add an explicit content type for `README.rst`, which resolves a warning in CD
* Use Trusted Publishing to publish to TestPyPI and PyPI, which resolves a warning in CD

GitHub environments, along with TestPyPI and PyPI publication settings, have all been configured to support this. Publishing to TestPyPI has been tested by uploading a bogus tag.