### PR TITLE
Clean setuptools build artifacts before running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    cov-clean
+    clean
     py{311,310,39,38,37}
     py37-mindeps
     cov-combine
@@ -34,14 +34,16 @@ commands =
     localsdk: python -c 'import os, subprocess, sys; subprocess.run([sys.executable, "-m", "pip", "install", "-e", os.environ["GLOBUS_SDK_PATH"]])'
     coverage run -m pytest {posargs}
 depends =
-    py{37,38,39,310,311}{,-mindeps}: cov-clean
+    py{37,38,39,310,311}{,-mindeps}: clean
     cov-combine: py{37,38,39,310,311}{,-mindeps}
     cov-report: cov-combine
 
-[testenv:cov-clean]
+[testenv:clean]
 deps = coverage
 skip_install = true
-commands = coverage erase
+commands =
+    python setup.py clean --all
+    coverage erase
 
 [testenv:cov-combine]
 deps = coverage


### PR DESCRIPTION
This resolves test suite failures caused by lowered code coverage numbers. The failure can occur under these circumstances:

* New Python files are introduced in one git branch
* The test suite is run, caching the new files in the `build/` directory
* A new git branch is switched to, which doesn't contain the new Python files
* The test suite is run

Under this circumstance, the cached Python files may persist in the wheel that is built, resulting in dead code that coverage detects as un-run across each test environment.

This is a force multiplier, resulting in (for the file that triggered this bug) 25 lines being multiplied across all six (6) Python test environments.

This PR resolves this problem by running `python setup.py clean --all`, which wipes out the `build/` directory's cached files.