### PR TITLE
Add a unit test for server-timing rendering

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -25,3 +25,5 @@ exclude_lines =
     if t.TYPE_CHECKING:
     # skip overloads
     @t.overload
+    # skip abstract methods
+    @abc.abstractmethod


### PR DESCRIPTION
This checks the rendering path for the Server-Timing header info, closing a test coverage gap.

Also, have coverage reports skip abstractmethods, which further tightens up the coverage report for the server_timing.py module.