### PR TITLE
Disallow untyped defs on the auth helper module

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -53,9 +53,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.parsing.shell_completion]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.services.auth]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.services.gcs]
 disallow_untyped_defs = false
 

--- a/src/globus_cli/commands/endpoint/role/create.py
+++ b/src/globus_cli/commands/endpoint/role/create.py
@@ -71,12 +71,13 @@ def role_create(
     auth_client = login_manager.get_auth_client()
 
     if principal_type == "identity":
-        principal_val = auth_client.maybe_lookup_identity_id(principal_val)
-        if not principal_val:
+        maybe_principal_val = auth_client.maybe_lookup_identity_id(principal_val)
+        if not maybe_principal_val:
             raise click.UsageError(
                 "Identity does not exist. "
                 "Use --provision-identity to auto-provision an identity."
             )
+        principal_val = maybe_principal_val
     elif principal_type == "provision-identity":
         principal_val = auth_client.maybe_lookup_identity_id(
             principal_val, provision=True


### PR DESCRIPTION
This results in several typing-related tweaks, but almost no runtime changes.
Some very minor adjustments are made:
- an unreachable case is marked with a NotImplementedError
- `(KeyError, IndexError)` is replaced with `LookupError` (not related to typing changes)
- a known-str value is explicitly checked with `isinstance` to guarantee the right type
- one usage site is slightly modified to avoid assigning `str | None` to a `str` variable