### PR TITLE
Align all Timer command help text to use periods

### DIFF
--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -76,28 +76,28 @@ def resolve_start_time(start: datetime.datetime | None) -> datetime.datetime:
 @click.option(
     "--start",
     type=click.DateTime(formats=DATETIME_FORMATS),
-    help="Start time for the job. Defaults to current time",
+    help="Start time for the job. Defaults to current time.",
 )
 @click.option(
     "--interval",
     type=TimedeltaType(),
     help=INTERVAL_HELP,
 )
-@click.option("--name", type=str, help="A name for the Timer job")
+@click.option("--name", type=str, help="A name for the Timer job.")
 @click.option(
     "--label",
     type=str,
-    help="A label for the Transfer tasks submitted by the Timer job",
+    help="A label for the Transfer tasks submitted by the Timer job.",
 )
 @click.option(
     "--stop-after-date",
     type=click.DateTime(formats=DATETIME_FORMATS),
-    help="Stop running the transfer after this date",
+    help="Stop running the transfer after this date.",
 )
 @click.option(
     "--stop-after-runs",
     type=click.IntRange(min=1),
-    help="Stop running the transfer after this number of runs have happened",
+    help="Stop running the transfer after this number of runs have happened.",
 )
 @LoginManager.requires_login("auth", "timer", "transfer")
 def transfer_command(
@@ -211,7 +211,7 @@ Please run
 
   globus session consent {scope_request_opts}
 
-to login with the required scopes"""
+to login with the required scopes."""
             )
             click.get_current_context().exit(4)
 

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -97,7 +97,7 @@ def format_option(f: F) -> F:
         type=click.Choice(
             [UNIX_FORMAT, JSON_FORMAT, TEXT_FORMAT], case_sensitive=False
         ),
-        help="Output format for stdout. Defaults to text",
+        help="Output format for stdout. Defaults to text.",
         expose_value=False,
         callback=callback,
     )(f)
@@ -106,7 +106,7 @@ def format_option(f: F) -> F:
         "--jq",
         help=(
             "A JMESPath expression to apply to json output. "
-            "Forces the format to be json processed by this expression"
+            "Forces the format to be json processed by this expression."
         ),
         expose_value=False,
         callback=jmespath_callback,
@@ -178,7 +178,7 @@ def verbose_option(f: F) -> F:
         expose_value=False,
         callback=callback,
         is_eager=True,
-        help="Control level of output",
+        help="Control level of output.",
     )(f)
 
 

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -71,7 +71,7 @@ def task_notify_option(f: C) -> C:
             "Comma separated list of task events which notify by email. "
             "'on' and 'off' may be used to enable or disable notifications "
             "for all event types. Otherwise, use 'succeeded', 'failed', or "
-            "'inactive'"
+            "'inactive'."
         ),
         cls=AnnotatedOption,
         type_annotation=DictType[str, bool],

--- a/src/globus_cli/parsing/shared_options/transfer_task_options.py
+++ b/src/globus_cli/parsing/shared_options/transfer_task_options.py
@@ -34,8 +34,8 @@ def sync_level_option(
             ("exists", "size", "mtime", "checksum"), case_sensitive=False
         ),
         help=(
-            "Specify that only new or modified files should be transferred, depending "
-            "on which setting is provided"
+            "Specify that only new or modified files should be transferred, "
+            "depending on which setting is provided."
         ),
     )(f)
 
@@ -47,9 +47,11 @@ def transfer_recursive_option(f: C) -> C:
         is_flag=True,
         default=None,
         help=(
-            "Specify these paths are for directories and should be transferred "
-            "recursively or for files that must not be transferred recursively. "
-            "Omit this option to use path type auto-detection."
+            "Use --recursive to flag that the paths are directories "
+            "and should be transferred recursively. "
+            "Use --no-recursive to flag that the paths are files "
+            "that must not be transferred recursively. "
+            "Omit these options to use path type auto-detection."
         ),
     )(f)
 


### PR DESCRIPTION
Prior to this change, sentences inconsistently end with periods.

This was found while reading the generated HTML documentation.