### PR TITLE
default transfer --recursive to None for type auto-detection

### DIFF
--- a/changelog.d/20230817_150141_aaschaer_auto_detect.md
+++ b/changelog.d/20230817_150141_aaschaer_auto_detect.md
@@ -1,4 +1,6 @@
 ### Bugfixes
 
-* When the `--recursive` option is not given on a `globus transfer` the `recursive`
-  flag will be omitted from the transfer item.
+* When the `--recursive` option is not given when using `globus transfer` the
+  `recursive` flag will be omitted from the transfer item rather than being sent as
+  `False`. If there is a need to explicitly use `False` to enforce the item is not a
+  directory, use the `--no-recursive` option.

--- a/changelog.d/20230817_150141_aaschaer_auto_detect.md
+++ b/changelog.d/20230817_150141_aaschaer_auto_detect.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* When the `--recursive` option is not given on a `globus transfer` the `recursive`
+  flag will be omitted from the transfer item.

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -107,7 +107,7 @@ def transfer_command(
     source: tuple[uuid.UUID, str | None],
     destination: tuple[uuid.UUID, str | None],
     batch: t.TextIO | None,
-    recursive: bool,
+    recursive: bool | None,
     start: datetime.datetime | None,
     interval: int | None,
     label: str | None,

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -219,7 +219,7 @@ def transfer_command(
     *,
     batch: t.TextIO | None,
     sync_level: Literal["exists", "size", "mtime", "checksum"] | None,
-    recursive: bool,
+    recursive: bool | None,
     source: tuple[uuid.UUID, str | None],
     destination: tuple[uuid.UUID, str | None],
     checksum_algorithm: str | None,
@@ -398,7 +398,7 @@ def transfer_command(
         )
 
     for item in transfer_data["DATA"]:
-        if item["recursive"]:
+        if item.get("recursive"):
             has_recursive_items = True
             break
     else:

--- a/src/globus_cli/parsing/shared_options/transfer_task_options.py
+++ b/src/globus_cli/parsing/shared_options/transfer_task_options.py
@@ -42,12 +42,13 @@ def sync_level_option(
 
 def transfer_recursive_option(f: C) -> C:
     return click.option(
-        "--recursive",
+        "--recursive/--no-recursive",
         "-r",
         is_flag=True,
         default=None,
-        help="SOURCE_PATH and DEST_PATH are both directories, "
-        "do a recursive directory transfer",
+        help="Specify these paths are for directories and should be transferred "
+        "recursively or for files that must not be transferred recursively. "
+        "Omit this option to use path type auto-detection.",
     )(f)
 
 

--- a/src/globus_cli/parsing/shared_options/transfer_task_options.py
+++ b/src/globus_cli/parsing/shared_options/transfer_task_options.py
@@ -45,6 +45,7 @@ def transfer_recursive_option(f: C) -> C:
         "--recursive",
         "-r",
         is_flag=True,
+        default=None,
         help="SOURCE_PATH and DEST_PATH are both directories, "
         "do a recursive directory transfer",
     )(f)

--- a/src/globus_cli/parsing/shared_options/transfer_task_options.py
+++ b/src/globus_cli/parsing/shared_options/transfer_task_options.py
@@ -46,9 +46,11 @@ def transfer_recursive_option(f: C) -> C:
         "-r",
         is_flag=True,
         default=None,
-        help="Specify these paths are for directories and should be transferred "
-        "recursively or for files that must not be transferred recursively. "
-        "Omit this option to use path type auto-detection.",
+        help=(
+            "Specify these paths are for directories and should be transferred "
+            "recursively or for files that must not be transferred recursively. "
+            "Omit this option to use path type auto-detection."
+        ),
     )(f)
 
 

--- a/tests/functional/task/test_task_submit.py
+++ b/tests/functional/task/test_task_submit.py
@@ -150,13 +150,31 @@ def test_rm_local_user(run_line, go_ep1_id):
     assert json_output["local_user"] == "my-user"
 
 
-def test_transfer_auto_detect(run_line, go_ep1_id, go_ep2_id, tmp_path):
+def test_transfer_recursive_options(run_line, go_ep1_id, go_ep2_id, tmp_path):
     """
-    Confirm not passing --recursive omits the recursive field from the transfer item
+    Confirm --recursive, --no-recursive, and omission of the --recursive option
+    result in the expected values in the transfer item
     """
     load_response_set("cli.get_submission_id")
-    result = run_line(f"globus transfer --dry-run -F json {go_ep1_id}:/ {go_ep1_id}:/")
 
+    # --recursive should set the value to True
+    result = run_line(
+        f"globus transfer --recursive --dry-run -F json {go_ep1_id}:/ {go_ep1_id}:/"
+    )
+    json_output = json.loads(result.output)
+    transfer_item = json_output["DATA"][0]
+    assert transfer_item["recursive"] is True
+
+    # --no-recursive should set the value to False
+    result = run_line(
+        f"globus transfer --no-recursive --dry-run -F json {go_ep1_id}:/ {go_ep1_id}:/"
+    )
+    json_output = json.loads(result.output)
+    transfer_item = json_output["DATA"][0]
+    assert transfer_item["recursive"] is False
+
+    # not using the option should omit the field
+    result = run_line(f"globus transfer --dry-run -F json {go_ep1_id}:/ {go_ep1_id}:/")
     json_output = json.loads(result.output)
     transfer_item = json_output["DATA"][0]
     assert "recursive" not in transfer_item

--- a/tests/functional/task/test_task_submit.py
+++ b/tests/functional/task/test_task_submit.py
@@ -148,3 +148,15 @@ def test_rm_local_user(run_line, go_ep1_id):
 
     json_output = json.loads(result.output)
     assert json_output["local_user"] == "my-user"
+
+
+def test_transfer_auto_detect(run_line, go_ep1_id, go_ep2_id, tmp_path):
+    """
+    Confirm not passing --recursive omits the recursive field from the transfer item
+    """
+    load_response_set("cli.get_submission_id")
+    result = run_line(f"globus transfer --dry-run -F json {go_ep1_id}:/ {go_ep1_id}:/")
+
+    json_output = json.loads(result.output)
+    transfer_item = json_output["DATA"][0]
+    assert "recursive" not in transfer_item


### PR DESCRIPTION
For: https://app.shortcut.com/globus/story/26492/cli-default-transfer-s-recursive-option-to-none-to-properly-use-type-auto-detection