### PR TITLE
Display the status of Timers jobs

### DIFF
--- a/changelog.d/20230822_163412_ada_sc_21795.md
+++ b/changelog.d/20230822_163412_ada_sc_21795.md
@@ -1,3 +1,3 @@
 ### Enhancements
 
-* Display the ``status`` of Timers jobs when listed or shown.
+* Display the `status` of Timers jobs when listed or shown.

--- a/changelog.d/20230822_163412_ada_sc_21795.md
+++ b/changelog.d/20230822_163412_ada_sc_21795.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Display the ``status`` of Timers jobs when listed or shown.

--- a/src/globus_cli/commands/timer/_common.py
+++ b/src/globus_cli/commands/timer/_common.py
@@ -52,6 +52,7 @@ _COMMON_FIELDS = [
 
 
 JOB_FORMAT_FIELDS = _COMMON_FIELDS + [
+    Field("Status", "status"),
     Field("Last Run", "last_ran_at", formatter=formatters.Date),
     Field("Next Run", "next_run", formatter=formatters.Date),
     Field("Stop After Date", "stop_after.date"),


### PR DESCRIPTION
Display the `status` field when listing or showing a Timers job.