### PR TITLE
Fix a parsing bug when erasing an endpoint subscription ID

### DIFF
--- a/changelog.d/20230824_153442_kurtmckee_fix_set_endpoint_id_null.md
+++ b/changelog.d/20230824_153442_kurtmckee_fix_set_endpoint_id_null.md
@@ -1,0 +1,3 @@
+### Bugfixes
+
+* Fix a bug that prevented running `globus endpoint set-subscription-id ... null`.

--- a/tests/functional/endpoint/test_endpoint_set_subscription_id.py
+++ b/tests/functional/endpoint/test_endpoint_set_subscription_id.py
@@ -21,3 +21,21 @@ def test_endpoint_set_subscription_id(run_line, ep_type):
         json.loads(responses.calls[-1].request.body)["subscription_id"]
         == subscription_id
     )
+
+
+def test_endpoint_set_subscription_id_null(run_line):
+    meta = load_response_set("cli.endpoint_operations").metadata
+    epid = meta["gcp_endpoint_id"]
+    subscription_id = "null"
+    run_line(f"globus endpoint set-subscription-id {epid} {subscription_id}")
+    assert json.loads(responses.calls[-1].request.body)["subscription_id"] is None
+
+
+def test_endpoint_set_subscription_id_invalid_subscription_id(run_line):
+    endpoint_id = str(uuid.UUID(int=0))
+    subscription_id = "invalid-uuid"
+    run_line(
+        f"globus endpoint set-subscription-id {endpoint_id} {subscription_id}",
+        assert_exit_code=2,
+        search_stderr="Invalid value for 'SUBSCRIPTION_ID'",
+    )


### PR DESCRIPTION
### Bugfixes

* Fix a bug that prevented running `globus endpoint set-subscription-id ... null`.
