### PR TITLE
Introduce `--orderby` for `globus ls`

### DIFF
--- a/changelog.d/20230828_102322_sirosen_add_ls_orderby.md
+++ b/changelog.d/20230828_102322_sirosen_add_ls_orderby.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* `globus ls` now supports an `--orderby` flag for sorting results. It is
+  mutually exclusive with `--recursive`.

--- a/tests/functional/test_ls.py
+++ b/tests/functional/test_ls.py
@@ -1,4 +1,11 @@
-from globus_sdk._testing import load_response_set
+import urllib.parse
+
+from globus_sdk._testing import (
+    RegisteredResponse,
+    get_last_request,
+    load_response,
+    load_response_set,
+)
 
 
 def test_path(run_line, go_ep1_id):
@@ -66,3 +73,36 @@ def test_local_user(run_line, go_ep1_id):
     load_response_set("cli.ls_results")
     result = run_line(f"globus ls {go_ep1_id}:/~/ -F json --local-user my-user")
     assert '"user": "my-user"' in result.output
+
+
+def test_recursive_and_orderby_mutex(run_line, go_ep1_id):
+    result = run_line(
+        f"globus ls {go_ep1_id}:/ --recursive --orderby name:ASC",
+        assert_exit_code=2,
+    )
+    assert "--recursive and --orderby are mutually exclusive" in result.stderr
+
+
+def test_orderby_encoding(run_line, go_ep1_id):
+    """
+    Does an ls on EP1:/, but pass `--orderby` and check that it was encoded correctly
+    in the request.
+    """
+    load_response_set("cli.transfer_activate_success")
+    load_response(
+        RegisteredResponse(
+            service="transfer",
+            path=f"/operation/endpoint/{go_ep1_id}/ls",
+            json={
+                "DATA": [],
+            },
+        )
+    )
+
+    run_line(f"globus ls {go_ep1_id}:/ --orderby size:DESC --orderby name:ASC")
+
+    last_req = get_last_request()
+    parsed_url = urllib.parse.urlparse(last_req.url)
+    parsed_params = urllib.parse.parse_qs(parsed_url.query)
+    assert "orderby" in parsed_params
+    assert parsed_params["orderby"] == ["size DESC,name ASC"]


### PR DESCRIPTION
Using the colon-delimited choice paramtype developed for `flows list --orderby`, it is now relatively trivial to add in `--orderby` support for `ls` and mark it as mutex with `--recursive`.

Tests check that the mutex setting is enforced correctly and that a simple `--orderby` usage is encoded correctly into a query param.