### PR TITLE
Improve documentation of `--batch`

### DIFF
--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -122,8 +122,8 @@ def delete_command(
     Empty lines and comments beginning with '#' are ignored.
 
     \b
-    If you use `--batch` and a commandline PATH, the commandline PATH is treated as
-    a prefix to all of the paths read from the `--batch` input.
+    If you use `--batch` and supply a PATH via the commandline, the commandline PATH is
+    treated as a prefix to all of the paths read from the `--batch` input.
 
     {AUTOMATIC_ACTIVATION}
     """

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -104,27 +104,26 @@ def delete_command(
 
     === Batch Input
 
-    If you give a SOURCE_PATH without the --batch flag, you will submit a
-    single-file or single-directory delete task. This has
-    behavior similar to `rm` and `rm -r`, across endpoints.
+    If you give a PATH without the `--batch` flag, you will submit a
+    single-file or single-directory delete task.
 
-    Using `--batch`, *globus delete* can submit a task which deletes multiple files or
-    directories. The value for `--batch` can be a file to read from, or the character
-    `-` which will read from stdin. From either the file or stdin, each line is treated
-    as a path to a file or directory to delete, respecting quotes.
+    Using `--batch`, `globus delete` can submit a task which deletes multiple files or
+    directories.
+    Each line of `--batch` input is treated as a path to a file or directory to delete.
 
     \b
     Lines are of the form
       PATH
 
-    Note that unlike 'globus transfer' --recursive is not an option at the per line
+    Note that unlike `globus transfer` --recursive is not an option at the per line
     level, instead, if given with the original command, all paths that point to
     directories will be recursively deleted.
 
     Empty lines and comments beginning with '#' are ignored.
 
-    Batch only requires an ENDPOINT on the "base" command, but you may pass an
-    ENPDOINT:PATH to prefix all the paths read in the batch with that path.
+    \b
+    If you use `--batch` and a commandline PATH, the commandline PATH is treated as
+    a prefix to all of the paths read from the `--batch` input.
 
     {AUTOMATIC_ACTIVATION}
     """

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -130,6 +130,27 @@ def transfer_command(
 
     \b
         globus timer create transfer --interval 1d --recursive $ep1:/foo/ $ep2:/bar/
+
+    \b
+    === Batch Input
+
+    If you use `SOURCE_PATH` and `DEST_PATH` without the `--batch` flag, you
+    will submit a single-file or single-directory timer.
+
+    Using `--batch`, `globus timer create transfer` can create a timer which
+    transfers multiple files or directories.
+    Each line of `--batch` input is treated as a separate file or directory
+    transfer to include in the timer.
+
+    \b
+    Lines are of the form
+    [--recursive] [--external-checksum TEXT] SOURCE_PATH DEST_PATH\n
+
+    Skips empty lines and allows comments beginning with "#".
+
+    \b
+    If you use `--batch` and a commandline SOURCE_PATH and/or DEST_PATH, these
+    paths will be used as dir prefixes to any paths read from the `--batch` input.
     """
     from globus_cli.services.transfer import add_batch_to_transfer_data, autoactivate
 

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -138,7 +138,7 @@ def transfer_command(
     will submit a single-file or single-directory timer.
 
     Using `--batch`, `globus timer create transfer` can create a timer which
-    transfers multiple files or directories.
+    transfers multiple specified files or directories.
     Each line of `--batch` input is treated as a separate file or directory
     transfer to include in the timer.
 
@@ -149,8 +149,8 @@ def transfer_command(
     Skips empty lines and allows comments beginning with "#".
 
     \b
-    If you use `--batch` and a commandline SOURCE_PATH and/or DEST_PATH, these
-    paths will be used as dir prefixes to any paths read from the `--batch` input.
+    If you use `--batch` and supply a SOURCE_PATH and/or DEST_PATH via the commandline,
+    these paths will be used as dir prefixes to any paths read from the `--batch` input.
     """
     from globus_cli.services.transfer import add_batch_to_transfer_data, autoactivate
 

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -264,16 +264,15 @@ def transfer_command(
     are ever created on the dest.
 
     \b
-    === Batched Input
+    === Batch Input
 
     If you use `SOURCE_PATH` and `DEST_PATH` without the `--batch` flag, you
     will submit a single-file or single-directory transfer task.
-    This has behavior similar to `cp` and `cp -r` across endpoints.
 
     Using `--batch`, `globus transfer` can submit a task which transfers multiple files
-    or directories. The value for `--batch` can be a file to read from, or the
-    character `-` which will read from stdin. From either the file or stdin, each line
-    is treated as a path to a file or directory to transfer, respecting quotes.
+    or directories.
+    Each line of `--batch` input is treated as a path to a file or directory to
+    transfer.
 
     \b
     Lines are of the form
@@ -283,7 +282,7 @@ def transfer_command(
 
     \b
     If you use `--batch` and a commandline SOURCE_PATH and/or DEST_PATH, these
-    paths will be used as dir prefixes to any paths read from the batch source.
+    paths will be used as dir prefixes to any paths read from the `--batch` input.
 
     \b
     === Sync Levels

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -269,8 +269,8 @@ def transfer_command(
     If you use `SOURCE_PATH` and `DEST_PATH` without the `--batch` flag, you
     will submit a single-file or single-directory transfer task.
 
-    Using `--batch`, `globus transfer` can submit a task which transfers multiple files
-    or directories.
+    Using `--batch`, `globus transfer` can submit a task which transfers multiple
+    specified files or directories.
     Each line of `--batch` input is treated as a path to a file or directory to
     transfer.
 

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import textwrap
 import typing as t
 
 import click
@@ -168,13 +169,15 @@ def delete_and_rm_options(
         f = click.option(
             "--batch",
             type=click.File("r"),
-            help=(
-                "Accept a batch of source/dest path pairs from a file. Use the "
-                "special `-` value to read from stdin; otherwise opens the file from "
-                "the argument and passes through lines from that file. Uses "
-                "SOURCE_ENDPOINT_ID and DEST_ENDPOINT_ID as passed on the commandline. "
-                "Commandline paths are still allowed and are used as prefixes to the "
-                "batchmode inputs. "
+            help=textwrap.dedent(
+                """\
+                Accept a batch of paths from a file.
+                Use `-` to read from stdin.
+
+                Uses ENDPOINT_ID as passed on the commandline.
+
+                See documentation on "Batch Input" for more information.
+                """
             ),
         )(f)
     return f

--- a/src/globus_cli/parsing/shared_options/transfer_task_options.py
+++ b/src/globus_cli/parsing/shared_options/transfer_task_options.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import textwrap
 import typing as t
 
 import click
@@ -60,12 +61,16 @@ def transfer_batch_option(f: C) -> C:
     return click.option(
         "--batch",
         type=click.File("r"),
-        help=(
-            "Accept a batch of source/dest path pairs from a file. Use the special `-` "
-            "value to read from stdin; otherwise opens the file from the argument and "
-            "passes through lines from that file. Uses SOURCE_ENDPOINT_ID and "
-            "DEST_ENDPOINT_ID as passed on the commandline. Commandline paths are "
-            "still allowed and are used as prefixes to the batchmode inputs."
+        help=textwrap.dedent(
+            """\
+            Accept a batch of source/dest path pairs from a file.
+            Use `-` to read from stdin.
+
+            Uses SOURCE_ENDPOINT_ID and DEST_ENDPOINT_ID as passed on the
+            commandline.
+
+            See documentation on "Batch Input" for more information.
+            """
         ),
     )(f)
 


### PR DESCRIPTION
Without changing the doc paradigm, ensure that all instances of
`--batch` inputs are correctly documented and stripped of extraneous
details.
