### PR TITLE
Fix some bugs

### DIFF
--- a/changelog.d/20230828_142533_kurtmckee_fix_some_bugs.md
+++ b/changelog.d/20230828_142533_kurtmckee_fix_some_bugs.md
@@ -1,0 +1,8 @@
+### Bugfixes
+
+*   Make `--no-recursive` and `--batch` mutually exclusive options.
+
+    This affects the `globus transfer` and the `globus timer create transfer` commands.
+
+    Previously, `--no-recursive` was not caught because of its internal representation.
+    This is now fixed, so `--no-recursive` cannot be combined with `--batch`.

--- a/changelog.d/20230829_122948_kurtmckee_fix_some_bugs.md
+++ b/changelog.d/20230829_122948_kurtmckee_fix_some_bugs.md
@@ -1,0 +1,11 @@
+### Bugfixes
+
+*   Fix a bug that caused `--batch` input files to default to non-recursive transfers.
+
+    This affects the `globus transfer` and `globus timer create transfer` commands.
+
+    It's now possible for `--batch` input files to use
+    `--recursive` to enable recursive transfers
+    or `--no-recursive` to explicitly disable recursive transfers.
+    If neither option is specified, path type auto-detection
+    will determine the correct recursion setting.

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -141,11 +141,11 @@ def transfer_command(
     dest_endpoint, cmd_dest_path = destination
 
     # avoid 'mutex_option_group', emit a custom error message
-    if recursive and batch:
+    if recursive is not None and batch:
+        option_name = "--recursive" if recursive else "--no-recursive"
         raise click.UsageError(
-            "You cannot use --recursive in addition to --batch. "
-            "Instead, use --recursive on lines of --batch input "
-            "which need it"
+            f"You cannot use {option_name} in addition to --batch. "
+            f"Instead, use {option_name} on lines of --batch input which need it."
         )
     if (cmd_source_path is None or cmd_dest_path is None) and (not batch):
         raise click.UsageError(

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -332,18 +332,17 @@ def transfer_command(
     dest_endpoint, cmd_dest_path = destination
 
     # avoid 'mutex_option_group', emit a custom error message
-    if recursive and batch:
+    if recursive is not None and batch:
+        option_name = "--recursive" if recursive else "--no-recursive"
         raise click.UsageError(
-            "You cannot use --recursive in addition to --batch. "
-            "Instead, use --recursive on lines of --batch input "
-            "which need it"
+            f"You cannot use {option_name} in addition to --batch. "
+            f"Instead, use {option_name} on lines of --batch input which need it."
         )
 
     if external_checksum and batch:
         raise click.UsageError(
             "You cannot use --external-checksum in addition to --batch. "
-            "Instead, use --external-checksum on lines of --batch input "
-            "which need it"
+            "Instead, use --external-checksum on lines of --batch input which need it."
         )
 
     # the performance options (of which there are a few), have elements which should be

--- a/src/globus_cli/services/transfer/data.py
+++ b/src/globus_cli/services/transfer/data.py
@@ -20,7 +20,7 @@ def add_batch_to_transfer_data(
 ) -> None:
     @click.command()
     @click.option("--external-checksum")
-    @click.option("--recursive", "-r", is_flag=True)
+    @click.option("--recursive/--no-recursive", "-r", default=None, is_flag=True)
     @click.argument("source_path", type=TaskPath(base_dir=source_base_path))
     @click.argument("dest_path", type=TaskPath(base_dir=dest_base_path))
     @mutex_option_group("--recursive", "--external-checksum")

--- a/tests/functional/task/test_task_submit.py
+++ b/tests/functional/task/test_task_submit.py
@@ -1,6 +1,8 @@
 import json
 
-from globus_sdk._testing import load_response_set
+import globus_sdk
+import pytest
+from globus_sdk._testing import get_last_request, load_response, load_response_set
 
 
 def test_filter_rules(run_line, go_ep1_id, go_ep2_id):
@@ -178,3 +180,35 @@ def test_transfer_recursive_options(run_line, go_ep1_id, go_ep2_id, tmp_path):
     json_output = json.loads(result.output)
     transfer_item = json_output["DATA"][0]
     assert "recursive" not in transfer_item
+
+
+@pytest.mark.parametrize("option", ("", "--recursive", "--no-recursive"))
+def test_recursion_options_in_batch_input(run_line, go_ep1_id, go_ep2_id, option):
+    load_response_set("cli.transfer_activate_success")
+    load_response(globus_sdk.TransferClient.submit_transfer)
+    load_response(globus_sdk.TransferClient.get_submission_id)
+
+    stdin = f"abc def {option}\n"
+    run_line(
+        [
+            "globus",
+            "transfer",
+            "--batch",
+            "-",
+            f"{go_ep1_id}:/",
+            f"{go_ep1_id}:/",
+        ],
+        stdin=stdin,
+    )
+
+    # Retrieve the first DATA item in the JSON request body.
+    request = get_last_request()
+    item = json.loads(request.body)["DATA"][0]
+
+    # Assert things.
+    if option == "--recursive":
+        assert item["recursive"] is True
+    elif option == "--no-recursive":
+        assert item["recursive"] is False
+    else:  # option == ""
+        assert "recursive" not in item

--- a/tests/functional/task/test_task_submit.py
+++ b/tests/functional/task/test_task_submit.py
@@ -50,7 +50,7 @@ def test_filter_rules(run_line, go_ep1_id, go_ep2_id):
     assert json_output["filter_rules"] == expected_filter_rules
 
 
-def test_exlude_recursive(run_line, go_ep1_id, go_ep2_id):
+def test_exclude_recursive(run_line, go_ep1_id, go_ep2_id):
     """
     Confirms using --exclude on non recursive transfers raises errors
     """
@@ -67,7 +67,7 @@ def test_exlude_recursive(run_line, go_ep1_id, go_ep2_id):
     )
 
 
-def test_exlude_recursive_batch_stdin(run_line, go_ep1_id, go_ep2_id):
+def test_exclude_recursive_batch_stdin(run_line, go_ep1_id, go_ep2_id):
     load_response_set("cli.get_submission_id")
     result = run_line(
         "globus transfer --exclude *.txt --batch - "
@@ -81,7 +81,7 @@ def test_exlude_recursive_batch_stdin(run_line, go_ep1_id, go_ep2_id):
     )
 
 
-def test_exlude_recursive_batch_file(run_line, go_ep1_id, go_ep2_id, tmp_path):
+def test_exclude_recursive_batch_file(run_line, go_ep1_id, go_ep2_id, tmp_path):
     load_response_set("cli.get_submission_id")
     temp = tmp_path / "batch"
     temp.write_text("abc /def\n")

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -1,5 +1,6 @@
 import os
 import re
+import uuid
 
 import pytest
 from globus_sdk._testing import RegisteredResponse, load_response, load_response_set
@@ -247,3 +248,22 @@ def test_env_checks(monkeypatch, run_line, cmd):
     monkeypatch.setitem(os.environ, "GLOBUS_CLI_INTERACTIVE", "Whoops")
     result = run_line(f"globus {cmd}", assert_exit_code=1)
     assert "GLOBUS_CLI_INTERACTIVE" in result.stderr
+
+
+@pytest.mark.parametrize("option", ("--recursive", "--no-recursive"))
+def test_recursive_and_batch_exclusive(run_line, option):
+    ep_id = str(uuid.UUID(int=1))
+
+    result = run_line(
+        [
+            "globus",
+            "transfer",
+            ep_id,
+            ep_id,
+            option,
+            "--batch",
+            "-",
+        ],
+        assert_exit_code=2,
+    )
+    assert f"You cannot use {option} in addition to --batch" in result.stderr

--- a/tests/functional/timer/test_transfer_create.py
+++ b/tests/functional/timer/test_transfer_create.py
@@ -191,7 +191,8 @@ def test_create_job_batch_data(run_line, ep_for_timer):
     assert transfer_body["DATA"][1]["destination_path"] == "p/q/r"
 
 
-def test_recursive_and_batch_exclusive(run_line):
+@pytest.mark.parametrize("option", ("--recursive", "--no-recursive"))
+def test_recursive_and_batch_exclusive(run_line, option):
     ep_id = str(uuid.UUID(int=1))
 
     result = run_line(
@@ -204,13 +205,13 @@ def test_recursive_and_batch_exclusive(run_line):
             ep_id,
             "--interval",
             "1800s",
-            "--recursive",
+            option,
             "--batch",
             "-",
         ],
         assert_exit_code=2,
     )
-    assert "You cannot use --recursive in addition to --batch" in result.stderr
+    assert f"You cannot use {option} in addition to --batch" in result.stderr
 
 
 def test_create_job_requires_some_pathargs(run_line):


### PR DESCRIPTION
### Bugfixes

*   Make `--no-recursive` and `--batch` mutually exclusive options.

    This affects the `globus transfer` and the `globus timer create transfer` commands.

    Previously, `--no-recursive` was not caught because of its internal representation.
    This is now fixed, so `--no-recursive` cannot be combined with `--batch`.

*   Fix a bug that caused `--batch` input files to default to non-recursive transfers.

    This affects the `globus transfer` and `globus timer create transfer` commands.

    It's now possible for `--batch` input files to use `--recursive` to enable recursive transfers
    or `--no-recursive` to explicitly disable recursive transfers.
    If neither option is specified, path type auto-detection    will determine the correct recursion setting.
