### PR TITLE
Update publishing workflows

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install CLI
         run: |
           python -m pip install -e .
@@ -24,12 +24,7 @@ jobs:
           tar --exclude "*.py" --exclude '.gitignore' -czf cli-reference.tar.gz -h reference/
       # upload as a release asset
       - name: Upload Autodoc
-        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # upload URL is pulled from the release event
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./cli-reference.tar.gz
-          asset_name: cli-reference.tar.gz
-          asset_content_type: application/gzip
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "${{ github.ref_name }}" cli-reference.tar.gz

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -5,11 +5,8 @@ on:
     types: [published]
 
 jobs:
-  publish:
+  build-dists:
     runs-on: ubuntu-latest
-    environment: publish-pypi
-    permissions:
-      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -18,7 +15,27 @@ jobs:
           python-version: "3.11"
 
       - run: python -m pip install build
-      - run: python -m build .
+
+      - name: Build Dists
+        run: python -m build .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: dist/*
+
+  publish_pypi:
+    needs: [build-dists]
+    runs-on: ubuntu-latest
+    environment: publish-pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -5,11 +5,8 @@ on:
     tags: ["*"]
 
 jobs:
-  publish:
+  build-dists:
     runs-on: ubuntu-latest
-    environment: publish-test-pypi
-    permissions:
-      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +19,26 @@ jobs:
       - name: Set dev version prior to upload
         run: python ./scripts/set_dev_version.py
 
-      - run: python -m build .
+      - name: Build Dists
+        run: python -m build .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: dist/*
+
+  publish:
+    needs: [build-dists]
+    runs-on: ubuntu-latest
+    environment: publish-test-pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: dist
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The latest guidance from the maintainers of
pypa/gh-action-pypi-publish is to split up publishing into two jobs so as to avoid exposing the OIDC token used for Trusted Publishers to the build process.

Switch both publishing jobs to a build-upload-download-publish flow to achieve this separation.

Update the `docs` workflow which publishes a reference doc tarball artifact on releases in a different way. For that, move from `github/upload-release-asset` (deprecated) to the GitHub CLI.

---

I've tested nearly identical updates in other FOSS projects successfully.