### PR TITLE
Warn/hint on inactive runs when showing logs

### DIFF
--- a/changelog.d/20230912_151825_sirosen_warn_inactive_run_logs.md
+++ b/changelog.d/20230912_151825_sirosen_warn_inactive_run_logs.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* A hint is now printed to stderr (interactive usage only) when
+  `globus flows run show-logs` is run on a *run* with the `INACTIVE` status,
+  informing users that the log will not grow until the *run* resumes

--- a/src/globus_cli/commands/flows/run/show_logs.py
+++ b/src/globus_cli/commands/flows/run/show_logs.py
@@ -89,8 +89,10 @@ def show_logs_command(
 
     if run_doc["status"] == "INACTIVE":
         print_command_hint(
-            "\nNOTE: This run is INACTIVE. "
-            "No further logs will be added until it is resumed.",
+            (
+                "\nNOTE: This run is INACTIVE. "
+                "No further logs will be added until it is resumed."
+            ),
             color="bright_blue",
         )
 

--- a/src/globus_cli/commands/flows/run/show_logs.py
+++ b/src/globus_cli/commands/flows/run/show_logs.py
@@ -49,6 +49,9 @@ def show_logs_command(
 
     flows_client = login_manager.get_flows_client()
 
+    # get the Flow, to check INACTIVE status below
+    run_doc = flows_client.get_run(run_id)
+
     paginator = Paginator.wrap(flows_client.get_run_logs)
     entry_iterator = PagingWrapper(
         paginator(run_id=run_id, reverse_order=reverse).items(),
@@ -82,6 +85,13 @@ def show_logs_command(
         # Display the log entries in a table.
         display(
             entry_iterator, fields=fields, json_converter=entry_iterator.json_converter
+        )
+
+    if run_doc["status"] == "INACTIVE":
+        print_command_hint(
+            "\nNOTE: This run is INACTIVE. "
+            "No further logs will be added until it is resumed.",
+            color="bright_blue",
         )
 
     # Check if there are more results

--- a/src/globus_cli/termio/__init__.py
+++ b/src/globus_cli/termio/__init__.py
@@ -17,13 +17,13 @@ from .field import Field
 from .printer import TextMode, display
 
 
-def print_command_hint(message):
+def print_command_hint(message: str, *, color: str = "yellow"):
     """
     Wrapper around echo that checks terminal state
     before printing a given command hint message
     """
     if term_is_interactive() and err_is_terminal() and out_is_terminal():
-        click.echo(click.style(message, fg="yellow"), err=True)
+        click.echo(click.style(message, fg=color), err=True)
 
 
 __all__ = [


### PR DESCRIPTION
When a `globus flows run show-logs` is run, the run will be checked to
see if its status is "INACTIVE".

This allows the CLI to print a useful hint to stderr (interactive mode
only) showing that the run log will not gain more entries until the
run is resumed.

This is an enhancement for interactive usage when a user is trying to
manually poll or "tail" the run-log and expects to see new data.
Because the log itself does not include the transition to "INACTIVE",
this usage leads to a delay between the run going inactive and the
user understanding that the state of the run has changed.

The hint is printed in a non-yellow color, and "bright_blue" was
selected from the options as a neutral color WRT the usual associated
semantics of red/yellow/green.
