### PR TITLE
More strictly check types with mypy in easy cases

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -32,9 +32,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.parsing.param_types.identity_type]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.parsing.param_types.nullable]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.parsing.shared_options]
 disallow_untyped_defs = false
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -134,8 +134,5 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.mkdir]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.rename]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.session.show]
 disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,9 +32,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.parsing.param_types.identity_type]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.parsing.param_types.location]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.parsing.param_types.nullable]
 disallow_untyped_defs = false
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -137,8 +137,5 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.rename]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.rm]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.session.show]
 disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -110,12 +110,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.update]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.gcp]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.gcp.create]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.get_identities]
 disallow_untyped_defs = false
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -131,8 +131,5 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.ls]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.mkdir]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.session.show]
 disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -124,6 +124,3 @@ disallow_untyped_defs = false
 
 [mypy-globus_cli.commands.ls]
 disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.session.show]
-disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -86,9 +86,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.permission.create]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.endpoint.permission.show]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.permission.update]
 disallow_untyped_defs = false
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -92,9 +92,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.set_subscription_id]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.endpoint.storage_gateway.list]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.update]
 disallow_untyped_defs = false
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -86,9 +86,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.permission.create]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.endpoint.permission.list]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.permission.show]
 disallow_untyped_defs = false
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -80,9 +80,6 @@ disallow_untyped_defs = false
 # command modules
 # listed separately to preserve the readability of the above config
 
-[mypy-globus_cli.commands.delete]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.permission._common]
 disallow_untyped_defs = false
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -86,9 +86,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.permission.create]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.endpoint.permission.delete]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.permission.list]
 disallow_untyped_defs = false
 

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -91,7 +91,7 @@ def delete_command(
     skip_activation_check: bool,
     notify: dict[str, bool],
     local_user: str | None,
-):
+) -> None:
     """
     Submits an asynchronous task that deletes files and/or directories on the target
     endpoint.
@@ -154,7 +154,7 @@ def delete_command(
         # the future to these lines with trivial modifications
         @click.command()
         @click.argument("path", type=TaskPath(base_dir=path))
-        def process_batch_line(path):
+        def process_batch_line(path: TaskPath) -> None:
             """
             Parse a line of batch input and add it to the delete submission
             item.

--- a/src/globus_cli/commands/endpoint/permission/delete.py
+++ b/src/globus_cli/commands/endpoint/permission/delete.py
@@ -1,3 +1,5 @@
+import uuid
+
 import click
 
 from globus_cli.login_manager import LoginManager
@@ -19,7 +21,9 @@ $ globus endpoint permission delete $ep_id $rule_id
 @endpoint_id_arg
 @click.argument("rule_id")
 @LoginManager.requires_login("transfer")
-def delete_command(login_manager: LoginManager, *, endpoint_id, rule_id):
+def delete_command(
+    login_manager: LoginManager, *, endpoint_id: uuid.UUID, rule_id: str
+) -> None:
     """
     Delete an existing access control rule, removing whatever permissions it previously
     granted users on the endpoint.

--- a/src/globus_cli/commands/endpoint/permission/list.py
+++ b/src/globus_cli/commands/endpoint/permission/list.py
@@ -21,7 +21,7 @@ $ globus endpoint permission list $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login("auth", "transfer")
-def list_command(login_manager: LoginManager, *, endpoint_id: uuid.UUID):
+def list_command(login_manager: LoginManager, *, endpoint_id: uuid.UUID) -> None:
     """List all rules in an endpoint's access control list."""
     transfer_client = login_manager.get_transfer_client()
     auth_client = login_manager.get_auth_client()

--- a/src/globus_cli/commands/endpoint/permission/show.py
+++ b/src/globus_cli/commands/endpoint/permission/show.py
@@ -25,7 +25,9 @@ $ globus endpoint permission show $ep_id $rule_id
 @endpoint_id_arg
 @click.argument("rule_id")
 @LoginManager.requires_login("auth", "transfer")
-def show_command(login_manager: LoginManager, *, endpoint_id: uuid.UUID, rule_id: str):
+def show_command(
+    login_manager: LoginManager, *, endpoint_id: uuid.UUID, rule_id: str
+) -> None:
     """
     Show detailed information about a single access control rule on an endpoint.
     """

--- a/src/globus_cli/commands/endpoint/storage_gateway/list.py
+++ b/src/globus_cli/commands/endpoint/storage_gateway/list.py
@@ -1,7 +1,7 @@
-import click
+import uuid
 
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import command
+from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import Field, TextMode, display, formatters
 
 STANDARD_FIELDS = [
@@ -13,16 +13,13 @@ STANDARD_FIELDS = [
 
 
 @command("list", short_help="List the Storage Gateways on an Endpoint")
-@click.argument(
-    "endpoint_id",
-    metavar="ENDPOINT_ID",
-)
+@endpoint_id_arg
 @LoginManager.requires_login("auth", "transfer")
 def storage_gateway_list(
     login_manager: LoginManager,
     *,
-    endpoint_id,
-):
+    endpoint_id: uuid.UUID,
+) -> None:
     """
     List the Storage Gateways on a given Globus Connect Server v5 Endpoint
     """

--- a/src/globus_cli/commands/gcp/__init__.py
+++ b/src/globus_cli/commands/gcp/__init__.py
@@ -8,5 +8,5 @@ from globus_cli.parsing import group
         "update": (".update", "update_command"),
     },
 )
-def gcp_command():
+def gcp_command() -> None:
     """Manage Globus Connect Personal endpoints"""

--- a/src/globus_cli/commands/gcp/create/__init__.py
+++ b/src/globus_cli/commands/gcp/create/__init__.py
@@ -8,5 +8,5 @@ from globus_cli.parsing import group
         "guest": (".guest", "guest_command"),
     },
 )
-def create_command():
+def create_command() -> None:
     """Create Globus Connect Personal collections"""

--- a/src/globus_cli/commands/mkdir.py
+++ b/src/globus_cli/commands/mkdir.py
@@ -29,7 +29,7 @@ def mkdir_command(
     *,
     endpoint_plus_path: tuple[uuid.UUID, str],
     local_user: str | None,
-):
+) -> None:
     """Make a directory on an endpoint at the given path.
 
     {AUTOMATIC_ACTIVATION}

--- a/src/globus_cli/commands/rename.py
+++ b/src/globus_cli/commands/rename.py
@@ -33,7 +33,7 @@ def rename_command(
     source: str,
     destination: str,
     local_user: str | None,
-):
+) -> None:
     """Rename a file or directory on an endpoint.
 
     The old path must be an existing file or directory. The new path must not yet

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -66,7 +66,7 @@ def rm_command(
     polling_interval: int,
     timeout: int | None,
     timeout_exit_code: int,
-):
+) -> None:
     """
     Submit a Delete Task to delete a single path, and then block and wait for it to
     complete.

--- a/src/globus_cli/commands/session/show.py
+++ b/src/globus_cli/commands/session/show.py
@@ -47,7 +47,7 @@ $ globus session show --format json
 """,
 )
 @LoginManager.requires_login("auth")
-def session_show(login_manager: LoginManager):
+def session_show(login_manager: LoginManager) -> None:
     """List all identities in your current CLI auth session.
 
     Lists identities that are in the session tied to the CLI's access tokens along with

--- a/src/globus_cli/parsing/param_types/nullable.py
+++ b/src/globus_cli/parsing/param_types/nullable.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 from urllib.parse import urlparse
 
@@ -6,7 +8,7 @@ import click
 from globus_cli.constants import EXPLICIT_NULL, ExplicitNullType
 
 
-def nullable_multi_callback(null="null"):
+def nullable_multi_callback(null: t.Any = "null") -> t.Callable[..., t.Any]:
     """
     A callback which converts multiple=True options as follows:
     - empty results, [] => None
@@ -23,7 +25,9 @@ def nullable_multi_callback(null="null"):
     Note that this will see values after the type conversion has happened.
     """
 
-    def callback(ctx, param, value):
+    def callback(
+        ctx: click.Context, param: click.Parameter, value: t.Sequence[t.Any] | None
+    ) -> t.Any:
         if value is None or len(value) == 0:
             return None
         if len(value) == 1 and value[0] == null:
@@ -42,10 +46,12 @@ class StringOrNull(click.ParamType):
     def get_type_annotation(self, param: click.Parameter) -> type:
         return t.cast(type, str | ExplicitNullType)
 
-    def get_metavar(self, param):
+    def get_metavar(self, param: click.Parameter) -> str:
         return "TEXT"
 
-    def convert(self, value, param, ctx):
+    def convert(
+        self, value: t.Any, param: click.Parameter | None, ctx: click.Context | None
+    ) -> t.Any:
         if value == "":
             return EXPLICIT_NULL
         else:
@@ -58,10 +64,12 @@ class UrlOrNull(StringOrNull):
     http or https URL.
     """
 
-    def get_metavar(self, param):
+    def get_metavar(self, param: click.Parameter) -> str:
         return "TEXT"
 
-    def convert(self, value, param, ctx):
+    def convert(
+        self, value: t.Any, param: click.Parameter | None, ctx: click.Context | None
+    ) -> t.Any:
         if value == "":
             return EXPLICIT_NULL
         else:

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -17,7 +17,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.local_id",
     "globus_cli.commands.endpoint.my_shared_endpoint_list",
     "globus_cli.commands.endpoint.permission.create",
-    "globus_cli.commands.endpoint.permission.delete",
     "globus_cli.commands.endpoint.permission.list",
     "globus_cli.commands.endpoint.permission.show",
     "globus_cli.commands.endpoint.permission.update",

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -21,7 +21,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.role.create",
     "globus_cli.commands.endpoint.search",
     "globus_cli.commands.endpoint.show",
-    "globus_cli.commands.endpoint.storage_gateway.list",
     "globus_cli.commands.get_identities",
     "globus_cli.commands.login",
     "globus_cli.commands.logout",

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -17,7 +17,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.local_id",
     "globus_cli.commands.endpoint.my_shared_endpoint_list",
     "globus_cli.commands.endpoint.permission.create",
-    "globus_cli.commands.endpoint.permission.show",
     "globus_cli.commands.endpoint.permission.update",
     "globus_cli.commands.endpoint.role.create",
     "globus_cli.commands.endpoint.search",

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -17,7 +17,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.local_id",
     "globus_cli.commands.endpoint.my_shared_endpoint_list",
     "globus_cli.commands.endpoint.permission.create",
-    "globus_cli.commands.endpoint.permission.list",
     "globus_cli.commands.endpoint.permission.show",
     "globus_cli.commands.endpoint.permission.update",
     "globus_cli.commands.endpoint.role.create",


### PR DESCRIPTION
This PR is a non-systematic review of the modules which were listed in mypy for exemption from strict checking for "easy wins".
In cases where the module was checked but skipped in the click-type-test testing, it has been removed from that exemption list as well.

Each commit in this series should take only one or two minutes to review, and the end result includes exactly one meaningful change to runtime logic (to use the shared `endpoint_id_arg` option decorator).

- Type-check the 'rm' command
- Type-check the 'rename' command
- Type-check the mkdir command
- Type-check the location ParamType
- Type-check the nullable ParamTypes
- Type-check the "session show" command
- Type-check gcp commands
- Type-check the delete command
- Type-check the acl delete command
- Type-check the acl list command
- Type-check the acl show command
- Type-check the 'storage-gateway list' command
