### PR TITLE
Apply more typing fixes

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -80,11 +80,5 @@ disallow_untyped_defs = false
 # command modules
 # listed separately to preserve the readability of the above config
 
-[mypy-globus_cli.commands.endpoint.permission._common]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.permission.create]
-disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.endpoint.update]
 disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -88,6 +88,3 @@ disallow_untyped_defs = false
 
 [mypy-globus_cli.commands.endpoint.update]
 disallow_untyped_defs = false
-
-[mypy-globus_cli.commands.ls]
-disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -95,8 +95,5 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.update]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.get_identities]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.ls]
 disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -86,9 +86,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.permission.create]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.endpoint.permission.update]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.set_subscription_id]
 disallow_untyped_defs = false
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -76,9 +76,3 @@ disallow_untyped_defs = false
 
 [mypy-globus_cli.termio.awscli_text]
 disallow_untyped_defs = false
-
-# command modules
-# listed separately to preserve the readability of the above config
-
-[mypy-globus_cli.commands.endpoint.permission.create]
-disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -98,8 +98,5 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.get_identities]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.login]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.ls]
 disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -86,9 +86,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.commands.endpoint.permission.create]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.commands.endpoint.set_subscription_id]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.commands.endpoint.update]
 disallow_untyped_defs = false
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ TEST_REQUIREMENTS = [
     "pytest<7",
     "pytest-xdist<3",
     "pytest-timeout<2",
-    "click-type-test==0.0.4;python_version>='3.10'",
+    "click-type-test==0.0.5;python_version>='3.10'",
     "responses==0.23.3",
     # loading test fixture data
     "ruamel.yaml==0.17.32",

--- a/src/globus_cli/commands/endpoint/deactivate.py
+++ b/src/globus_cli/commands/endpoint/deactivate.py
@@ -1,3 +1,5 @@
+import uuid
+
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import TextMode, display
@@ -17,7 +19,7 @@ $ globus endpoint deactivate $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login("transfer")
-def endpoint_deactivate(login_manager: LoginManager, *, endpoint_id: str) -> None:
+def endpoint_deactivate(login_manager: LoginManager, *, endpoint_id: uuid.UUID) -> None:
     """
     Remove the credential previously assigned to an endpoint via
     'globus endpoint activate' or any other form of endpoint activation

--- a/src/globus_cli/commands/endpoint/delete.py
+++ b/src/globus_cli/commands/endpoint/delete.py
@@ -1,3 +1,5 @@
+import uuid
+
 from globus_cli.endpointish import Endpointish
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
@@ -16,7 +18,7 @@ $ globus endpoint delete $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login("transfer")
-def endpoint_delete(login_manager: LoginManager, *, endpoint_id: str) -> None:
+def endpoint_delete(login_manager: LoginManager, *, endpoint_id: uuid.UUID) -> None:
     """Delete a given endpoint.
 
     WARNING: Deleting an endpoint will permanently disable any existing shared

--- a/src/globus_cli/commands/endpoint/local_id.py
+++ b/src/globus_cli/commands/endpoint/local_id.py
@@ -44,7 +44,7 @@ globus ls "${ep_id}:/${dir_to_ls}"
     type_annotation=bool,
     help="Use local Globus Connect Personal endpoint (default)",
 )
-def local_id(personal: bool) -> None:
+def local_id(*, personal: bool) -> None:
     """
     Look for data referring to a local installation of Globus Connect Personal software
     and display the associated endpoint ID.

--- a/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
+++ b/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
@@ -1,3 +1,5 @@
+import uuid
+
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import display
@@ -15,7 +17,9 @@ $ globus endpoint my-shared-endpoint-list $ep_id
 )
 @endpoint_id_arg
 @LoginManager.requires_login("transfer")
-def my_shared_endpoint_list(login_manager: LoginManager, *, endpoint_id: str) -> None:
+def my_shared_endpoint_list(
+    login_manager: LoginManager, *, endpoint_id: uuid.UUID
+) -> None:
     """
     Show a list of all shared endpoints hosted on the target endpoint for which the user
     has the "administrator" or "access_manager" effective roles.

--- a/src/globus_cli/commands/endpoint/permission/_common.py
+++ b/src/globus_cli/commands/endpoint/permission/_common.py
@@ -8,7 +8,7 @@ class AclPrincipalFormatter(formatters.auth.PrincipalDictFormatter):
     # unrecognized types. This handles various cases in which
     # `principal_type=all_authenticated_users` or similar, which is the shape of the
     # data from Globus Transfer
-    def fallback_rendering(self, principal: str, principal_type: str):
+    def fallback_rendering(self, principal: str, principal_type: str) -> str:
         return principal_type
 
     # TODO: re-assess Group rendering in the CLI

--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import uuid
 

--- a/src/globus_cli/commands/endpoint/permission/update.py
+++ b/src/globus_cli/commands/endpoint/permission/update.py
@@ -38,7 +38,7 @@ $ globus endpoint permission update $ep_id $rule_id --permissions r
 def update_command(
     login_manager: LoginManager,
     *,
-    permissions: Literal["r", "rw"] | None,
+    permissions: Literal["r", "rw"],
     rule_id: str,
     endpoint_id: uuid.UUID
 ) -> None:

--- a/src/globus_cli/commands/endpoint/permission/update.py
+++ b/src/globus_cli/commands/endpoint/permission/update.py
@@ -1,8 +1,16 @@
+import sys
+import uuid
+
 import click
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import TextMode, display
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @command(
@@ -27,7 +35,13 @@ $ globus endpoint permission update $ep_id $rule_id --permissions r
     help="Permissions to add. Read-Only or Read/Write",
 )
 @LoginManager.requires_login("transfer")
-def update_command(login_manager: LoginManager, *, permissions, rule_id, endpoint_id):
+def update_command(
+    login_manager: LoginManager,
+    *,
+    permissions: Literal["r", "rw"] | None,
+    rule_id: str,
+    endpoint_id: uuid.UUID
+) -> None:
     """
     Update an existing access control rule's permissions.
 

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import click
 from globus_sdk.paging import Paginator
 
@@ -7,6 +9,11 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import display
 from globus_cli.utils import PagingWrapper
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @command(
@@ -74,7 +81,16 @@ def endpoint_search(
     filter_fulltext: str | None,
     limit: int,
     filter_owner_id: str | None,
-    filter_scope: str | None,
+    filter_scope: Literal[
+        "all",
+        "administered-by-me",
+        "my-endpoints",
+        "my-gcp-endpoints",
+        "recently-used",
+        "in-use",
+        "shared-by-me",
+        "shared-with-me",
+    ],
 ) -> None:
     """
     Search for Globus endpoints with search filters. If --filter-scope is set to the

--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -16,7 +16,7 @@ class SubscriptionIdType(click.ParamType):
 
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
-    ):
+    ) -> t.Any:
         if value is None or (ctx and ctx.resilient_parsing):
             return None
         if value.lower() == "null":

--- a/src/globus_cli/commands/endpoint/show.py
+++ b/src/globus_cli/commands/endpoint/show.py
@@ -1,3 +1,5 @@
+import uuid
+
 import click
 
 from globus_cli.endpointish import Endpointish
@@ -39,7 +41,10 @@ GCP_FIELDS = STANDARD_FIELDS + [
 @click.option("--skip-endpoint-type-check", is_flag=True, hidden=True)
 @LoginManager.requires_login("transfer")
 def endpoint_show(
-    login_manager: LoginManager, *, endpoint_id: str, skip_endpoint_type_check: bool
+    login_manager: LoginManager,
+    *,
+    endpoint_id: uuid.UUID,
+    skip_endpoint_type_check: bool
 ) -> None:
     """Display a detailed endpoint definition"""
     transfer_client = login_manager.get_transfer_client()

--- a/src/globus_cli/commands/get_identities.py
+++ b/src/globus_cli/commands/get_identities.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 
 import click

--- a/src/globus_cli/commands/get_identities.py
+++ b/src/globus_cli/commands/get_identities.py
@@ -1,7 +1,9 @@
+import typing as t
+
 import click
 
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import IdentityType, command
+from globus_cli.parsing import IdentityType, ParsedIdentity, command
 from globus_cli.termio import Field, TextMode, display, is_verbose
 from globus_cli.utils import CLIStubResponse
 
@@ -37,7 +39,9 @@ $ globus get-identities --verbose go@globusid.org clitester1a@globusid.org \
 )
 @click.option("--provision", hidden=True, is_flag=True)
 @LoginManager.requires_login("auth")
-def get_identities_command(login_manager: LoginManager, *, values, provision):
+def get_identities_command(
+    login_manager: LoginManager, *, values: tuple[ParsedIdentity, ...], provision: bool
+) -> None:
     """
     Lookup Globus Auth Identities given one or more uuids
     and/or usernames.
@@ -70,20 +74,20 @@ def get_identities_command(login_manager: LoginManager, *, values, provision):
         ]
     res = CLIStubResponse({"identities": results})
 
-    def _custom_text_format(identities):
+    def _custom_text_format(identities: list[dict[str, t.Any]]) -> None:
         """
         Non-verbose text output is customized
         """
 
-        def resolve_identity(value):
+        def resolve_identity(value: dict[str, t.Any]) -> str:
             """
             helper to deal with variable inputs and uncertain response order
             """
             for identity in identities:
                 if identity["id"] == value:
-                    return identity["username"]
+                    return t.cast(str, identity["username"])
                 if identity["username"] == value:
-                    return identity["id"]
+                    return t.cast(str, identity["id"])
             return "NO_SUCH_IDENTITY"
 
         # standard output is one resolved identity per line in the same order

--- a/src/globus_cli/commands/login.py
+++ b/src/globus_cli/commands/login.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 import click
 from globus_sdk.scopes import GCSEndpointScopeBuilder
 from globus_sdk.services.flows import SpecificFlowClient
@@ -80,7 +82,12 @@ Clients are always "logged in"
     """,
     multiple=True,
 )
-def login_command(no_local_server, force, gcs_servers, flow_ids: tuple[str]):
+def login_command(
+    no_local_server: bool,
+    force: bool,
+    gcs_servers: tuple[uuid.UUID, ...],
+    flow_ids: tuple[uuid.UUID, ...],
+) -> None:
     """
     Get credentials for the Globus CLI.
 

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -194,7 +194,7 @@ def ls_command(
     ],
     filter_val: str | None,
     local_user: str | None,
-):
+) -> None:
     """
     List the contents of a directory on an endpoint. If no path is given, the default
     directory on that endpoint will be used.

--- a/src/globus_cli/commands/task/cancel.py
+++ b/src/globus_cli/commands/task/cancel.py
@@ -53,7 +53,9 @@ $ globus task cancel --all
     "--all", "-a", is_flag=True, help="Cancel all in-progress tasks that you own"
 )
 @LoginManager.requires_login("transfer")
-def cancel_task(login_manager: LoginManager, *, all: bool, task_id: uuid.UUID) -> None:
+def cancel_task(
+    login_manager: LoginManager, *, all: bool, task_id: uuid.UUID | None
+) -> None:
     """
     Cancel a task you own or all tasks which you own.
 
@@ -110,5 +112,5 @@ def cancel_task(login_manager: LoginManager, *, all: bool, task_id: uuid.UUID) -
         display(None, text_mode=_custom_text, json_converter=json_converter)
 
     else:
-        res = transfer_client.cancel_task(task_id)
+        res = transfer_client.cancel_task(t.cast(uuid.UUID, task_id))
         display(res, text_mode=TextMode.text_raw, response_key="message")

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -20,7 +20,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.search",
     "globus_cli.commands.endpoint.show",
     "globus_cli.commands.get_identities",
-    "globus_cli.commands.login",
     "globus_cli.commands.logout",
 )
 

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -12,7 +12,6 @@ click_type_test = pytest.importorskip(
 )
 
 _SKIP_MODULES = (
-    "globus_cli.commands.endpoint.local_id",
     "globus_cli.commands.endpoint.my_shared_endpoint_list",
     "globus_cli.commands.endpoint.permission.create",
     "globus_cli.commands.endpoint.permission.update",

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -12,7 +12,6 @@ click_type_test = pytest.importorskip(
 )
 
 _SKIP_MODULES = (
-    "globus_cli.commands.endpoint.delete",
     "globus_cli.commands.endpoint.local_id",
     "globus_cli.commands.endpoint.my_shared_endpoint_list",
     "globus_cli.commands.endpoint.permission.create",

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -18,7 +18,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.permission.update",
     "globus_cli.commands.endpoint.role.create",
     "globus_cli.commands.endpoint.search",
-    "globus_cli.commands.endpoint.show",
     "globus_cli.commands.get_identities",
 )
 

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -12,7 +12,6 @@ click_type_test = pytest.importorskip(
 )
 
 _SKIP_MODULES = (
-    "globus_cli.commands.endpoint.my_shared_endpoint_list",
     "globus_cli.commands.endpoint.permission.create",
     "globus_cli.commands.endpoint.permission.update",
     "globus_cli.commands.endpoint.role.create",

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -18,7 +18,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.permission.update",
     "globus_cli.commands.endpoint.role.create",
     "globus_cli.commands.endpoint.search",
-    "globus_cli.commands.get_identities",
 )
 
 _ALL_NON_GROUP_COMMANDS: tuple[click.Command, ...] = (

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -13,7 +13,6 @@ click_type_test = pytest.importorskip(
 
 _SKIP_MODULES = (
     "globus_cli.commands.endpoint.permission.create",
-    "globus_cli.commands.endpoint.permission.update",
     "globus_cli.commands.endpoint.role.create",
     "globus_cli.commands.endpoint.search",
 )

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -12,7 +12,6 @@ click_type_test = pytest.importorskip(
 )
 
 _SKIP_MODULES = (
-    "globus_cli.commands.endpoint.deactivate",
     "globus_cli.commands.endpoint.delete",
     "globus_cli.commands.endpoint.local_id",
     "globus_cli.commands.endpoint.my_shared_endpoint_list",

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -14,7 +14,6 @@ click_type_test = pytest.importorskip(
 _SKIP_MODULES = (
     "globus_cli.commands.endpoint.permission.create",
     "globus_cli.commands.endpoint.role.create",
-    "globus_cli.commands.endpoint.search",
 )
 
 _ALL_NON_GROUP_COMMANDS: tuple[click.Command, ...] = (

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -20,7 +20,6 @@ _SKIP_MODULES = (
     "globus_cli.commands.endpoint.search",
     "globus_cli.commands.endpoint.show",
     "globus_cli.commands.get_identities",
-    "globus_cli.commands.logout",
 )
 
 _ALL_NON_GROUP_COMMANDS: tuple[click.Command, ...] = (


### PR DESCRIPTION
This is another round of refinement to our type checking.
This body of work revealed a deficiency in click-type-test (fixed in v0.0.5), which is why that is updated in the course of these changes.

As with my previous series of small adjustments, each commit here should take 1-2 minutes to review and the runtime changes are very, very limited.

Notably not all of the commands touched here tested under click-type-test in the end.
A couple of commands use a special decorator which interprets the arguments which are passed, and which cannot be explained to click-type-test easily (as of today).
Resolving those issues is considered out-of-scope for this body of work, which is intentionally limited to trivial changes only.

- Fix annotations for deactivate command
- Fix annotations for endpoint delete command
- Fix annotations for login command
- Fix annotations for logout command
- Fix annotations for endpoint show command
- Fix annotations for get-identities command
- Fix annotations for endpoint local-id command
- Fix annotations for shared endpoint list command
- Fix annotations for acl update command
- Update click-type-test to v0.0.5
- Fix annotations for endpoint search command
- Fix annotations in set-subscription-id command
- Fix type annotations for ls command
- Fix type checking of command modules
- Fix type checking of permission create command
