### PR TITLE
Fix the behavior of warnings in tests and resolve the revealed warnings

### DIFF
--- a/changelog.d/20231009_093456_sirosen_fix_test_warnings.md
+++ b/changelog.d/20231009_093456_sirosen_fix_test_warnings.md
@@ -1,0 +1,3 @@
+### Bugfixes
+
+* Fix the rendering of timedeltas in CLI output  for `globus timer` commands

--- a/src/globus_cli/_warnings.py
+++ b/src/globus_cli/_warnings.py
@@ -1,0 +1,14 @@
+import warnings
+
+# this bool turns off all warning controls, handing control of python
+# warnings to the testsuite
+# this ensures that `pytest --filterwarnings error` works
+_TEST_WARNING_CONTROL: bool = False
+
+
+def simplefilter(filterstr: str) -> None:
+    """
+    wrap `warnings.simplefilter` with a check on `_TEST_WARNING_CONTROL`
+    """
+    if not _TEST_WARNING_CONTROL:
+        warnings.simplefilter(filterstr)

--- a/src/globus_cli/_warnings.py
+++ b/src/globus_cli/_warnings.py
@@ -1,4 +1,10 @@
+import sys
 import warnings
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 # this bool turns off all warning controls, handing control of python
 # warnings to the testsuite
@@ -6,7 +12,9 @@ import warnings
 _TEST_WARNING_CONTROL: bool = False
 
 
-def simplefilter(filterstr: str) -> None:
+def simplefilter(
+    filterstr: Literal["default", "error", "ignore", "always", "module", "once"]
+) -> None:
     """
     wrap `warnings.simplefilter` with a check on `_TEST_WARNING_CONTROL`
     """

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -113,10 +113,10 @@ def print_error_or_response(
         for key in data.headers:
             click.echo(f"{key}: {data.headers[key]}")
         click.echo()
-    # raw_text/text must be used here, to present the exact data which was sent, with
+    # text must be used here, to present the exact data which was sent, with
     # whitespace and other detail preserved
     if isinstance(data, globus_sdk.GlobusAPIError):
-        click.echo(data.raw_text)
+        click.echo(data.text)
     else:
         # however, we will pass this through display using 'simple_text' to get
         # the right semantics

--- a/src/globus_cli/commands/group/join.py
+++ b/src/globus_cli/commands/group/join.py
@@ -53,7 +53,7 @@ def group_join(
                 f"Couldn't determine identity from value: {identity}"
             )
     else:
-        userinfo = auth_client.oauth2_userinfo()
+        userinfo = auth_client.userinfo()
         identity_id = userinfo["sub"]
 
     response = groups_client.batch_membership_action(

--- a/src/globus_cli/commands/logout.py
+++ b/src/globus_cli/commands/logout.py
@@ -75,9 +75,7 @@ def logout_command(login_manager: LoginManager, *, ignore_errors: bool) -> None:
     # try to get the user's preferred username from userinfo
     # if an API error is raised, they probably are not logged in
     try:
-        username = login_manager.get_auth_client().oauth2_userinfo()[
-            "preferred_username"
-        ]
+        username = login_manager.get_auth_client().userinfo()["preferred_username"]
     except globus_sdk.AuthAPIError:
         warnecho(
             "Unable to lookup username. You may not be logged in. "

--- a/src/globus_cli/commands/session/update.py
+++ b/src/globus_cli/commands/session/update.py
@@ -133,7 +133,7 @@ def session_update(
 
     auth_client = login_manager.get_auth_client()
     session_params = {"session_message": "Authenticate to update your CLI session."}
-    identity_set = auth_client.oauth2_userinfo()["identity_set"]
+    identity_set = auth_client.userinfo()["identity_set"]
 
     if all:
         _update_session_params_all_case(identity_set, session_params)

--- a/src/globus_cli/commands/timer/_common.py
+++ b/src/globus_cli/commands/timer/_common.py
@@ -33,7 +33,7 @@ class CallbackActionTypeFormatter(formatters.StrFormatter):
 
 class TimedeltaFormatter(formatters.FieldFormatter[datetime.timedelta]):
     def parse(self, value: t.Any) -> datetime.timedelta:
-        if not isinstance(value, int):
+        if not isinstance(value, (int, float)):
             raise ValueError("bad timedelta value")
         return datetime.timedelta(seconds=value)
 

--- a/src/globus_cli/commands/whoami.py
+++ b/src/globus_cli/commands/whoami.py
@@ -58,7 +58,7 @@ def whoami_command(login_manager: LoginManager, *, linked_identities: bool) -> N
     # get userinfo from auth.
     # if we get back an error the user likely needs to log in again
     try:
-        res = auth_client.oauth2_userinfo()
+        res = auth_client.userinfo()
     except globus_sdk.AuthAPIError:
         click.echo(
             "Unable to get user information. Please try logging in again.", err=True

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import logging.config
 import typing as t
-import warnings
 
 import click
+
+from globus_cli import _warnings
 
 # Format Enum for output formatting
 # could use a namedtuple, but that's overkill
@@ -118,10 +119,10 @@ def debug_option(f: F) -> F:
     def callback(ctx, param, value):
         if not value or ctx.resilient_parsing:
             # turn off warnings altogether
-            warnings.simplefilter("ignore")
+            _warnings.simplefilter("ignore")
             return
 
-        warnings.simplefilter("default")
+        _warnings.simplefilter("default")
         state = ctx.ensure_object(CommandState)
         state.debug = True
         _setup_logging(level="DEBUG")
@@ -146,20 +147,20 @@ def verbose_option(f: F) -> F:
         # all warnings are ignored
         # logging is not turned on
         if value == 0:
-            warnings.simplefilter("ignore")
+            _warnings.simplefilter("ignore")
 
         # verbosity level 1
         # warnings set to once
         # logging set to error
         if value == 1:
-            warnings.simplefilter("once")
+            _warnings.simplefilter("once")
             _setup_logging(level="ERROR")
 
         # verbosity level 2
         # warnings set to default
         # logging set to info
         if value == 2:
-            warnings.simplefilter("default")
+            _warnings.simplefilter("default")
             _setup_logging(level="INFO")
 
         # verbosity level 3+
@@ -167,7 +168,7 @@ def verbose_option(f: F) -> F:
         # logging set to debug
         # sets debug flag to true
         if value >= 3:
-            warnings.simplefilter("always")
+            _warnings.simplefilter("always")
             state.debug = True
             _setup_logging(level="DEBUG")
 

--- a/src/globus_cli/services/auth.py
+++ b/src/globus_cli/services/auth.py
@@ -59,6 +59,13 @@ class CustomAuthClient(globus_sdk.AuthClient):
 
         return value
 
+    # this method has been added in the latest SDK versions but is not
+    # present in the last release
+    # this is therefore temporary until an SDK release ships with the change
+    # so that CLI testing against SDK main can succeed
+    if not hasattr(globus_sdk.AuthClient, "userinfo"):
+        userinfo = globus_sdk.AuthClient.oauth2_userinfo
+
     @t.overload
     def maybe_lookup_identity_id(
         self, identity_name: str, provision: Literal[True]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,8 @@ def pytest_configure(config):
         global _PYTEST_VERBOSE
         _PYTEST_VERBOSE = True
 
+    globus_cli._warnings._TEST_WARNING_CONTROL = True
+
 
 @pytest.fixture(autouse=True)
 def mocksleep():

--- a/tests/functional/test_jmespath_output.py
+++ b/tests/functional/test_jmespath_output.py
@@ -29,7 +29,7 @@ def test_jmespath_extract_from_list(run_line, go_ep2_id):
         (
             "globus endpoint search 'Tutorial' "
             "--filter-owner-id go@globusid.org "
-            "--jmespath 'DATA[?id==`{}`] | [0]'"
+            "--jmespath \"DATA[?id=='{}'] | [0]\""
         ).format(go_ep2_id)
     )
     outputdict = json.loads(result.output)


### PR DESCRIPTION
This is a series of commits which each does a well-defined thing on its own, but in concert they "enable warnings and fix them".

1. Turn on warnings in the tests.

Although we had `filterwarnings = error` set, the CLI assumes control of warnings via `simplefilter` to suppress warnings in the user-facing context.
As a result, `filterwarnings` was ineffective.
The fix I've applied is a wrapper module `globus_cli._warnings` which lets `pytest_configure` reach in and turn off `simplefilter` altogether.
This makes the tests fail because warnings are now being emitted in the tests.

2. Fix timedelta formatting

We wrote the output formatters to be robust to failed data parsing and to fallback to `str(data)` with a warning.
The `globus timer` command tree had a formatter for `datetime.timedelta` which was checking for `isinstance(data, int)` rather than `isinstance(data, (int, float))`.
Good thing our mock data was pulled from real API responses and not synthesized by hand to match our expectations -- we now have a bugfix for timedelta rendering.

This is the only item which I deemed worthy of a changelog entry.

3. GlobusAPIError.raw_text -> GlobusAPIError.text

Seen in `globus api` commands; we deprecated `raw_text` in favor of `text`.
Fix!

4. Fix deprecated `jmespath` literal in tests

This one is a `PendingDeprecationWarning`, so I don't know what the timeline is yet.
`jmespath` used to use or at least accept backticks for strings in expressions.
It now wants single quotes.
I'm concerned that this will impact the validity of some of our CLI examples over time, but for now I'm setting that issue aside as we fix the tests.

5. Handle `oauth2_userinfo` deprecation in SDK `main`

Finally, the driver for this adventure.
`oauth2_userinfo()` is deprecated in SDK `main` in favor of `userinfo()`.
It therefore *should have* warned, and after (1) it did!

There are two easy paths to resolution:
- ignore the warning for now
- patch our customized AuthClient to support `userinfo` early

I chose the second one, since either way involves removing something from this patch later (either compat code or the warning ignore).
This front-loads the work, making the later cleanup simpler.
