### PR TITLE
Update pre-commit hooks and configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
   hooks:
     - id: check-github-workflows
     - id: check-dependabot
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.15.0
+  hooks:
+    - id: pyupgrade
+      args: ["--py36-plus"]
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 23.9.1
   hooks:
@@ -25,11 +30,6 @@ repos:
   rev: 5.12.0
   hooks:
     - id: isort
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
-  hooks:
-    - id: pyupgrade
-      args: ["--py36-plus"]
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   hooks:
     - id: flake8
       additional_dependencies:
-        - 'flake8-bugbear==22.10.27'
+        - 'flake8-bugbear==23.9.16'
         - 'flake8-typing-as-t==0.0.3'
 - repo: https://github.com/PyCQA/isort
   rev: 5.12.0

--- a/src/globus_cli/termio/formatters/base.py
+++ b/src/globus_cli/termio/formatters/base.py
@@ -18,6 +18,7 @@ class FieldFormatter(abc.ABC, t.Generic[T]):
         warnings.warn(
             f"Formatting failed for '{value!r}' with formatter={self!r}",
             FormattingFailedWarning,
+            stacklevel=1,
         )
 
     @abc.abstractmethod


### PR DESCRIPTION

This PR introduces the following changes:

* Run `pre-commit autoupdate`.
* Run `upadup`.
* (If applicable) resolve any new issues uncovered by updated hooks.
* (If applicable) remove pre-commit hooks that don't apply to any files in the repo.
* (If applicable) reorders and/or otherwise standardizes the pre-commit hooks.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>