### PR TITLE
Group all Dependabot updates for GitHub actions together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION

This PR introduces the following changes:

*   _(For some repos)_ Introduce a Dependabot config
*   Configure Dependabot to group all GitHub action version updates together.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>