### PR TITLE
Show the status of the timer after deleting it

### DIFF
--- a/changelog.d/20231023_074126_kurtmckee_show_deleted_timer_status.md
+++ b/changelog.d/20231023_074126_kurtmckee_show_deleted_timer_status.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* Show the status of the timer when running `globus timer delete`.
+
+  This clarifies whether the timer is immediately deleted or in a `delete_pending` state.

--- a/src/globus_cli/commands/timer/_common.py
+++ b/src/globus_cli/commands/timer/_common.py
@@ -68,6 +68,7 @@ JOB_FORMAT_FIELDS = _COMMON_FIELDS + [
 ]
 
 DELETED_JOB_FORMAT_FIELDS = _COMMON_FIELDS + [
+    Field("Status", "status"),
     Field("Stop After Date", "stop_after.date"),
     Field("Stop After Number of Runs", "stop_after.n_runs"),
 ]


### PR DESCRIPTION
### Enhancements

* Show the status of the timer when running `globus timer delete`.

  This clarifies whether the timer is immediately deleted or in a `delete_pending` state.
