### PR TITLE
Add a __main__.py to allow `python -m globus_cli`

### DIFF
--- a/src/globus_cli/__main__.py
+++ b/src/globus_cli/__main__.py
@@ -1,0 +1,3 @@
+from globus_cli import main
+
+main()


### PR DESCRIPTION
This is just a dev utility to be able to invoke globus-cli from a virtualenv without using the entry-point. It's very niche but handy in certain cases.
