### PR TITLE
Update pre-commit and fix slyp warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     - id: pyupgrade
       args: ["--py36-plus"]
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 23.9.1
+  rev: 23.10.1
   hooks:
     - id: black
 - repo: https://github.com/pycqa/flake8
@@ -34,7 +34,7 @@ repos:
   hooks:
     - id: isort
 - repo: https://github.com/sirosen/slyp
-  rev: 0.1.1
+  rev: 0.1.2
   hooks:
     - id: slyp
 - repo: https://github.com/codespell-project/codespell

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -76,10 +76,10 @@ ORDER_BY_FIELDS = (
 def list_command(
     login_manager: LoginManager,
     *,
-    filter_role: Literal[
-        "flow_viewer", "flow_starter", "flow_administrator", "flow_owner"
-    ]
-    | None,
+    filter_role: (
+        Literal["flow_viewer", "flow_starter", "flow_administrator", "flow_owner"]
+        | None
+    ),
     orderby: tuple[
         tuple[
             Literal[


### PR DESCRIPTION
slyp v0.1.2 catches a very interesting annotation wrap with W120. At first it might look okay, but note how the `None` gets "folded over", vs the parenthesized version. This looks like a win for the W120 check.