### PR TITLE
Add support for GARE-shaped data in timer and flow resume

### DIFF
--- a/changelog.d/20231031_164554_sirosen_handle_session_gares.md
+++ b/changelog.d/20231031_164554_sirosen_handle_session_gares.md
@@ -1,0 +1,6 @@
+### Enhancements
+
+* `globus timer resume` and `globus flows run resume` have new functionality
+  for handling session-related errors (e.g. high-assurance timeouts), enabling
+  them to prompt the user in the event that a **timer** or **run** is inactive
+  due to a session error.

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -93,7 +93,8 @@ def check_inactive_reason(
     # (consents may be present without session requirements met)
     if unhandled_requirements:
         raise CLIAuthRequirementsError(
-            "This run needs strong authentication in order to resume.",
+            "This run has additional authentication requirements that must be met "
+            "in order to resume.",
             gare=gare,
             epilog=textwrap.dedent(
                 f"""\

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -51,7 +51,7 @@ def resume_command(
             ):
                 raise CLIAuthRequirementsError(
                     "This run is missing a necessary consent in order to resume.",
-                    required_scopes=gare.authorization_parameters.required_scopes,
+                    gare=gare,
                 )
 
     fields = [

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -43,16 +43,10 @@ def resume_command(
 
     specific_flow_client = login_manager.get_specific_flow_client(flow_id)
 
+    gare: GlobusAuthRequirementsError | None = None
     if not skip_inactive_reason_check:
         gare = _get_inactive_reason(run_doc)
-        if gare is not None and gare.authorization_parameters.required_scopes:
-            if not _has_required_consent(
-                login_manager, gare.authorization_parameters.required_scopes
-            ):
-                raise CLIAuthRequirementsError(
-                    "This run is missing a necessary consent in order to resume.",
-                    gare=gare,
-                )
+        check_inactive_reason(login_manager, gare)
 
     fields = [
         Field("Run ID", "run_id"),
@@ -66,6 +60,41 @@ def resume_command(
 
     res = specific_flow_client.resume_run(run_id)
     display(res, fields=fields, text_mode=TextMode.text_record)
+
+
+def check_inactive_reason(
+    login_manager: LoginManager,
+    gare: GlobusAuthRequirementsError | None,
+) -> None:
+    if gare is None:
+        return
+    if gare.authorization_parameters.required_scopes:
+        consent_required = not _has_required_consent(
+            login_manager, gare.authorization_parameters.required_scopes
+        )
+        if consent_required:
+            raise CLIAuthRequirementsError(
+                "This timer is missing a necessary consent in order to resume.",
+                gare=gare,
+            )
+
+    # at this point, the required_scopes may have been checked and satisfied
+    # therefore, we should check if there are additional requirements other than
+    # the scopes/consents
+    unhandled_requirements = set(gare.authorization_parameters.to_dict().keys()) - {
+        "required_scopes",
+        # also remove 'message' -- not a 'requirement'
+        "session_message",
+    }
+    # reraise if anything remains after consent checking
+    # this ensures that we will reraise if we get an error which contains
+    # both required_scopes and additional requirements
+    # (consents may be present without session requirements met)
+    if unhandled_requirements:
+        raise CLIAuthRequirementsError(
+            "This timer needs strong authentication in order to resume.",
+            gare=gare,
+        )
 
 
 def _get_inactive_reason(

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -98,7 +98,7 @@ def check_inactive_reason(
             gare=gare,
             epilog=textwrap.dedent(
                 f"""\
-                After updating your session, resume the timer with
+                After updating your session, resume the run with
 
                     globus flows run resume --skip-inactive-reason-check {run_id}
                 """

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -82,7 +82,7 @@ def check_inactive_reason(
     # at this point, the required_scopes may have been checked and satisfied
     # therefore, we should check if there are additional requirements other than
     # the scopes/consents
-    unhandled_requirements = set(gare.authorization_parameters.to_dict().keys()) - {
+    unhandled_requirements = set(gare.authorization_parameters.to_dict()) - {
         "required_scopes",
         # also remove 'message' -- not a 'requirement'
         "session_message",

--- a/src/globus_cli/commands/timer/resume.py
+++ b/src/globus_cli/commands/timer/resume.py
@@ -20,41 +20,6 @@ if t.TYPE_CHECKING:
     )
 
 
-def _full_speed_ahead(ctx: click.Context, param: click.Parameter, value: bool) -> None:
-    # this easter egg has no effects other than printing a message
-    # this choice was made to ensure that there are no important behaviors which are
-    # impacted by it, or which *require* its use
-    if value:
-        click.secho(
-            r'''
-   ___                       __   __
-  / _ \ ___ _ __ _   ___    / /_ / /  ___
- / // // _ `//  ' \ / _ \  / __// _ \/ -_)
-/____/ \_,_//_/_/_//_//_/  \__//_//_/\__/
-
-  __                           __
- / /_ ___   ____ ___  ___  ___/ /___  ___  ___
-/ __// _ \ / __// _ \/ -_)/ _  // _ \/ -_)(_-< _
-\__/ \___//_/  / .__/\__/ \_,_/ \___/\__//___/( )
-              /_/                             |/
-   ___       __ __                         __        __                 __ __
-  / _/__ __ / // /  ___  ___  ___  ___  ___/ / ___ _ / /  ___  ___ _ ___/ // /
- / _// // // // /  (_-< / _ \/ -_)/ -_)/ _  / / _ `// _ \/ -_)/ _ `// _  //_/
-/_/  \_,_//_//_/  /___// .__/\__/ \__/ \_,_/  \_,_//_//_/\__/ \_,_/ \_,_/(_)
-                      /_/
-
- .  o ..
- o . o o.o
-      ...oo
-        __[]__
-     __|_o_o_o\__
-     \""""""""""/
-      \. ..  . /
- ^^^^^^^^^^^^^^^^^^^^
-'''
-        )
-
-
 @command("resume", short_help="Resume a timer")
 @click.argument("TIMER_ID", type=click.UUID)
 @click.option(
@@ -65,13 +30,6 @@ def _full_speed_ahead(ctx: click.Context, param: click.Parameter, value: bool) -
         'Skip the check of the timer\'s "inactive reason", which is used to determine '
         "if additional steps are required to successfully resume the timer."
     ),
-)
-@click.option(
-    "--damn-the-torpedoes",
-    expose_value=False,
-    is_flag=True,
-    hidden=True,
-    callback=_full_speed_ahead,
 )
 @LoginManager.requires_login("timer")
 def resume_command(

--- a/src/globus_cli/commands/timer/resume.py
+++ b/src/globus_cli/commands/timer/resume.py
@@ -19,6 +19,41 @@ if t.TYPE_CHECKING:
     )
 
 
+def _full_speed_ahead(ctx: click.Context, param: click.Parameter, value: bool) -> None:
+    # this easter egg has no effects other than printing a message
+    # this choice was made to ensure that there are no important behaviors which are
+    # impacted by it, or which *require* its use
+    if value:
+        click.secho(
+            r'''
+   ___                       __   __
+  / _ \ ___ _ __ _   ___    / /_ / /  ___
+ / // // _ `//  ' \ / _ \  / __// _ \/ -_)
+/____/ \_,_//_/_/_//_//_/  \__//_//_/\__/
+
+  __                           __
+ / /_ ___   ____ ___  ___  ___/ /___  ___  ___
+/ __// _ \ / __// _ \/ -_)/ _  // _ \/ -_)(_-< _
+\__/ \___//_/  / .__/\__/ \_,_/ \___/\__//___/( )
+              /_/                             |/
+   ___       __ __                         __        __                 __ __
+  / _/__ __ / // /  ___  ___  ___  ___  ___/ / ___ _ / /  ___  ___ _ ___/ // /
+ / _// // // // /  (_-< / _ \/ -_)/ -_)/ _  / / _ `// _ \/ -_)/ _ `// _  //_/
+/_/  \_,_//_//_/  /___// .__/\__/ \__/ \_,_/  \_,_//_//_/\__/ \_,_/ \_,_/(_)
+                      /_/
+
+ .  o ..
+ o . o o.o
+      ...oo
+        __[]__
+     __|_o_o_o\__
+     \""""""""""/
+      \. ..  . /
+ ^^^^^^^^^^^^^^^^^^^^
+'''
+        )
+
+
 @command("resume", short_help="Resume a timer")
 @click.argument("JOB_ID", type=click.UUID)
 @click.option(
@@ -29,6 +64,13 @@ if t.TYPE_CHECKING:
         'Skip the check of the timer\'s "inactive reason", which is used to determine '
         "if additional steps are required to successfully resume the timer."
     ),
+)
+@click.option(
+    "--damn-the-torpedoes",
+    expose_value=False,
+    is_flag=True,
+    hidden=True,
+    callback=_full_speed_ahead,
 )
 @LoginManager.requires_login("timer")
 def resume_command(

--- a/src/globus_cli/commands/timer/resume.py
+++ b/src/globus_cli/commands/timer/resume.py
@@ -48,7 +48,7 @@ def resume_command(
         if consent_required and not skip_inactive_reason_check:
             raise CLIAuthRequirementsError(
                 "This run is missing a necessary consent in order to resume.",
-                required_scopes=gare.authorization_parameters.required_scopes,
+                gare=gare,
             )
 
     resumed = timer_client.resume_job(

--- a/src/globus_cli/commands/timer/resume.py
+++ b/src/globus_cli/commands/timer/resume.py
@@ -90,11 +90,12 @@ def check_inactive_reason(
     # (consents may be present without session requirements met)
     if unhandled_requirements:
         raise CLIAuthRequirementsError(
-            "This timer needs strong authentication in order to resume.",
+            "This timer has additional authentication requirements that must be met "
+            "in order to resume.",
             gare=gare,
             epilog=textwrap.dedent(
                 f"""\
-                After updating your session, resume the timer with
+                After updating your session, resume the timer with:
 
                     globus timer resume --skip-inactive-reason-check {timer_id}
                 """

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -55,6 +55,8 @@ def handle_internal_auth_requirements(
         click.echo("\n* * *\n")
         click.echo(exception.epilog)
 
+    return None
+
 
 @error_handler(
     error_class="GlobusAPIError",
@@ -86,9 +88,10 @@ def consent_required_hook(exception: globus_sdk.GlobusAPIError) -> int | None:
             "Fatal Error: ConsentRequired but no required_scopes!", bold=True, fg="red"
         )
         return 255
-    return _concrete_consent_required_hook(
+    _concrete_consent_required_hook(
         exception.message, exception.info.consent_required.required_scopes
     )
+    return None
 
 
 def _concrete_session_hook(

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -25,11 +25,7 @@ def _pretty_json(data: dict, compact=False) -> str:
     exit_status=4,
 )
 def handle_internal_auth_requirements(exception: CLIAuthRequirementsError) -> None:
-    if not (
-        exception.gare
-        and exception.gare.authorization_parameters
-        and exception.gare.authorization_parameters.required_scopes
-    ):
+    if not (exception.gare and exception.gare.authorization_parameters.required_scopes):
         click.secho(
             "Fatal Error: Unsupported internal auth requirements error!",
             bold=True,

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -25,14 +25,21 @@ def _pretty_json(data: dict, compact=False) -> str:
     exit_status=4,
 )
 def handle_internal_auth_requirements(exception: CLIAuthRequirementsError) -> None:
-    if not exception.required_scopes:
+    if not (
+        exception.gare
+        and exception.gare.authorization_parameters
+        and exception.gare.authorization_parameters.required_scopes
+    ):
         click.secho(
             "Fatal Error: Unsupported internal auth requirements error!",
             bold=True,
             fg="red",
         )
         click.get_current_context().exit(255)
-    _concrete_consent_required_hook(exception.message, exception.required_scopes)
+
+    required_scopes = exception.gare.authorization_parameters.required_scopes
+
+    _concrete_consent_required_hook(exception.message, required_scopes)
 
 
 @error_handler(

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -20,6 +20,15 @@ def _pretty_json(data: dict, compact=False) -> str:
     return json.dumps(data, indent=2, separators=(",", ": "), sort_keys=True)
 
 
+_DEFAULT_SESSION_REAUTH_MESSAGE = (
+    "The resource you are trying to access requires you to re-authenticate."
+)
+_DEFAULT_CONSENT_REAUTH_MESSAGE = (
+    "The resource you are trying to access requires you to "
+    "consent to additional access for the Globus CLI."
+)
+
+
 @error_handler(
     error_class=CLIAuthRequirementsError,
     exit_status=4,
@@ -38,17 +47,19 @@ def handle_internal_auth_requirements(
 
     required_scopes = gare.authorization_parameters.required_scopes
     if required_scopes:
-        _concrete_consent_required_hook(exception.message, required_scopes)
+        _concrete_consent_required_hook(
+            required_scopes=required_scopes, message=exception.message
+        )
 
     session_policies = gare.authorization_parameters.session_required_policies
     session_identities = gare.authorization_parameters.session_required_identities
     session_domains = gare.authorization_parameters.session_required_single_domain
     if session_policies or session_identities or session_domains:
         _concrete_session_hook(
-            exception.message,
-            session_policies,
-            session_identities,
-            session_domains,
+            policies=session_policies,
+            identities=session_identities,
+            domains=session_domains,
+            message=exception.message or _DEFAULT_SESSION_REAUTH_MESSAGE,
         )
 
     if exception.epilog:
@@ -68,10 +79,17 @@ def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
     Expects an exception with a valid authorization_paramaters info field
     """
     message = exception.info.authorization_parameters.session_message
-    identities = exception.info.authorization_parameters.session_required_identities
-    domains = exception.info.authorization_parameters.session_required_single_domain
-    policies = exception.info.authorization_parameters.session_required_policies
-    return _concrete_session_hook(message, policies, identities, domains)
+    if message:
+        message = f"{_DEFAULT_SESSION_REAUTH_MESSAGE}\nmessage: {message}"
+    else:
+        message = _DEFAULT_SESSION_REAUTH_MESSAGE
+
+    return _concrete_session_hook(
+        identities=exception.info.authorization_parameters.session_required_identities,
+        domains=exception.info.authorization_parameters.session_required_single_domain,
+        policies=exception.info.authorization_parameters.session_required_policies,
+        message=message,
+    )
 
 
 @error_handler(
@@ -88,21 +106,32 @@ def consent_required_hook(exception: globus_sdk.GlobusAPIError) -> int | None:
             "Fatal Error: ConsentRequired but no required_scopes!", bold=True, fg="red"
         )
         return 255
+
+    # specialized message for data_access errors
+    # otherwise, use more generic phrasing
+    if exception.message == "Missing required data_access consent":
+        message = (
+            "The collection you are trying to access data on requires you to "
+            "grant consent for the Globus CLI to access it."
+        )
+    else:
+        message = f"{_DEFAULT_CONSENT_REAUTH_MESSAGE}\nmessage: {exception.message}"
+
     _concrete_consent_required_hook(
-        exception.message, exception.info.consent_required.required_scopes
+        required_scopes=exception.info.consent_required.required_scopes,
+        message=message,
     )
     return None
 
 
 def _concrete_session_hook(
-    message: str | None,
+    *,
     policies: list[str] | None,
     identities: list[str] | None,
     domains: list[str] | None,
+    message: str = _DEFAULT_SESSION_REAUTH_MESSAGE,
 ) -> None:
-    click.echo("The resource you are trying to access requires you to re-authenticate.")
-    if message:
-        click.echo(message)
+    click.echo(message)
 
     if identities or domains:
         # cast: mypy can't deduce that `domains` is not None if `identities` is None
@@ -112,47 +141,36 @@ def _concrete_session_hook(
             else " ".join(t.cast(t.List[str], domains))
         )
         click.echo(
-            "\nPlease run\n\n"
+            "\nPlease run:\n\n"
             f"    globus session update {update_target}\n\n"
-            "to re-authenticate with the required identities"
+            "to re-authenticate with the required identities."
         )
     elif policies:
         click.echo(
-            "\nPlease run\n\n"
+            "\nPlease run:\n\n"
             f"    globus session update --policy '{','.join(policies)}'\n\n"
-            "to re-authenticate with the required identities"
+            "to re-authenticate with the required identities."
         )
     else:
         click.echo(
             '\nPlease use "globus session update" to re-authenticate '
-            "with specific identities"
+            "with specific identities."
         )
 
 
 def _concrete_consent_required_hook(
-    message: str | None, required_scopes: list[str]
+    *,
+    required_scopes: list[str],
+    message: str = _DEFAULT_CONSENT_REAUTH_MESSAGE,
 ) -> None:
-    # specialized message for data_access errors
-    # otherwise, use more generic phrasing
-    if message == "Missing required data_access consent":
-        click.echo(
-            "The collection you are trying to access data on requires you to "
-            "grant consent for the Globus CLI to access it."
-        )
-    else:
-        click.echo(
-            "The resource you are trying to access requires you to "
-            "consent to additional access for the Globus CLI."
-        )
-    if message:
-        click.echo(f"message: {message}")
+    click.echo(message)
 
     click.echo(
-        "\nPlease run\n\n"
+        "\nPlease run:\n\n"
         "  globus session consent {}\n\n".format(
             " ".join(f"'{x}'" for x in required_scopes)
         )
-        + "to login with the required scopes"
+        + "to login with the required scopes."
     )
 
 

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -6,6 +6,13 @@ import click
 
 from globus_cli.types import DATA_CONTAINER_T
 
+# NB: GARE parsing requires other SDK components and therefore needs to be deferred to
+# avoid the performance impact of non-lazy imports
+if t.TYPE_CHECKING:
+    from globus_sdk.experimental.auth_requirements_error import (
+        GlobusAuthRequirementsError,
+    )
+
 F = t.TypeVar("F", bound=t.Callable)
 
 
@@ -200,7 +207,7 @@ class CLIAuthRequirementsError(Exception):
     """
 
     def __init__(
-        self, message: str, *, required_scopes: list[str] | None = None
+        self, message: str, *, gare: GlobusAuthRequirementsError | None = None
     ) -> None:
         self.message = message
-        self.required_scopes = required_scopes
+        self.gare = gare

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -207,7 +207,12 @@ class CLIAuthRequirementsError(Exception):
     """
 
     def __init__(
-        self, message: str, *, gare: GlobusAuthRequirementsError | None = None
+        self,
+        message: str,
+        *,
+        gare: GlobusAuthRequirementsError | None = None,
+        epilog: str | None = None,
     ) -> None:
         self.message = message
+        self.epilog = epilog
         self.gare = gare

--- a/tests/functional/timer/test_job_resume.py
+++ b/tests/functional/timer/test_job_resume.py
@@ -2,23 +2,100 @@ import uuid
 
 import globus_sdk
 import pytest
-from globus_sdk._testing import load_response_set, register_response_set
-from globus_sdk._testing.data.timer.get_job import JOB_JSON
-from globus_sdk._testing.data.timer.get_job import RESPONSES as TIMERS_GET_RESPONSES
-from globus_sdk._testing.data.timer.resume_job import (
-    RESPONSES as TIMERS_RESUME_RESPONSES,
-)
+from globus_sdk._testing import load_response, load_response_set, register_response_set
 
 
-def _urlscope(m: str, s: str) -> str:
-    return f"https://auth.globus.org/scopes/{m}/{s}"
+def test_resume_job_active(run_line):
+    meta = load_response("timer.get_job").metadata
+    load_response("timer.resume_job")
+    job_id = meta["job_id"]
+    run_line(
+        ["globus", "timer", "resume", job_id],
+        search_stdout=f"Successfully resumed job {job_id}.",
+    )
+
+
+def test_resume_job_inactive_user(run_line):
+    meta = load_response("timer.get_job", case="inactive_user").metadata
+    load_response("timer.resume_job")
+    job_id = meta["job_id"]
+    run_line(
+        ["globus", "timer", "resume", job_id],
+        search_stdout=f"Successfully resumed job {job_id}.",
+    )
+
+
+def test_resume_job_inactive_gare_consent_missing(run_line):
+    meta = load_response_set("cli.timer_resume.inactive_gare.consents_missing").metadata
+    job_id = meta["job_id"]
+    required_scope = meta["required_scope"]
+    result = run_line(
+        ["globus", "timer", "resume", job_id],
+        assert_exit_code=4,
+    )
+    assert f"globus session consent '{required_scope}'" in result.output
+
+
+def test_resume_job_inactive_gare_consent_present(run_line):
+    meta = load_response_set("cli.timer_resume.inactive_gare.consents_present").metadata
+    job_id = meta["job_id"]
+    run_line(
+        ["globus", "timer", "resume", job_id],
+        search_stdout=f"Successfully resumed job {job_id}.",
+    )
+
+
+def test_resume_job_inactive_gare_consent_missing_but_skip_check(run_line):
+    meta = load_response_set("cli.timer_resume.inactive_gare.consents_missing").metadata
+    job_id = meta["job_id"]
+    run_line(
+        ["globus", "timer", "resume", "--skip-inactive-reason-check", job_id],
+        search_stdout=f"Successfully resumed job {job_id}.",
+    )
+
+
+TIMER_ID = str(uuid.uuid1())
+TIMER_JSON = {
+    "name": "example timer",
+    "start": "2022-04-01T19:30:00+00:00",
+    "stop_after": None,
+    "interval": 864000.0,
+    "callback_url": "https://actions.automate.globus.org/transfer/transfer/run",
+    "callback_body": {
+        "body": {
+            "label": "example timer",
+            "skip_source_errors": True,
+            "sync_level": 3,
+            "verify_checksum": True,
+            "source_endpoint_id": "ddb59aef-6d04-11e5-ba46-22000b92c6ec",
+            "destination_endpoint_id": "ddb59af0-6d04-11e5-ba46-22000b92c6ec",
+            "transfer_items": [
+                {
+                    "source_path": "/share/godata/file1.txt",
+                    "destination_path": "/~/file1.txt",
+                    "recursive": False,
+                }
+            ],
+        }
+    },
+    "inactive_reason": None,
+    "scope": None,
+    "job_id": TIMER_ID,
+    "status": "loaded",
+    "submitted_at": "2022-04-01T19:29:55.942546+00:00",
+    "last_ran_at": "2022-04-01T19:30:07.103090+00:00",
+    "next_run": "2022-04-11T19:30:00+00:00",
+    "n_runs": 1,
+    "n_errors": 0,
+    "results": {"data": [], "page_next": None},
+}
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _register_responses(mock_user_data):
     # Note: this value must match so that the mock login data matches the responses
     user_id = mock_user_data["sub"]
-    job_id = str(uuid.uuid1())
+    timer_id = str(uuid.uuid1())
     collection_id = str(uuid.uuid1())
     transfer_scope = globus_sdk.TransferClient.scopes.all
     timers_scope = globus_sdk.TimerClient.scopes.timer
@@ -31,13 +108,28 @@ def _register_responses(mock_user_data):
 
     metadata = {
         "user_id": user_id,
-        "job_id": job_id,
+        "job_id": timer_id,
         "collection_id": collection_id,
         "required_scope": required_scope,
     }
 
-    get_job_json_inactive_gare_body = {
-        **JOB_JSON,
+    get_job_json_consent_gare_body = {
+        **TIMER_JSON,
+        "status": "inactive",
+        "inactive_reason": {
+            "cause": "globus_auth_requirements",
+            "detail": {
+                "code": "ConsentRequired",
+                "authorization_parameters": {
+                    "session_message": "Missing required data_access consent",
+                    "required_scopes": [required_scope],
+                },
+            },
+        },
+    }
+
+    get_job_json_consent_gare_body = {
+        **TIMER_JSON,
         "status": "inactive",
         "inactive_reason": {
             "cause": "globus_auth_requirements",
@@ -56,15 +148,15 @@ def _register_responses(mock_user_data):
         dict(
             get_job=dict(
                 service="timer",
-                path=f"/jobs/{job_id}",
+                path=f"/jobs/{timer_id}",
                 method="GET",
-                json=get_job_json_inactive_gare_body,
+                json=get_job_json_consent_gare_body,
             ),
             resume=dict(
                 service="timer",
-                path=f"/jobs/{job_id}/resume",
+                path=f"/jobs/{timer_id}/resume",
                 method="POST",
-                json={"message": f"Successfully resumed job {job_id}."},
+                json={"message": f"Successfully resumed job {timer_id}."},
             ),
             consents=dict(
                 service="auth",
@@ -89,15 +181,15 @@ def _register_responses(mock_user_data):
         dict(
             get_job=dict(
                 service="timer",
-                path=f"/jobs/{job_id}",
+                path=f"/jobs/{timer_id}",
                 method="GET",
-                json=get_job_json_inactive_gare_body,
+                json=get_job_json_consent_gare_body,
             ),
             resume=dict(
                 service="timer",
-                path=f"/jobs/{job_id}/resume",
+                path=f"/jobs/{timer_id}/resume",
                 method="POST",
-                json={"message": f"Successfully resumed job {job_id}."},
+                json={"message": f"Successfully resumed job {timer_id}."},
             ),
             consents=dict(
                 service="auth",
@@ -133,50 +225,5 @@ def _register_responses(mock_user_data):
     )
 
 
-def test_resume_job_active(run_line):
-    TIMERS_GET_RESPONSES.activate("default")
-    TIMERS_RESUME_RESPONSES.activate("default")
-    job_id = TIMERS_GET_RESPONSES.metadata["job_id"]
-    run_line(
-        ["globus", "timer", "resume", job_id],
-        search_stdout=f"Successfully resumed job {job_id}.",
-    )
-
-
-def test_resume_job_inactive_user(run_line):
-    TIMERS_GET_RESPONSES.activate("inactive_user")
-    TIMERS_RESUME_RESPONSES.activate("default")
-    job_id = TIMERS_GET_RESPONSES.metadata["job_id"]
-    run_line(
-        ["globus", "timer", "resume", job_id],
-        search_stdout=f"Successfully resumed job {job_id}.",
-    )
-
-
-def test_resume_job_inactive_gare_consent_missing(run_line):
-    meta = load_response_set("cli.timer_resume.inactive_gare.consents_missing").metadata
-    job_id = meta["job_id"]
-    required_scope = meta["required_scope"]
-    result = run_line(
-        ["globus", "timer", "resume", job_id],
-        assert_exit_code=4,
-    )
-    assert f"globus session consent '{required_scope}'" in result.output
-
-
-def test_resume_job_inactive_gare_consent_present(run_line):
-    meta = load_response_set("cli.timer_resume.inactive_gare.consents_present").metadata
-    job_id = meta["job_id"]
-    run_line(
-        ["globus", "timer", "resume", job_id],
-        search_stdout=f"Successfully resumed job {job_id}.",
-    )
-
-
-def test_resume_job_inactive_gare_consent_missing_but_skip_check(run_line):
-    meta = load_response_set("cli.timer_resume.inactive_gare.consents_missing").metadata
-    job_id = meta["job_id"]
-    run_line(
-        ["globus", "timer", "resume", "--skip-inactive-reason-check", job_id],
-        search_stdout=f"Successfully resumed job {job_id}.",
-    )
+def _urlscope(m: str, s: str) -> str:
+    return f"https://auth.globus.org/scopes/{m}/{s}"


### PR DESCRIPTION
This updates `globus timer resume` and `globus flows run resume` to handle Globus Auth Requirements Error formatted data in the inactive reason fields for a **timer** or a **run**.

The changes here both improve internal infrastructure and support for GARE data and use that improved infrastructure to handle GAREs which ar encountered in Timers and Flows.

In terms of significant improvements to infrastructure:
- `CLIAuthRequirementsError` now contains a GARE
- The session-error hook is now restructured to mirror the consent-error hook
- `CLIAuthRequirementsError` handling now supports session errors

And the feature changes are the same in each of the resume commands:
- Always check GARE for session errors, not just consent errors
- Only enable the "smooth resume" behavior for consent handling cases; always trigger an error when handling session errors
- When handling session errors, instruct the user (via `CLIAuthRequirementsError.epilog`) to return and run the command with `--skip-inactive-reason-check` in order to bypass the session-reading behavior

---

- Update internal auth errors to carry a GARE
- Allow 'resume's to to raise session errors
- Handle session GAREs in hooks
- Add 'timer resume' easter egg
- Simplify exit code paths in exceptions hooks
- Add an epilog to GARE handling
- Cleanup timer resume tests
- Add tests for 'timer resume' on session errors
- Add tests for `flows run resume` GARE handling
- Add changelog for new GARE handling
