### PR TITLE
WIP: use v2 API for Timer creation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "globus-sdk==3.30.0",
+        "globus-sdk==3.31.0",
         "click>=8.1.4,<9",
         "jmespath==1.0.1",
         "packaging>=17.0",

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -21,6 +21,7 @@ from globus_cli.parsing import (
     command,
     encrypt_data_option,
     fail_on_quota_errors_option,
+    mutex_option_group,
     preserve_timestamp_option,
     skip_source_errors_option,
     sync_level_option,
@@ -99,6 +100,7 @@ def resolve_start_time(start: datetime.datetime | None) -> datetime.datetime:
     type=click.IntRange(min=1),
     help="Stop running the transfer after this number of runs have happened.",
 )
+@mutex_option_group("--stop-after-date", "--stop-after-runs")
 @LoginManager.requires_login("auth", "timer", "transfer")
 def transfer_command(
     login_manager: LoginManager,

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -30,9 +30,9 @@ from globus_cli.parsing import (
     transfer_recursive_option,
     verify_checksum_option,
 )
-from globus_cli.termio import TextMode, display
+from globus_cli.termio import Field, TextMode, display, formatters
 
-from .._common import DATETIME_FORMATS, JOB_FORMAT_FIELDS
+from .._common import DATETIME_FORMATS, ScheduleFormatter
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -43,19 +43,25 @@ if t.TYPE_CHECKING:
     from globus_cli.services.auth import CustomAuthClient
 
 
+FORMAT_FIELDS = [
+    Field("Timer ID", "job_id"),
+    Field("Name", "name"),
+    Field("Type", "timer_type"),
+    Field("Submitted At", "submitted_at", formatter=formatters.Date),
+    Field("Status", "status"),
+    Field("Last Run", "last_ran_at", formatter=formatters.Date),
+    Field("Next Run", "next_run", formatter=formatters.Date),
+    Field("Schedule", "schedule", formatter=ScheduleFormatter()),
+    Field("Number of Runs", "number_of_runs"),
+    Field("Number of Timer Errors", "number_of_errors"),
+]
+
+
 INTERVAL_HELP = """\
 Interval at which the job should run. Expressed in weeks, days, hours, minutes, and
 seconds. Use 'w', 'd', 'h', 'm', and 's' as suffixes to specify.
 e.g. '1h30m', '500s', '10d'
 """
-
-
-def resolve_start_time(start: datetime.datetime | None) -> datetime.datetime:
-    # handle the default start time (now)
-    start_ = start or datetime.datetime.now()
-    # set the timezone to local system time if the timezone input is not aware
-    start_with_tz = start_.astimezone() if start_.tzinfo is None else start_
-    return start_with_tz
 
 
 @command("transfer", short_help="Create a recurring transfer job in Timer")
@@ -175,12 +181,38 @@ def transfer_command(
             "transfer requires either SOURCE_PATH and DEST_PATH or --batch"
         )
 
-    # Interval must be null iff the job is non-repeating, i.e. stop-after-runs == 1.
-    if stop_after_runs != 1:
+    # Interval must be null iff the job is 'once', i.e. stop-after-runs == 1.
+    # and it must be non-null if the job is 'recurring'
+    schedule: globus_sdk.RecurringTimerSchedule | globus_sdk.OnceTimerSchedule
+    start_ = start if start is not None else globus_sdk.MISSING
+    if stop_after_runs == 1:
+        if interval is not None:
+            raise click.UsageError("'--interval' is invalid with `--stop-after-runs=1`")
+        schedule = globus_sdk.OnceTimerSchedule(datetime=start_)
+    else:
         if interval is None:
             raise click.UsageError(
-                "'--interval' is required unless `--stop-after-runs=1` is used."
+                "'--interval' is required unless `--stop-after-runs=1`"
             )
+
+        end: dict[str, t.Any] | globus_sdk.MissingType = globus_sdk.MISSING
+        # reminder: these two cases are mutex
+        if stop_after_runs is not None:
+            end = {
+                "condition": "iterations",
+                "count": stop_after_runs,
+            }
+        elif stop_after_date is not None:
+            end = {
+                "condition": "time",
+                "datetime": stop_after_date,
+            }
+
+        schedule = globus_sdk.RecurringTimerSchedule(
+            interval_seconds=interval,
+            end=end,
+            start=start if start is not None else globus_sdk.MISSING,
+        )
 
     # default name, dynamically computed from the current time
     if name is None:
@@ -265,19 +297,9 @@ to login with the required scopes."""
     else:  # unreachable
         raise NotImplementedError()
 
-    response = timer_client.create_job(
-        globus_sdk.TimerJob.from_transfer_data(
-            transfer_data,
-            resolve_start_time(start),
-            interval,
-            name=name,
-            stop_after=stop_after_date,
-            stop_after_n=stop_after_runs,
-            # the transfer AP scope string (without any dependencies)
-            scope="https://auth.globus.org/scopes/actions.globus.org/transfer/transfer",
-        )
-    )
-    display(response, text_mode=TextMode.text_record, fields=JOB_FORMAT_FIELDS)
+    body = globus_sdk.TransferTimer(name=name, schedule=schedule, body=transfer_data)
+    response = timer_client.create_timer(body)
+    display(response["timer"], text_mode=TextMode.text_record, fields=FORMAT_FIELDS)
 
 
 def _derive_needed_scopes(

--- a/tests/functional/timer/test_transfer_create.py
+++ b/tests/functional/timer/test_transfer_create.py
@@ -13,6 +13,23 @@ from globus_sdk._testing import (
 from globus_sdk.scopes import GCSCollectionScopeBuilder
 
 
+@pytest.fixture
+def resolve_times_to_utc(monkeypatch):
+    # implicit timezone is localtime, but to handle mocking and testing
+    # make timezone resolution return the time converted to UTC
+    def fake_resolve(dt):
+        if dt is None:
+            return globus_sdk.MISSING
+        if dt.tzinfo is not None:
+            return dt
+        # this is *significantly* different from the real code at runtime
+        return dt.replace(tzinfo=datetime.timezone.utc)
+
+    monkeypatch.setattr(
+        "globus_cli.commands.timer.create.transfer.resolve_start_time", fake_resolve
+    )
+
+
 def setup_timer_consent_tree_response(identity_id, *data_access_collection_ids):
     load_response(
         RegisteredResponse(
@@ -112,7 +129,7 @@ def non_ha_mapped_collection():
 
 @pytest.fixture
 def ep_for_timer():
-    load_response(globus_sdk.TimerClient.create_job)
+    load_response(globus_sdk.TimerClient.create_timer)
     load_response(globus_sdk.TransferClient.get_submission_id)
     ep_meta = load_response(globus_sdk.TransferClient.get_endpoint).metadata
     ep_id = ep_meta["endpoint_id"]
@@ -134,7 +151,7 @@ def ep_for_timer():
         ["--stop-after-runs", "1"],
     ],
 )
-def test_create_job_simple(run_line, ep_for_timer, extra_args):
+def test_create_timer_simple(run_line, ep_for_timer, extra_args):
     run_line(
         [
             "globus",
@@ -150,7 +167,7 @@ def test_create_job_simple(run_line, ep_for_timer, extra_args):
     )
 
     sent_data = json.loads(get_last_request().body)
-    transfer_body = sent_data["callback_body"]["body"]
+    transfer_body = sent_data["timer"]["body"]
     assert transfer_body["DATA_TYPE"] == "transfer"
     assert isinstance(transfer_body["DATA"], list)
     assert len(transfer_body["DATA"]) == 1
@@ -159,7 +176,7 @@ def test_create_job_simple(run_line, ep_for_timer, extra_args):
     assert transfer_body["DATA"][0]["destination_path"] == "/file2"
 
 
-def test_create_job_batch_data(run_line, ep_for_timer):
+def test_create_timer_batch_data(run_line, ep_for_timer):
     batch_input = "abc /def\n/xyz p/q/r\n"
 
     run_line(
@@ -179,7 +196,7 @@ def test_create_job_batch_data(run_line, ep_for_timer):
     )
 
     sent_data = json.loads(get_last_request().body)
-    transfer_body = sent_data["callback_body"]["body"]
+    transfer_body = sent_data["timer"]["body"]
     assert transfer_body["DATA_TYPE"] == "transfer"
     assert isinstance(transfer_body["DATA"], list)
     assert len(transfer_body["DATA"]) == 2
@@ -214,7 +231,7 @@ def test_recursive_and_batch_exclusive(run_line, option):
     assert f"You cannot use {option} in addition to --batch" in result.stderr
 
 
-def test_create_job_requires_some_pathargs(run_line):
+def test_create_timer_requires_some_pathargs(run_line):
     ep_id = str(uuid.UUID(int=1))
 
     result = run_line(
@@ -241,9 +258,7 @@ def test_interval_usually_required(run_line):
         ],
         assert_exit_code=2,
     )
-    assert (
-        "'--interval' is required unless `--stop-after-runs=1` is used" in result.stderr
-    )
+    assert "'--interval' is required unless `--stop-after-runs=1`" in result.stderr
 
 
 def test_stop_conditions_are_mutex(run_line):
@@ -266,7 +281,7 @@ def test_stop_conditions_are_mutex(run_line):
     assert "mutually exclusive" in result.stderr
 
 
-def test_interval_not_required_if_stop_after_is_one(run_line, ep_for_timer):
+def test_timer_uses_once_schedule_if_stop_after_is_one(run_line, ep_for_timer):
     run_line(
         [
             "globus",
@@ -281,10 +296,12 @@ def test_interval_not_required_if_stop_after_is_one(run_line, ep_for_timer):
         ],
     )
     sent_data = json.loads(get_last_request().body)
-    assert sent_data["stop_after_n"] == 1
+    sent_timer = sent_data["timer"]
+    schedule = sent_timer["schedule"]
+    assert schedule["type"] == "once"
 
 
-def test_start_time_allows_timezone(run_line, ep_for_timer):
+def test_start_time_allows_timezone(run_line, ep_for_timer, resolve_times_to_utc):
     # explicit timezone is preserved in the formatted data sent to the service
     run_line(
         [
@@ -302,33 +319,19 @@ def test_start_time_allows_timezone(run_line, ep_for_timer):
         ],
     )
     sent_data = json.loads(get_last_request().body)
-    assert sent_data["start"] == "2022-01-01T00:00:00-05:00"
+    sent_timer = sent_data["timer"]
+    schedule = sent_timer["schedule"]
+    assert schedule["type"] == "once"
+    assert schedule["datetime"] == "2022-01-01T00:00:00-05:00"
 
 
 def test_start_time_without_timezone_converts_to_have_tzinfo(
-    run_line, ep_for_timer, monkeypatch
+    run_line, ep_for_timer, monkeypatch, resolve_times_to_utc
 ):
-    # implicit timezone is localtime, but to handle mocking and testing
-    # make timezone resolution return the time converted to EST
-
-    # setup a patch that makes `astimezone` use EST always
-    # and assert that no explicit timezone is passed
-    est_tz = datetime.timezone(datetime.timedelta(hours=-5), name="EST")
-
-    def fake_resolve(dt):
-        assert dt is not None
-        # this is *significantly* different from the real code at runtime
-        # it assigns the EST timezone without a conversion (which is what the code
-        # would do if the caller were in EST)
-        return dt.replace(tzinfo=est_tz)
-
-    monkeypatch.setattr(
-        "globus_cli.commands.timer.create.transfer.resolve_start_time", fake_resolve
-    )
-
     # argument and the expected transform
+    # note that this is really just running the fake tz resolver
     start_arg = "2022-01-01T06:00:00"
-    expect_value = "2022-01-01T06:00:00-05:00"
+    expect_value = "2022-01-01T06:00:00+00:00"
 
     run_line(
         [
@@ -345,8 +348,12 @@ def test_start_time_without_timezone_converts_to_have_tzinfo(
             start_arg,
         ],
     )
+
     sent_data = json.loads(get_last_request().body)
-    assert sent_data["start"] == expect_value
+    sent_timer = sent_data["timer"]
+    schedule = sent_timer["schedule"]
+    assert schedule["type"] == "once"
+    assert schedule["datetime"] == expect_value
 
 
 @pytest.mark.parametrize("data_access_position", ["source", "destination", "both"])
@@ -424,7 +431,7 @@ def test_timer_creation_supports_data_access_on_source_or_dest(
         )
         assert f"globus session consent {scope_opts}" in result.output
     else:
-        assert "Interval" in result.output
+        assert "every 604800 seconds" in result.output
         req = get_last_request()
         assert req.url.startswith("https://timer")
 

--- a/tests/functional/timer/test_transfer_create.py
+++ b/tests/functional/timer/test_transfer_create.py
@@ -246,6 +246,26 @@ def test_interval_usually_required(run_line):
     )
 
 
+def test_stop_conditions_are_mutex(run_line):
+    ep_id = str(uuid.UUID(int=1))
+    result = run_line(
+        [
+            "globus",
+            "timer",
+            "create",
+            "transfer",
+            "--stop-after-runs",
+            "1",
+            "--stop-after-date",
+            "2021-01-01T00:00:00",
+            f"{ep_id}:/foo/",
+            f"{ep_id}:/bar/",
+        ],
+        assert_exit_code=2,
+    )
+    assert "mutually exclusive" in result.stderr
+
+
 def test_interval_not_required_if_stop_after_is_one(run_line, ep_for_timer):
     run_line(
         [

--- a/tests/unit/test_timezone_handling.py
+++ b/tests/unit/test_timezone_handling.py
@@ -1,18 +1,15 @@
 import datetime
 
+import globus_sdk
+
 from globus_cli.commands.timer.create.transfer import resolve_start_time
 
 EST = datetime.timezone(datetime.timedelta(hours=-5), name="EST")
 
 
-def test_resolve_start_time_defaults_to_now():
+def test_resolve_start_time_converts_none_to_missing():
     value = resolve_start_time(None)
-    assert isinstance(value, datetime.datetime)
-    assert value.tzinfo is not None
-    # check for closeness, rather than being exact
-    assert (datetime.datetime.now().astimezone() - value) < datetime.timedelta(
-        seconds=1
-    )
+    assert value is globus_sdk.MISSING
 
 
 def test_resolve_start_time_preserves_existing_tzinfo():


### PR DESCRIPTION
This is a work-in-progress PR.  Updating Timer creation to use the new v2 API will require that globus/globus-sdk-python#900 is released, but it will also require that all Globus products are ready to display these timers.

---

Changes basically consist of translating the current CLI options into the newer API structure. Additionally, because there is a new suite of helpers to use from the SDK, there is some relevant refinement to handling of timezone data included here.

The work was done by:
1. getting it working interactively using `timer_client.post(...)`
2. getting it ported to work interactively using `timer_client.create_timer(...)`
3. applying any necessary fixes to the tests

This process is not a perfect/ideal one, but reflects the fact that the first phase of development was carried out *before* the new API was released.  So it's possible that there are improvements which are possible now but which haven't been realized.
