### PR TITLE
Allow copied-and-pasted API routes to the `globus api groups` command

### DIFF
--- a/changelog.d/20231128_151455_kurtmckee_fix_groups_api.md
+++ b/changelog.d/20231128_151455_kurtmckee_fix_groups_api.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Accommodate copied-and-pasted API routes to the `globus api groups` command
+  that include the `/v2` route.

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -258,6 +258,7 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
         # the overall flow of this command will be as follows:
         # - prepare a client
         # - prepare parameters for the request
+        # - Groups-only - strip copied-and-pasted paths with `/v2/` that will fail
         # - send the request capturing any error raised
         # - process the response
         #   - on success or error with --allow-errors, print
@@ -299,6 +300,10 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
                 headers_d["Content-Type"] = detected_content_type
         for header_name, header_value in header:
             headers_d[header_name] = header_value
+
+        # Strip `/v2` from Groups paths, which are auto-added by `GroupsClient`.
+        if service_name == "groups" and path.startswith("/v2"):
+            path = path[3:]
 
         # try sending and handle any error
         try:

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -45,6 +45,20 @@ def test_api_command_get(run_line, service_name, is_error_response):
     assert result.output == '{"foo": "bar"}\n'
 
 
+def test_api_groups_v2_path_stripping(run_line):
+    load_response(
+        RegisteredResponse(
+            service="groups",
+            status=200,
+            path="/foo",
+            json={"foo": "bar"},
+        )
+    )
+
+    result = run_line(["globus", "api", "groups", "get", "/v2/foo"])
+    assert result.output == '{"foo": "bar"}\n'
+
+
 def test_api_command_can_use_jmespath(run_line):
     load_response("cli.api.transfer_stub")
 


### PR DESCRIPTION
### Bugfixes

* Accommodate copied-and-pasted API routes to the `globus api groups` command  that include the `/v2` route.
