### PR TITLE
Implement mapped collection create

### DIFF
--- a/src/globus_cli/commands/collection/create/__init__.py
+++ b/src/globus_cli/commands/collection/create/__init__.py
@@ -5,6 +5,7 @@ from globus_cli.parsing import group
     "create",
     lazy_subcommands={
         "guest": (".guest", "collection_create_guest"),
+        "mapped": (".mapped", "collection_create_mapped"),
     },
 )
 def collection_create() -> None:

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import typing as t
+import uuid
+
+import click
+import globus_sdk
+
+from globus_cli.constants import EXPLICIT_NULL, ExplicitNullType
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import (
+    CommaDelimitedList,
+    JSONStringOrFile,
+    StringOrNull,
+    UrlOrNull,
+    command,
+    endpoint_id_arg,
+    mutex_option_group,
+    nullable_multi_callback,
+)
+from globus_cli.termio import Field, TextMode, display
+
+
+def _mkhelp(txt):
+    return f"{txt} the collection"
+
+
+def collection_create_params(f):
+    """
+    Collection of options consumed by GCS Collection update
+
+    Usage:
+
+    >>> @collection_create_and_update_params(create=False)
+    >>> def command_func(**kwargs):
+    >>>     ...
+    """
+    multi_use_option_str = "Give this option multiple times in a single command"
+
+    f = click.argument("DISPLAY_NAME")(f)
+    f = click.option(
+        "--public/--private",
+        "public",
+        default=True,
+        help="Set the collection to be public or private",
+    )(f)
+    f = click.option(
+        "--description", type=StringOrNull(), help=_mkhelp("Description for")
+    )(f)
+    f = click.option(
+        "--info-link", type=StringOrNull(), help=_mkhelp("Link for info about")
+    )(f)
+    f = click.option(
+        "--contact-info", type=StringOrNull(), help=_mkhelp("Contact Info for")
+    )(f)
+    f = click.option(
+        "--contact-email",
+        type=StringOrNull(),
+        help=_mkhelp("Contact email for"),
+    )(f)
+    f = click.option(
+        "--organization", type=StringOrNull(), help=_mkhelp("Organization for")
+    )(f)
+    f = click.option(
+        "--department", type=StringOrNull(), help=_mkhelp("Department which operates")
+    )(f)
+    f = click.option(
+        "--keywords",
+        type=CommaDelimitedList(),
+        help=_mkhelp("Comma separated list of keywords to help searches for"),
+    )(f)
+    f = click.option(
+        "--force-encryption/--no-force-encryption",
+        "force_encryption",
+        default=None,
+        help=(
+            "When set, all transfers to and from this collection are "
+            "always encrypted"
+        ),
+    )(f)
+    f = click.option(
+        "--sharing-restrict-paths",
+        type=JSONStringOrFile(null="null"),
+        help="Path restrictions for sharing data on guest collections "
+        "based on this collection. This option is only usable on Mapped "
+        "Collections",
+    )(f)
+    f = click.option(
+        "--allow-guest-collections/--no-allow-guest-collections",
+        default=None,
+        help=(
+            "Allow Guest Collections to be created on this Collection. This option "
+            "is only usable on Mapped Collections. If this option is disabled on a "
+            "Mapped Collection which already has associated Guest Collections, "
+            "those collections will no longer be accessible"
+        ),
+    )(f)
+    f = click.option(
+        "--disable-anonymous-writes/--enable-anonymous-writes",
+        default=None,
+        help=(
+            "Allow anonymous write ACLs on Guest Collections attached to this "
+            "Mapped Collection. This option is only usable on non high assurance "
+            "Mapped Collections and the setting is inherited by the hosted Guest "
+            "Collections. Anonymous write ACLs are enabled by default "
+            "(requires an endpoint with API v1.8.0)"
+        ),
+    )(f)
+    f = click.option(
+        "--domain-name",
+        help=(
+            "DNS host name for the collection (mapped "
+            "collections only). This may be either a host name "
+            "or a fully-qualified domain name, but if it is the latter "
+            "it must be a subdomain of the endpoint's domain"
+        ),
+    )(f)
+    f = click.option(
+        "--default-directory",
+        default=None,
+        help="Default directory when browsing the collection",
+    )(f)
+
+    f = click.option(
+        "--enable-https",
+        is_flag=True,
+        help=(
+            "Explicitly enable HTTPS supprt (requires a managed endpoint "
+            "with API v1.1.0)"
+        ),
+    )(f)
+    f = click.option(
+        "--disable-https",
+        is_flag=True,
+        help=(
+            "Explicitly disable HTTPS supprt (requires a managed endpoint "
+            "with API v1.1.0)"
+        ),
+    )(f)
+    f = mutex_option_group("--enable-https", "--disable-https")(f)
+
+    f = click.option(
+        "--user-message",
+        help=(
+            "A message for clients to display to users when interacting "
+            "with this collection"
+        ),
+        type=StringOrNull(),
+    )(f)
+    f = click.option(
+        "--user-message-link",
+        help=(
+            "Link to additional messaging for clients to display to users "
+            "when interacting with this endpoint, linked to an http or https URL "
+            "with this collection"
+        ),
+        type=UrlOrNull(),
+    )(f)
+    f = click.option(
+        "--sharing-user-allow",
+        "sharing_users_allow",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "Connector-specific username allowed to create guest collections."
+            f"{multi_use_option_str} to allow multiple users. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--sharing-user-deny",
+        "sharing_users_deny",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "Connector-specific username denied permission to create guest "
+            f"collections. {multi_use_option_str} to deny multiple users. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--posix-sharing-group-allow",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "POSIX group allowed access to create guest collections "
+            "(POSIX Connector Only). "
+            f"{multi_use_option_str} to allow multiple groups. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--posix-sharing-group-deny",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "POSIX group denied permission to create guest collections "
+            "(POSIX Connector Only). "
+            f"{multi_use_option_str} to deny multiple groups. "
+            + 'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--google-project-id",
+        help=(
+            "For Google Cloud Storage backed Collections only. The Google "
+            "Cloud Platform project ID which is used by this Collection"
+        ),
+        type=StringOrNull(),
+    )(f)
+
+    # POSIX Staging connector (GCS v5.4.10)
+    f = click.option(
+        "--posix-staging-sharing-group-allow",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "POSIX group allowed access to create guest collections "
+            "(POSIX Staging Connector Only). "
+            f"{multi_use_option_str} to allow multiple groups. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--posix-staging-sharing-group-deny",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "POSIX group denied permission to create guest collections "
+            "(POSIX Staging Connector Only). "
+            f"{multi_use_option_str} to deny multiple groups. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+
+    f = click.option(
+        "--verify",
+        type=click.Choice(["force", "disable", "default"], case_sensitive=False),
+        help=(
+            "Set the policy for this collection for file integrity verification "
+            "after transfer. 'force' requires all transfers to perform "
+            "verfication. 'disable' disables all verification checks. 'default' "
+            "allows the user to decide on verification at Transfer task submit  "
+            "time. When set on mapped collections, this policy is inherited by any "
+            "guest collections"
+        ),
+    )(f)
+    return f
+
+
+@command("create", short_help="Create a new Mapped Collection")
+@endpoint_id_arg
+@click.argument("STORAGE_GATEWAY_ID")
+@click.argument("BASE_PATH")
+@collection_create_params
+@click.option(
+    "--identity-id",
+    help=(
+        "Globus Auth identity to who acts as the owner of this Collection. This "
+        "identity must be an administrator on the Endpoint"
+    ),
+)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+def collection_create_mapped(
+    *,
+    login_manager: LoginManager,
+    # positional args
+    endpoint_id: uuid.UUID,
+    storage_gateway_id: uuid.UUID,
+    base_path: str,
+    display_name: str,
+    # options
+    public: bool,
+    description: str | None,
+    info_link: str | None,
+    contact_info: str | None,
+    contact_email: str | None,
+    organization: str | None,
+    department: str | None,
+    keywords: str | None,
+    default_directory: str | None,
+    force_encryption: bool | None,
+    domain_name: str | None,
+    disable_anonymous_writes: bool | None,
+    identity_id: str | None,
+    google_project_id: str | None,
+    posix_sharing_group_allow: t.Iterable[str] | None,
+    posix_sharing_group_deny: t.Iterable[str] | None,
+    posix_staging_sharing_group_allow: t.Iterable[str] | None,
+    posix_staging_sharing_group_deny: t.Iterable[str] | None,
+    sharing_restrict_paths: t.Dict[str, t.Iterable[str]] | None | ExplicitNullType,
+    allow_guest_collections: bool | None,
+    sharing_users_allow: t.Iterable[str] | None,
+    sharing_users_deny: t.Iterable[str] | None,
+    user_message: str | None | ExplicitNullType,
+    user_message_link: str | None | ExplicitNullType,
+    enable_https: bool | None,
+    disable_https: bool | None,
+    verify: str | None,
+) -> None:
+    """
+    Create a new Mapped Collection, rooted on some given path within an
+    existing Storage Gateway.
+
+    The ENDPOINT_ID and STORAGE_GATEWAY_ID are both required in order to specify where
+    and how the collection is hosted.
+    """
+    gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
+
+    policies: t.Optional[globus_sdk.CollectionPolicies] = None
+    if google_project_id is not None:
+        policies = globus_sdk.GoogleCloudStorageCollectionPolicies(
+            project=google_project_id
+        )
+
+    if posix_sharing_group_allow is not None or posix_sharing_group_deny is not None:
+        if policies is not None:
+            raise click.UsageError("Incompatible policy options detected")
+        # Added in 5.4.8 for POSIX connector
+        policies = globus_sdk.POSIXCollectionPolicies(
+            posix_sharing_group_allow=posix_sharing_group_allow,
+            posix_sharing_group_deny=posix_sharing_group_deny,
+        )
+
+    if (
+        posix_staging_sharing_group_allow is not None
+        or posix_staging_sharing_group_deny is not None
+    ):
+        if policies is not None:
+            raise click.UsageError("Incompatible policy options detected")
+        # Added in 5.4.10 for POSIX staging connector
+        policies = globus_sdk.POSIXStagingStoragePolicies(
+            sharing_groups_allow=posix_staging_sharing_group_allow,
+            sharing_groups_deny=posix_staging_sharing_group_deny,
+        )
+
+    if sharing_restrict_paths == EXPLICIT_NULL:
+        sharing_restrict_paths = None
+    if user_message == EXPLICIT_NULL:
+        user_message = None
+    if user_message_link == EXPLICIT_NULL:
+        user_message_link = None
+
+    # These are added in GCS 5.4.4, so if neither --enable-https or
+    # --disable-https are set, then we'll not try to set the value for
+    # backward compatibility
+    if enable_https is False:
+        enable_https = None
+    if disable_https:
+        enable_https = False
+
+    force_verify: bool | None = None
+    disable_verify: bool | None = None
+    if verify is not None:
+        if verify.lower() == "force":
+            force_verify, disable_verify = True, False
+        elif verify.lower() == "disable":
+            force_verify, disable_verify = False, True
+        else:
+            force_verify, disable_verify = False, False
+
+    collection_doc = globus_sdk.MappedCollectionDocument(
+        storage_gateway_id=storage_gateway_id,
+        collection_base_path=base_path,
+        display_name=display_name,
+        public=public,
+        description=description,
+        info_link=info_link,
+        contact_info=contact_info,
+        contact_email=contact_email,
+        organization=organization,
+        department=department,
+        keywords=keywords,
+        default_directory=default_directory,
+        force_encryption=force_encryption,
+        domain_name=domain_name,
+        disable_anonymous_writes=disable_anonymous_writes,
+        identity_id=identity_id,
+        policies=policies,
+        allow_guest_collections=allow_guest_collections,
+        sharing_users_allow=sharing_users_allow,
+        sharing_users_deny=sharing_users_deny,
+        sharing_restrict_paths=sharing_restrict_paths,
+        user_message=user_message,
+        user_message_link=user_message_link,
+        enable_https=enable_https,
+        disable_verify=disable_verify,
+        force_verify=force_verify,
+    )
+    res = gcs_client.create_collection(collection_doc)
+
+    display(res, text_mode=TextMode.text_record, fields=[Field("Collection ID", "id")])

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -6,6 +6,10 @@ import uuid
 import click
 import globus_sdk
 
+from globus_cli.commands.collection._common import (
+    filter_fields,
+    standard_collection_fields,
+)
 from globus_cli.constants import ExplicitNullType
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
@@ -15,7 +19,7 @@ from globus_cli.parsing import (
     endpoint_id_arg,
     endpointish_params,
 )
-from globus_cli.termio import Field, TextMode, display
+from globus_cli.termio import TextMode, display
 
 
 def _make_multi_use_option_str(s: str) -> str:
@@ -292,4 +296,9 @@ def collection_create_mapped(
     )
     res = gcs_client.create_collection(collection_doc)
 
-    display(res, text_mode=TextMode.text_record, fields=[Field("Collection ID", "id")])
+    fields = standard_collection_fields(login_manager.get_auth_client())
+    display(
+        res,
+        text_mode=TextMode.text_record,
+        fields=filter_fields(fields, res),
+    )

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -10,238 +10,191 @@ from globus_cli.constants import ExplicitNullType
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
     JSONStringOrFile,
-    StringOrNull,
-    UrlOrNull,
+    ParsedJSONData,
     command,
     endpoint_id_arg,
     endpointish_params,
-    mutex_option_group,
-    nullable_multi_callback,
 )
 from globus_cli.termio import Field, TextMode, display
 
 
-def collection_create_params(f):
-    """
-    Collection of options consumed by GCS Collection create.
-    """
-    multi_use_option_str = "Give this option multiple times in a single command"
-    f = click.argument("BASE_PATH")(f)
-
-    f = click.option(
-        "--storage-gateway",
-        help=(
-            "The storage gateway ID to host this collection. "
-            "If no value is provided but the endpoint has exactly one gateway, "
-            "that gateway will be used by default."
-        ),
-    )(f)
-    f = click.option(
-        "--public/--private",
-        "public",
-        default=True,
-        help="Set the collection to be public or private",
-    )(f)
-    f = click.option(
-        "--sharing-restrict-paths",
-        type=JSONStringOrFile(null="null"),
-        help="Path restrictions for sharing data on guest collections "
-        "based on this collection. This option is only usable on Mapped "
-        "Collections",
-    )(f)
-    f = click.option(
-        "--allow-guest-collections/--no-allow-guest-collections",
-        default=None,
-        help=(
-            "Allow Guest Collections to be created on this Collection. This option "
-            "is only usable on Mapped Collections. If this option is disabled on a "
-            "Mapped Collection which already has associated Guest Collections, "
-            "those collections will no longer be accessible"
-        ),
-    )(f)
-    f = click.option(
-        "--disable-anonymous-writes/--enable-anonymous-writes",
-        default=None,
-        help=(
-            "Allow anonymous write ACLs on Guest Collections attached to this "
-            "Mapped Collection. This option is only usable on non high assurance "
-            "Mapped Collections and the setting is inherited by the hosted Guest "
-            "Collections. Anonymous write ACLs are enabled by default "
-            "(requires an endpoint with API v1.8.0)"
-        ),
-    )(f)
-    f = click.option(
-        "--domain-name",
-        help=(
-            "DNS host name for the collection (mapped "
-            "collections only). This may be either a host name "
-            "or a fully-qualified domain name, but if it is the latter "
-            "it must be a subdomain of the endpoint's domain"
-        ),
-    )(f)
-
-    f = click.option(
-        "--enable-https",
-        is_flag=True,
-        help=(
-            "Explicitly enable HTTPS supprt (requires a managed endpoint "
-            "with API v1.1.0)"
-        ),
-    )(f)
-    f = click.option(
-        "--disable-https",
-        is_flag=True,
-        help=(
-            "Explicitly disable HTTPS supprt (requires a managed endpoint "
-            "with API v1.1.0)"
-        ),
-    )(f)
-    f = mutex_option_group("--enable-https", "--disable-https")(f)
-
-    f = click.option(
-        "--user-message",
-        help=(
-            "A message for clients to display to users when interacting "
-            "with this collection"
-        ),
-        type=StringOrNull(),
-    )(f)
-    f = click.option(
-        "--user-message-link",
-        help=(
-            "Link to additional messaging for clients to display to users "
-            "when interacting with this endpoint, linked to an http or https URL "
-            "with this collection"
-        ),
-        type=UrlOrNull(),
-    )(f)
-    f = click.option(
-        "--sharing-user-allow",
-        "sharing_users_allow",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "Connector-specific username allowed to create guest collections."
-            f"{multi_use_option_str} to allow multiple users. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--sharing-user-deny",
-        "sharing_users_deny",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "Connector-specific username denied permission to create guest "
-            f"collections. {multi_use_option_str} to deny multiple users. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--posix-sharing-group-allow",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "POSIX group allowed access to create guest collections "
-            "(POSIX Connector Only). "
-            f"{multi_use_option_str} to allow multiple groups. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--posix-sharing-group-deny",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "POSIX group denied permission to create guest collections "
-            "(POSIX Connector Only). "
-            f"{multi_use_option_str} to deny multiple groups. "
-            + 'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--google-project-id",
-        help=(
-            "For Google Cloud Storage backed Collections only. The Google "
-            "Cloud Platform project ID which is used by this Collection"
-        ),
-        type=StringOrNull(),
-    )(f)
-
-    # POSIX Staging connector (GCS v5.4.10)
-    f = click.option(
-        "--posix-staging-sharing-group-allow",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "POSIX group allowed access to create guest collections "
-            "(POSIX Staging Connector Only). "
-            f"{multi_use_option_str} to allow multiple groups. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--posix-staging-sharing-group-deny",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "POSIX group denied permission to create guest collections "
-            "(POSIX Staging Connector Only). "
-            f"{multi_use_option_str} to deny multiple groups. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    return f
+def _make_multi_use_option_str(s: str) -> str:
+    return f"Give this option multiple times to {s}."
 
 
 @command("create", short_help="Create a new Mapped Collection")
 @endpoint_id_arg
-@endpointish_params.create(name="collection")
-@collection_create_params
+@click.option(
+    "--base-path",
+    default="/",
+    show_default=True,
+    help="The location within the storage gateway where the collection is rooted.",
+)
+@click.option(
+    "--storage-gateway",
+    help=(
+        "The storage gateway ID to host this collection. "
+        "If no value is provided but the endpoint has exactly one gateway, "
+        "that gateway will be used by default."
+    ),
+)
+@click.option(
+    "--public/--private",
+    "public",
+    default=True,
+    help="Set the collection to be public or private.",
+)
+@click.option(
+    "--sharing-restrict-paths",
+    type=JSONStringOrFile(null="null"),
+    help=(
+        "Path restrictions for sharing data on guest collections "
+        "based on this collection."
+    ),
+)
+@click.option(
+    "--allow-guest-collections/--no-allow-guest-collections",
+    default=None,
+    help=(
+        "Allow Guest Collections to be created on this Collection. "
+        "If this option is later disabled on a Mapped Collection which has associated "
+        "Guest Collections, those collections will no longer be accessible."
+    ),
+)
+@click.option(
+    "--disable-anonymous-writes/--enable-anonymous-writes",
+    default=None,
+    help=(
+        "Allow anonymous write ACLs on Guest Collections attached to this "
+        "Mapped Collection. This option is only usable on non high assurance "
+        "Mapped Collections and the setting is inherited by the hosted Guest "
+        "Collections. Anonymous write ACLs are enabled by default "
+        "(requires an endpoint with API v1.8.0)."
+    ),
+)
+@click.option(
+    "--domain-name",
+    help=(
+        "DNS host name for the collection. This may be either a host name "
+        "or a fully-qualified domain name, but if it is the latter "
+        "it must be a subdomain of the endpoint's domain."
+    ),
+)
 @click.option(
     "--identity-id",
     help=(
         "Globus Auth identity to who acts as the owner of this Collection. This "
-        "identity must be an administrator on the Endpoint"
+        "identity must be an administrator on the Endpoint."
     ),
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@click.option(
+    "--enable-https/--disable-https",
+    "enable_https",
+    default=None,
+    help=(
+        "Explicitly enable or disable  HTTPS support (requires a managed endpoint "
+        "with API v1.1.0)"
+    ),
+)
+@click.option(
+    "--sharing-user-allow",
+    "sharing_users_allow",
+    multiple=True,
+    help=(
+        "Connector-specific username allowed to create guest collections."
+        + _make_multi_use_option_str("allow multiple users")
+    ),
+)
+@click.option(
+    "--sharing-user-deny",
+    "sharing_users_deny",
+    multiple=True,
+    help=(
+        "Connector-specific username denied permission to create guest collections. "
+        + _make_multi_use_option_str("deny multiple users")
+    ),
+)
+@click.option(
+    "--posix-sharing-group-allow",
+    multiple=True,
+    help=(
+        "POSIX group allowed access to create guest collections "
+        + "(POSIX Connector only). "
+        + _make_multi_use_option_str("allow multiple groups")
+    ),
+)
+@click.option(
+    "--posix-sharing-group-deny",
+    multiple=True,
+    help=(
+        "POSIX group denied permission to create guest collections "
+        + "(POSIX Connector only). "
+        + _make_multi_use_option_str("deny multiple groups")
+    ),
+)
+@click.option(
+    "--google-project-id",
+    help=(
+        "The Google Cloud Platform project ID which is used by this Collection "
+        "(Google Cloud Storage backed Collections only)."
+    ),
+)
+@click.option(
+    # POSIX Staging connector (GCS v5.4.10)
+    "--posix-staging-sharing-group-allow",
+    multiple=True,
+    help=(
+        "POSIX group allowed access to create guest collections "
+        + "(POSIX Staging Connector Only). "
+        + _make_multi_use_option_str("allow multiple groups")
+    ),
+)
+@click.option(
+    "--posix-staging-sharing-group-deny",
+    multiple=True,
+    help=(
+        "POSIX group denied permission to create guest collections "
+        + "(POSIX Staging Connector Only). "
+        + _make_multi_use_option_str("deny multiple groups")
+    ),
+)
+@endpointish_params.create(name="collection")
+@LoginManager.requires_login("auth", "transfer")
 def collection_create_mapped(
-    *,
     login_manager: LoginManager,
+    *,
     # positional args
-    endpoint_id: uuid.UUID,
     base_path: str,
     display_name: str,
+    endpoint_id: uuid.UUID,
     # options
-    storage_gateway: str | None,
-    public: bool,
-    description: str | None,
-    info_link: str | None,
-    contact_info: str | None,
-    contact_email: str | None,
-    organization: str | None,
-    department: str | None,
-    keywords: list[str] | None,
-    default_directory: str | None,
-    force_encryption: bool | None,
-    domain_name: str | None,
-    disable_anonymous_writes: bool | None,
-    identity_id: str | None,
-    google_project_id: str | None,
-    posix_sharing_group_allow: t.Iterable[str] | None,
-    posix_sharing_group_deny: t.Iterable[str] | None,
-    posix_staging_sharing_group_allow: t.Iterable[str] | None,
-    posix_staging_sharing_group_deny: t.Iterable[str] | None,
-    sharing_restrict_paths: t.Dict[str, t.Iterable[str]] | None | ExplicitNullType,
     allow_guest_collections: bool | None,
-    sharing_users_allow: t.Iterable[str] | None,
-    sharing_users_deny: t.Iterable[str] | None,
+    contact_email: str | None | ExplicitNullType,
+    contact_info: str | None | ExplicitNullType,
+    default_directory: str | None | ExplicitNullType,
+    department: str | None | ExplicitNullType,
+    description: str | None | ExplicitNullType,
+    disable_anonymous_writes: bool | None,
+    domain_name: str | None,
+    enable_https: bool | None,
+    force_encryption: bool | None,
+    google_project_id: str | None,
+    identity_id: str | None,
+    info_link: str | None | ExplicitNullType,
+    keywords: list[str] | None,
+    organization: str | None | ExplicitNullType,
+    posix_sharing_group_allow: tuple[str, ...],
+    posix_sharing_group_deny: tuple[str, ...],
+    posix_staging_sharing_group_allow: tuple[str, ...],
+    posix_staging_sharing_group_deny: tuple[str, ...],
+    public: bool,
+    sharing_restrict_paths: ParsedJSONData | None | ExplicitNullType,
+    sharing_users_allow: tuple[str, ...],
+    sharing_users_deny: tuple[str, ...],
+    storage_gateway: str | None,
     user_message: str | None | ExplicitNullType,
     user_message_link: str | None | ExplicitNullType,
-    enable_https: bool | None,
-    disable_https: bool | None,
-    verify: str | None,
+    verify: dict[str, bool],
 ) -> None:
     """
     Create a new Mapped Collection, rooted on some given path within an
@@ -251,6 +204,11 @@ def collection_create_mapped(
     and there is only one storage gateway on the endpoint, that gateway will be used.
     Otherwise, '--storage-gateway' is required.
     """
+    if isinstance(sharing_restrict_paths, ParsedJSONData) and not isinstance(
+        sharing_restrict_paths.data, dict
+    ):
+        raise click.UsageError("--sharing-restrict-paths must be a JSON object")
+
     gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
     if storage_gateway is not None:
         storage_gateway_id = storage_gateway
@@ -269,78 +227,68 @@ def collection_create_mapped(
                 "You must specify which one to use with the --storage-gateway option."
             )
 
-    policies: t.Optional[globus_sdk.CollectionPolicies] = None
+    policies: globus_sdk.CollectionPolicies | None = None
     if google_project_id is not None:
         policies = globus_sdk.GoogleCloudStorageCollectionPolicies(
             project=google_project_id
         )
 
-    if posix_sharing_group_allow is not None or posix_sharing_group_deny is not None:
+    if posix_sharing_group_allow or posix_sharing_group_deny:
         if policies is not None:
-            raise click.UsageError("Incompatible policy options detected")
+            raise click.UsageError("Incompatible policy options detected.")
         # Added in 5.4.8 for POSIX connector
         policies = globus_sdk.POSIXCollectionPolicies(
             sharing_groups_allow=posix_sharing_group_allow,
             sharing_groups_deny=posix_sharing_group_deny,
         )
 
-    if (
-        posix_staging_sharing_group_allow is not None
-        or posix_staging_sharing_group_deny is not None
-    ):
+    if posix_staging_sharing_group_allow or posix_staging_sharing_group_deny:
         if policies is not None:
-            raise click.UsageError("Incompatible policy options detected")
+            raise click.UsageError("Incompatible policy options detected.")
         # Added in 5.4.10 for POSIX staging connector
         policies = globus_sdk.POSIXStagingCollectionPolicies(
             sharing_groups_allow=posix_staging_sharing_group_allow,
             sharing_groups_deny=posix_staging_sharing_group_deny,
         )
 
-    # These are added in GCS 5.4.4, so if neither --enable-https or
-    # --disable-https are set, then we'll not try to set the value for
-    # backward compatibility
-    if enable_https is False:
-        enable_https = None
-    if disable_https:
-        enable_https = False
-
-    force_verify: bool | None = None
-    disable_verify: bool | None = None
-    if verify is not None:
-        if verify.lower() == "force":
-            force_verify, disable_verify = True, False
-        elif verify.lower() == "disable":
-            force_verify, disable_verify = False, True
-        else:
-            force_verify, disable_verify = False, False
+    converted_kwargs: dict[str, t.Any] = ExplicitNullType.nullify_dict(
+        {
+            # required arguments
+            "collection_base_path": base_path,
+            "display_name": display_name,
+            # options
+            "allow_guest_collections": allow_guest_collections,
+            "contact_email": contact_email,
+            "contact_info": contact_info,
+            "default_directory": default_directory,
+            "department": department,
+            "description": description,
+            "disable_anonymous_writes": disable_anonymous_writes,
+            "domain_name": domain_name,
+            "enable_https": enable_https,
+            "force_encryption": force_encryption,
+            "identity_id": identity_id,
+            "info_link": info_link,
+            "keywords": keywords,
+            "organization": organization,
+            "policies": policies,
+            "public": public,
+            "sharing_restrict_paths": (
+                sharing_restrict_paths.data
+                if isinstance(sharing_restrict_paths, ParsedJSONData)
+                else sharing_restrict_paths
+            ),
+            "sharing_users_allow": sharing_users_allow,
+            "sharing_users_deny": sharing_users_deny,
+            "storage_gateway_id": storage_gateway_id,
+            "user_message": user_message,
+            "user_message_link": user_message_link,
+        }
+    )
+    converted_kwargs.update(verify)
 
     collection_doc = globus_sdk.MappedCollectionDocument(
-        storage_gateway_id=storage_gateway_id,
-        collection_base_path=base_path,
-        display_name=display_name,
-        public=public,
-        description=description,
-        info_link=info_link,
-        contact_info=contact_info,
-        contact_email=contact_email,
-        organization=organization,
-        department=department,
-        keywords=keywords,
-        default_directory=default_directory,
-        force_encryption=force_encryption,
-        domain_name=domain_name,
-        disable_anonymous_writes=disable_anonymous_writes,
-        identity_id=identity_id,
-        policies=policies,
-        allow_guest_collections=allow_guest_collections,
-        sharing_users_allow=sharing_users_allow,
-        sharing_users_deny=sharing_users_deny,
-        sharing_restrict_paths=ExplicitNullType.nullify(sharing_restrict_paths),
-        user_message=ExplicitNullType.nullify(user_message),
-        user_message_link=ExplicitNullType.nullify(user_message_link),
-        enable_https=enable_https,
-        disable_verify=disable_verify,
-        force_verify=force_verify,
+        **converted_kwargs,
     )
     res = gcs_client.create_collection(collection_doc)
 

--- a/tests/functional/collection/test_collection_create_mapped.py
+++ b/tests/functional/collection/test_collection_create_mapped.py
@@ -1,0 +1,385 @@
+import uuid
+
+import pytest
+from globus_sdk._testing import load_response, register_response_set
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _register_responses():
+    storage_gateway_id = str(uuid.uuid4())
+    collection_id = str(uuid.uuid4())
+    domain = "globus.org"
+    username = f"gargamel@{domain}"
+    identity_id = str(uuid.uuid4())
+    endpoint_id = str(uuid.uuid4())
+
+    register_response_set(
+        "cli.collection_create_mapped.storage_gateway_list",
+        {
+            "default": {
+                "service": "gcs",
+                "path": "/storage_gateways",
+                "method": "GET",
+                "json": {
+                    "DATA_TYPE": "result#1.0.0",
+                    "code": "success",
+                    "data": [
+                        {
+                            "DATA_TYPE": "storage_gateway#1.2.0",
+                            "admin_managed_credentials": False,
+                            "allowed_domains": [domain],
+                            "authentication_timeout_mins": 15840,
+                            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                            "display_name": "localposix",
+                            "high_assurance": False,
+                            "id": storage_gateway_id,
+                            "policies": {"DATA_TYPE": "posix_storage_policies#1.0.0"},
+                            "require_high_assurance": False,
+                            "require_mfa": False,
+                        }
+                    ],
+                    "detail": "success",
+                    "has_next_page": False,
+                    "http_response_code": 200,
+                },
+                "metadata": {
+                    "storage_gateway_id": storage_gateway_id,
+                    "domain": domain,
+                },
+            },
+            "multiple": {
+                "service": "gcs",
+                "path": "/storage_gateways",
+                "method": "GET",
+                "json": {
+                    "DATA_TYPE": "result#1.0.0",
+                    "code": "success",
+                    "data": [
+                        {
+                            "DATA_TYPE": "storage_gateway#1.2.0",
+                            "admin_managed_credentials": False,
+                            "allowed_domains": [domain],
+                            "authentication_timeout_mins": 15840,
+                            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                            "display_name": "localposix",
+                            "high_assurance": False,
+                            "id": storage_gateway_id,
+                            "policies": {"DATA_TYPE": "posix_storage_policies#1.0.0"},
+                            "require_high_assurance": False,
+                            "require_mfa": False,
+                        },
+                        {
+                            "DATA_TYPE": "storage_gateway#1.2.0",
+                            "admin_managed_credentials": False,
+                            "allowed_domains": [domain],
+                            "authentication_timeout_mins": 15840,
+                            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                            "display_name": "localposix2",
+                            "high_assurance": False,
+                            "id": str(uuid.uuid4()),
+                            "policies": {"DATA_TYPE": "posix_storage_policies#1.0.0"},
+                            "require_high_assurance": False,
+                            "require_mfa": False,
+                        },
+                    ],
+                    "detail": "success",
+                    "has_next_page": False,
+                    "http_response_code": 200,
+                },
+                "metadata": {
+                    "storage_gateway_id": storage_gateway_id,
+                    "domain": domain,
+                },
+            },
+            "empty": {
+                "service": "gcs",
+                "path": "/storage_gateways",
+                "method": "GET",
+                "json": {
+                    "DATA_TYPE": "result#1.0.0",
+                    "code": "success",
+                    "data": [],
+                    "detail": "success",
+                    "has_next_page": False,
+                    "http_response_code": 200,
+                },
+            },
+        },
+    )
+
+    register_response_set(
+        "cli.collection_create_mapped.mapped_collection_create",
+        {
+            "default": {
+                "service": "gcs",
+                "path": "/collections",
+                "method": "POST",
+                "json": {
+                    "DATA_TYPE": "result#1.0.0",
+                    "code": "success",
+                    "data": [
+                        {
+                            "DATA_TYPE": "collection#1.9.0",
+                            "allow_guest_collections": False,
+                            "authentication_timeout_mins": 15840,
+                            "collection_type": "mapped",
+                            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                            "contact_email": username,
+                            "created_at": "2023-12-12",
+                            "delete_protected": True,
+                            "disable_anonymous_writes": False,
+                            "disable_verify": False,
+                            "display_name": "myposix",
+                            "domain_name": "foo.abc.xyz.data.globus.org",
+                            "enable_https": True,
+                            "force_encryption": False,
+                            "force_verify": False,
+                            "high_assurance": False,
+                            "https_url": None,
+                            "id": collection_id,
+                            "identity_id": identity_id,
+                            "last_access": None,
+                            "manager_url": "https://abc.xyz.data.globus.org",
+                            "policies": {
+                                "DATA_TYPE": "posix_collection_policies#1.1.0"
+                            },
+                            "public": True,
+                            "require_mfa": False,
+                            "storage_gateway_id": storage_gateway_id,
+                            "tlsftp_url": "tlsftp://foo.abc.xyz.data.globus.org:443",
+                        }
+                    ],
+                    "detail": "success",
+                    "has_next_page": False,
+                    "http_response_code": 200,
+                },
+                "metadata": {
+                    "collection_id": collection_id,
+                    "username": username,
+                    "domain": domain,
+                    "identity_id": identity_id,
+                    "storage_gateway_id": storage_gateway_id,
+                },
+            }
+        },
+    )
+
+    register_response_set(
+        "cli.collection_create_mapped.get_endpoint",
+        {
+            "default": {
+                "service": "transfer",
+                "path": f"/endpoint/{endpoint_id}",
+                "method": "GET",
+                "json": {
+                    "DATA": [
+                        {"DATA_TYPE": "server", "hostname": "abc.xyz.data.globus.org"}
+                    ],
+                    "DATA_TYPE": "endpoint",
+                    "canonical_name": f"{endpoint_id}#{endpoint_id}",
+                    "description": "example gcsv5 endpoint",
+                    "display_name": "Happy Fun Endpoint",
+                    "entity_type": "GCSv5_endpoint",
+                    "gcs_manager_url": "https://abc.xyz.data.globus.org",
+                    "gcs_version": "5.4.71",
+                    "id": endpoint_id,
+                    "is_globus_connect": False,
+                    "non_functional": True,
+                    "owner_id": endpoint_id,
+                    "owner_string": f"{endpoint_id}@clients.auth.globus.org",
+                    "subscription_id": None,
+                },
+                "metadata": {"endpoint_id": endpoint_id},
+            }
+        },
+    )
+
+    register_response_set(
+        "cli.collection_create_mapped.get_identities",
+        {
+            "default": {
+                "service": "auth",
+                "path": "/v2/api/identities",
+                "method": "GET",
+                "json": {
+                    "identities": [
+                        {
+                            "email": username,
+                            "id": identity_id,
+                            "identity_provider": str(uuid.uuid4()),
+                            "name": "Gargamel Smurfnapper",
+                            # Azrael is his cat
+                            "organization": "Friends of Azrael",
+                            "status": "used",
+                            "username": username,
+                        }
+                    ]
+                },
+            }
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "only_one_storage_gateway, implicit_storage_gateway",
+    (
+        (False, False),
+        (True, False),
+        (True, True),
+    ),
+)
+def test_mapped_collection_create(
+    run_line,
+    add_gcs_login,
+    only_one_storage_gateway,
+    implicit_storage_gateway,
+):
+    load_response("cli.collection_create_mapped.get_identities")
+    load_response(
+        "cli.collection_create_mapped.storage_gateway_list",
+        case="default" if only_one_storage_gateway else "multiple",
+    )
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+    create_meta = load_response(
+        "cli.collection_create_mapped.mapped_collection_create"
+    ).metadata
+
+    owner_username = create_meta["username"]
+    epid = gcs_meta["endpoint_id"]
+
+    cmd = ["globus", "gcs", "collection", "create", "mapped", epid, "/"]
+    if not implicit_storage_gateway:
+        cmd.extend(["--storage-gateway", create_meta["storage_gateway_id"]])
+
+    add_gcs_login(epid)
+    run_line(
+        cmd,
+        search_stdout=[
+            ("Storage Gateway ID", create_meta["storage_gateway_id"]),
+            ("Owner", owner_username),
+        ],
+    )
+
+
+def test_mapped_collection_create_fails_on_multiple_storage_gateways_unspecified(
+    run_line, add_gcs_login
+):
+    load_response("cli.collection_create_mapped.storage_gateway_list", case="multiple")
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+    epid = gcs_meta["endpoint_id"]
+
+    add_gcs_login(epid)
+    run_line(
+        f"globus gcs collection create mapped {epid} /",
+        assert_exit_code=2,
+        search_stderr="This endpoint has multiple storage gateways.",
+    )
+
+
+def test_mapped_collection_create_fails_no_storage_gateways(run_line, add_gcs_login):
+    load_response("cli.collection_create_mapped.storage_gateway_list", case="empty")
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+    epid = gcs_meta["endpoint_id"]
+
+    add_gcs_login(epid)
+    run_line(
+        f"globus gcs collection create mapped {epid} /",
+        assert_exit_code=2,
+        search_stderr="This endpoint does not have any storage gateways.",
+    )
+
+
+def test_mapped_collection_create_invalid_sharing_restrict_paths(run_line):
+    run_line(
+        (
+            f"globus gcs collection create mapped {uuid.uuid4()} / "
+            "--sharing-restrict-paths 0"
+        ),
+        assert_exit_code=2,
+        search_stderr="--sharing-restrict-paths must be a JSON object",
+    )
+
+
+@pytest.mark.parametrize(
+    "add_opts",
+    (
+        ["--google-project-id", "fooid"],
+        ["--posix-sharing-group-allow", "foo", "--posix-sharing-group-deny", "bar"],
+        [
+            "--posix-staging-sharing-group-allow",
+            "foo",
+            "--posix-staging-sharing-group-deny",
+            "bar",
+        ],
+    ),
+)
+def test_mapped_collection_create_accepts_various_policy_options(
+    run_line,
+    add_gcs_login,
+    add_opts,
+):
+    load_response("cli.collection_create_mapped.get_identities")
+    load_response("cli.collection_create_mapped.storage_gateway_list")
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+    create_meta = load_response(
+        "cli.collection_create_mapped.mapped_collection_create"
+    ).metadata
+
+    owner_username = create_meta["username"]
+    epid = gcs_meta["endpoint_id"]
+
+    cmd = ["globus", "gcs", "collection", "create", "mapped", epid, "/"] + add_opts
+
+    add_gcs_login(epid)
+    run_line(
+        cmd,
+        search_stdout=[
+            ("Storage Gateway ID", create_meta["storage_gateway_id"]),
+            ("Owner", owner_username),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "add_opts",
+    (
+        pytest.param(
+            ["--google-project-id", "fooid", "--posix-sharing-group-allow", "foo"],
+            id="google+posix",
+        ),
+        pytest.param(
+            [
+                "--google-project-id",
+                "fooid",
+                "--posix-staging-sharing-group-allow",
+                "foo",
+            ],
+            id="google+posix-staging",
+        ),
+        pytest.param(
+            [
+                "--posix-sharing-group-allow",
+                "foo",
+                "--posix-staging-sharing-group-allow",
+                "foo",
+            ],
+            id="posix+posix-staging",
+        ),
+    ),
+)
+def test_mapped_collection_create_rejects_incompatible_policy_options(
+    run_line,
+    add_gcs_login,
+    add_opts,
+):
+    load_response("cli.collection_create_mapped.storage_gateway_list")
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+
+    epid = gcs_meta["endpoint_id"]
+
+    cmd = ["globus", "gcs", "collection", "create", "mapped", epid, "/"] + add_opts
+
+    add_gcs_login(epid)
+    run_line(
+        cmd, assert_exit_code=2, search_stderr="Incompatible policy options detected."
+    )


### PR DESCRIPTION
This is a rebase of the prior work which I had on this, with some minimal cleanup to get things into a reasonable state. I'm opening it as a draft to improve visibility. It conflicts with the guest collection creation command and will need a rebase after that merges (so please ignore the conflicts).

I see a few things which need additional attention in here, and I especially note that there were no tests when I dusted this off. I think I had done some measure of manual testing which at this point is not very relevant.

Some areas of interest:
- This shares parameters with `collection update`, and it will share some with guest creation as well -- we should move those to common helpers where possible.
- Handling of the `policies` sub-object is tricky. The current implementation has a small collection of mutually exclusive options which can be used. (These could be declared as mutex, but I believe mutex checking of `multiple=True` options requires some care.) I would like it better if we could declare these usages separately somehow, but I think the current solution is likely to be a good pragmatic solution for the near-to-medium term.
- The commit history notes an interesting rationale for naming the option `--storage-gateway` rather than `--storage-gateway-id`. The expectation baked into this is that a typical endpoint will have only one or two gateways attached, and that typically when there are two (or more), there will only be one of each type. It is therefore a planned enhancement to support `--storage-gateway posix` as a method for selecting the only POSIX gateway on the Endpoint. I think this branch of work should be updated to either implement that logic OR switch to `--storage-gateway-id`. I'm not yet sure which.