### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         id: setup-python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: |
             .github/workflows/build.yaml
@@ -60,14 +60,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         # we do not want a large number of windows and macos builds, so
         # enumerate them explicitly
         include:
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.12"
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.12"
     name: "test py${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         id: setup-python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: |
             .github/workflows/build.yaml
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         id: setup-python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: |
             .github/workflows/build.yaml
@@ -240,7 +240,7 @@ jobs:
   test-sdk-main:
     strategy:
       matrix:
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.7", "3.12"]
     runs-on: ubuntu-latest
     name: "sdk-main"
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: 3.11
+          python-version: "3.12"
       - name: Install CLI
         run: |
           python -m pip install -e .

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - run: python -m pip install build
 

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - run: python -m pip install build
 

--- a/changelog.d/20231207_091830_kurtmckee_python_3_12.md
+++ b/changelog.d/20231207_091830_kurtmckee_python_3_12.md
@@ -1,0 +1,3 @@
+### Other
+
+* Test against Python 3.12 in CI.

--- a/changelog.d/20231207_094126_kurtmckee_python_3_12.md
+++ b/changelog.d/20231207_094126_kurtmckee_python_3_12.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Support Python 3.12.

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,16 @@ import re
 from setuptools import find_packages, setup
 
 TEST_REQUIREMENTS = [
-    "coverage<7",
-    "pytest<7",
+    "coverage>=7",
+    "pytest>=7",
     "pytest-xdist<3",
     "pytest-timeout<2",
     "click-type-test==0.0.5;python_version>='3.10'",
     "responses==0.23.3",
     # loading test fixture data
     "ruamel.yaml==0.17.32",
+    # Python 3.12 needs setuptools.
+    "setuptools;python_version>='3.12'",
 ]
 DEV_REQUIREMENTS = TEST_REQUIREMENTS + [
     "tox>=4",
@@ -79,5 +81,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/src/globus_cli/services/transfer/delegate_proxy.py
+++ b/src/globus_cli/services/transfer/delegate_proxy.py
@@ -162,10 +162,9 @@ def create_proxy_cert(
     builder = builder.serial_number(serial)
 
     # set the new proxy as valid from now until lifetime_hours have passed
-    builder = builder.not_valid_before(datetime.datetime.utcnow())
-    builder = builder.not_valid_after(
-        datetime.datetime.utcnow() + datetime.timedelta(hours=lifetime_hours)
-    )
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    builder = builder.not_valid_before(now)
+    builder = builder.not_valid_after(now + datetime.timedelta(hours=lifetime_hours))
 
     # set the public key of the new proxy to the given public key
     builder = builder.public_key(loaded_public_key)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     clean
-    py{311,310,39,38,37}
+    py{312,311,310,39,38,37}
     py37-mindeps
     cov-combine
     cov-report
@@ -29,13 +29,13 @@ deps =
 #
 # usage examples:
 #   GLOBUS_SDK_PATH=../globus-sdk tox -e py311-localsdk
-#   GLOBUS_SDK_PATH=../globus-sdk tox -e 'py{37,38,39,310,311}-localsdk'
+#   GLOBUS_SDK_PATH=../globus-sdk tox -e 'py{37,38,39,310,311,312}-localsdk'
 commands =
     localsdk: python -c 'import os, subprocess, sys; subprocess.run([sys.executable, "-m", "pip", "install", "-e", os.environ["GLOBUS_SDK_PATH"]])'
     coverage run -m pytest {posargs}
 depends =
-    py{37,38,39,310,311}{,-mindeps}: clean
-    cov-combine: py{37,38,39,310,311}{,-mindeps}
+    py{37,38,39,310,311,312}{,-mindeps}: clean
+    cov-combine: py{37,38,39,310,311,312}{,-mindeps}
     cov-report: cov-combine
 
 [testenv:clean]
@@ -65,8 +65,9 @@ commands = pre-commit run --all-files
 
 [testenv:mypy]
 base_python =
-   python3.11
-   python3.10
+    python3.12
+    python3.11
+    python3.10
 deps =
     mypy==1.7.1
     types-jwt


### PR DESCRIPTION
I noticed during yesterday's release that the CLI doesn't support Python 3.12 (this manifests visibly in the README badge).

This PR fixes that, and tests against Python 3.12 in CI.