### PR TITLE
globus api --scope-string (for clients)

### DIFF
--- a/changelog.d/20231206_130249_derek_api_scopes.md
+++ b/changelog.d/20231206_130249_derek_api_scopes.md
@@ -1,0 +1,12 @@
+
+### Enhancements
+
+* The ``globus api <service>`` command now supports a ``--scope-string`` parameter.
+
+  * If supplied, the CLI will enforce that any specified scope strings are included
+    in consent requirements *in addition to* standard service scope requirements.
+
+  * This parameter may be supplied multiple times to specify multiple scope strings.
+
+  * This parameter is only supported in the context of Client Credentials-based authentication.
+    ([Client Credentials with GLOBUS_CLI_CLIENT_ID](https://docs.globus.org/cli/environment_variables/#client_credentials_with_globus_cli_client_id))

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -259,8 +259,8 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
         type=str,
         multiple=True,
         help=(
-            "A scope string to consent to for this command (only supported for "
-            "confidential client usage). "
+            "A scope string that will be used when making the api call. "
+            "At present, only supported for confidential-client based authorization. "
             "Pass this option multiple times to specify multiple scopes."
         ),
     )

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -118,6 +118,13 @@ class LoginManager:
 
         return self._validate_token(tokens["refresh_token"])
 
+    def _tokens_meet_auth_requirements(
+        self, resource_server: str, tokens: dict[str, t.Any]
+    ) -> bool:
+        return self._tokens_meet_static_requirements(
+            resource_server, tokens
+        ) and self._tokens_meet_nonstatic_requirements(resource_server, tokens)
+
     def _tokens_meet_static_requirements(
         self, resource_server: str, tokens: dict[str, t.Any]
     ) -> bool:
@@ -309,7 +316,7 @@ class LoginManager:
             # or for another client, but automatic retries will handle that
             access_token = None
             expires_at = None
-            if tokens:
+            if tokens and self._tokens_meet_auth_requirements(resource_server, tokens):
                 access_token = tokens["access_token"]
                 expires_at = tokens["expires_at_seconds"]
 

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -110,13 +110,9 @@ class LoginManager:
         if tokens is None or "refresh_token" not in tokens:
             return False
 
-        if not self._tokens_meet_static_requirements(resource_server, tokens):
-            return False
-
-        if not self._tokens_meet_nonstatic_requirements(resource_server, tokens):
-            return False
-
-        return self._validate_token(tokens["refresh_token"])
+        return self._tokens_meet_auth_requirements(
+            resource_server, tokens
+        ) and self._validate_token(tokens["refresh_token"])
 
     def _tokens_meet_auth_requirements(
         self, resource_server: str, tokens: dict[str, t.Any]

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -115,7 +115,7 @@ def test_api_command_with_scope_strings(monkeypatch, client_login, run_line):
     run_line("globus api transfer get /foo --scope-string foobarjohn")
 
     token_grant = [
-        kall for kall in responses.calls if kall.request.url.endswith("/token")
+        call for call in responses.calls if call.request.url.endswith("/token")
     ][0]
     request_params = urllib.parse.parse_qs(token_grant.request.body)
     assert request_params["grant_type"][0] == "client_credentials"

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -1,6 +1,7 @@
 import urllib.parse
 
 import pytest
+import responses
 from globus_sdk._testing import (
     RegisteredResponse,
     get_last_request,
@@ -105,3 +106,29 @@ def test_api_command_query_params_multiple_become_list(run_line):
     parsed_query_string = urllib.parse.parse_qs(parsed_url.query)
     assert list(parsed_query_string.keys()) == ["filter"]
     assert set(parsed_query_string["filter"]) == {"frobulated", "demuddled", "reversed"}
+
+
+def test_api_command_with_scope_strings(monkeypatch, client_login, run_line):
+    load_response("cli.api.transfer_stub")
+    load_response("auth.oauth2_client_credentials_tokens")
+
+    run_line("globus api transfer get /foo --scope-string foobarjohn")
+
+    token_grant = [
+        kall for kall in responses.calls if kall.request.url.endswith("/token")
+    ][0]
+    request_params = urllib.parse.parse_qs(token_grant.request.body)
+    assert request_params["grant_type"][0] == "client_credentials"
+    scopes = request_params["scope"][0].split(" ")
+    # This is the default transfer scope, inherited through the service name.
+    assert "urn:globus:auth:scope:transfer.api.globus.org:all" in scopes
+    # This is the scope string we explicitly passed in.
+    assert "foobarjohn" in scopes
+
+
+def test_api_command_rejects_non_client_based_scope_strings(run_line):
+    result = run_line(
+        "globus api auth GET /v2/api/projects --scope-string foobarjohn",
+        assert_exit_code=2,
+    )
+    assert "only supported for confidential-client authorized calls" in result.stderr


### PR DESCRIPTION
## What?
* The ``globus api <service>`` command now supports a ``--scope-string`` parameter.

  * If supplied, the CLI will enforce that any specified scope strings are included
    in consent requirements *in addition to* standard service scope requirements.

  * This parameter may be supplied multiple times to specify multiple scope strings.

  * This parameter is only supported in the context of Client Credentials-based authentication.
    ([Client Credentials with GLOBUS_CLI_CLIENT_ID](https://docs.globus.org/cli/environment_variables/#client_credentials_with_globus_cli_client_id))

## Why?
Provide users a path to interact with APIs not currently supported in the CLI which require specific scope consents (ie. auth's project management apis) 

## Testing

```zsh
> export GLOBUS_CLI_CLIENT_ID="...redacted..."
> export GLOBUS_CLI_CLIENT_SECRET="...redacted..."
> globus api auth GET /v2/api/projects --scope-string 'urn:globus:auth:scope:auth.globus.org:manage_projects'
```
