### PR TITLE
Tighten the mypy belt once more

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -47,9 +47,6 @@ disallow_untyped_defs = false
 [mypy-globus_cli.services.transfer.client]
 disallow_untyped_defs = false
 
-[mypy-globus_cli.services.transfer.data]
-disallow_untyped_defs = false
-
 [mypy-globus_cli.services.transfer.delegate_proxy]
 disallow_untyped_defs = false
 


### PR DESCRIPTION
Also, no longer stringify UUIDs preemptively, as the SDK handles this implicitly now as part of request encoding. This lets us make a data-building helper much shorter.
