### PR TITLE
Remove README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,26 +10,6 @@
     :alt: Supported Python Versions
     :target: https://img.shields.io/pypi/pyversions/globus-cli.svg
 
-.. image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
-    :alt: License
-    :target: https://opensource.org/licenses/Apache-2.0
-
-.. image:: https://results.pre-commit.ci/badge/github/globus/globus-cli/main.svg
-   :target: https://results.pre-commit.ci/latest/github/globus/globus-cli/main
-   :alt: pre-commit.ci status
-
-..
-    This is the badge style used by the isort repo itself, so we'll use their
-    preferred colors
-
-.. image:: https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336
-    :alt: Import Style
-    :target: https://pycqa.github.io/isort/
-
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :alt: Code Style
-    :target: https://github.com/psf/black
-
 
 Globus CLI
 ==========


### PR DESCRIPTION
The badges don't contribute meaningful information to me, just a wall of colors. I'd like to remove them.

## PyPI rendering

![image](https://github.com/globus/globus-cli/assets/39996/6061083d-0035-4077-80a8-976e49b7a24c)

# GitHub rendering

![image](https://github.com/globus/globus-cli/assets/39996/dd992fae-1658-44c5-ba0c-35b47809bd25)
