### PR TITLE
Use client id as identity id if cli is invoked with client creds

### DIFF
--- a/changelog.d/20231208_110449_derek_client_identity_lookup.md
+++ b/changelog.d/20231208_110449_derek_client_identity_lookup.md
@@ -1,0 +1,5 @@
+
+### Bugfixes
+
+* Commands which attempt to infer the identity of the user running the command will now
+  correctly use the client_id for confidential client based invocation patterns.

--- a/src/globus_cli/commands/collection/create/guest.py
+++ b/src/globus_cli/commands/collection/create/guest.py
@@ -13,12 +13,9 @@ from globus_cli.commands.collection._common import (
 )
 from globus_cli.constants import ExplicitNullType
 from globus_cli.endpointish import EntityType
-from globus_cli.login_manager import (
-    LoginManager,
-    MissingLoginError,
-    read_well_known_config,
-)
+from globus_cli.login_manager import LoginManager, MissingLoginError
 from globus_cli.login_manager.context import LoginContext
+from globus_cli.login_manager.utils import get_current_identity_id
 from globus_cli.parsing import command, endpointish_params, mutex_option_group
 from globus_cli.services.gcs import CustomGCSClient
 from globus_cli.termio import TextMode, display
@@ -171,8 +168,7 @@ def _select_user_credential_id(
     storage_gateway_id = mapped_collection["storage_gateway_id"]
 
     if not identity_id:
-        user_data = read_well_known_config("auth_user_data", allow_null=False)
-        identity_id = user_data["sub"]
+        identity_id = get_current_identity_id()
 
     # Grab the list of user credentials which match the endpoint, storage gateway,
     #   identity id, and local username (if specified)

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -7,7 +7,8 @@ import uuid
 import click
 import globus_sdk
 
-from globus_cli.login_manager import LoginManager, read_well_known_config
+from globus_cli.login_manager import LoginManager
+from globus_cli.login_manager.utils import get_current_identity_id
 from globus_cli.parsing import command, run_id_arg
 from globus_cli.termio import Field, TextMode, display, formatters
 from globus_cli.utils import CLIAuthRequirementsError
@@ -127,7 +128,6 @@ def _has_required_consent(
     login_manager: LoginManager, required_scopes: list[str]
 ) -> bool:
     auth_client = login_manager.get_auth_client()
-    user_data = read_well_known_config("auth_user_data", allow_null=False)
-    user_identity_id = user_data["sub"]
+    user_identity_id = get_current_identity_id()
     consents = auth_client.get_consents(user_identity_id)
     return consents.contains_scopes(required_scopes)

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -10,11 +10,8 @@ import globus_sdk
 from globus_sdk.scopes import GCSCollectionScopeBuilder, MutableScope
 
 from globus_cli.endpointish import Endpointish
-from globus_cli.login_manager import (
-    LoginManager,
-    is_client_login,
-    read_well_known_config,
-)
+from globus_cli.login_manager import LoginManager, is_client_login
+from globus_cli.login_manager.utils import get_current_identity_id
 from globus_cli.parsing import (
     ENDPOINT_PLUS_OPTPATH,
     TimedeltaType,
@@ -315,8 +312,7 @@ def _derive_needed_scopes(
     needs_data_access: list[str],
 ) -> list[str]:
     # read the identity ID stored from the login flow
-    user_data = read_well_known_config("auth_user_data", allow_null=False)
-    user_identity_id = user_data["sub"]
+    user_identity_id = get_current_identity_id()
 
     # get the user's Globus CLI consents
     consents = auth_client.get_consents(user_identity_id)

--- a/src/globus_cli/commands/timer/resume.py
+++ b/src/globus_cli/commands/timer/resume.py
@@ -7,7 +7,8 @@ import uuid
 import click
 import globus_sdk
 
-from globus_cli.login_manager import LoginManager, read_well_known_config
+from globus_cli.login_manager import LoginManager
+from globus_cli.login_manager.utils import get_current_identity_id
 from globus_cli.parsing import command
 from globus_cli.termio import TextMode, display
 from globus_cli.utils import CLIAuthRequirementsError
@@ -124,7 +125,6 @@ def _has_required_consent(
     login_manager: LoginManager, required_scopes: list[str]
 ) -> bool:
     auth_client = login_manager.get_auth_client()
-    user_data = read_well_known_config("auth_user_data", allow_null=False)
-    user_identity_id = user_data["sub"]
+    user_identity_id = get_current_identity_id()
     consents = auth_client.get_consents(user_identity_id)
     return consents.contains_scopes(required_scopes)

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -34,7 +34,7 @@ from .tokenstore import (
     read_well_known_config,
     token_storage_adapter,
 )
-from .utils import is_remote_session
+from .utils import get_current_identity_id, is_remote_session
 
 if t.TYPE_CHECKING:
     from ..services.auth import ConsentForestResponse, CustomAuthClient
@@ -182,10 +182,9 @@ class LoginManager:
     @property
     @functools.lru_cache(maxsize=1)  # noqa: B019
     def _cached_consent_forest(self) -> ConsentForestResponse:
-        user_data = read_well_known_config("auth_user_data", allow_null=False)
-        user_identity_id = user_data["sub"]
+        identity_id = get_current_identity_id()
 
-        return self.get_auth_client().get_consents(user_identity_id)
+        return self.get_auth_client().get_consents(identity_id)
 
     def run_login_flow(
         self,

--- a/src/globus_cli/login_manager/utils.py
+++ b/src/globus_cli/login_manager/utils.py
@@ -1,5 +1,22 @@
 import os
+import typing as t
+
+from globus_cli.login_manager.client_login import is_client_login
+from globus_cli.login_manager.tokenstore import read_well_known_config
 
 
 def is_remote_session() -> bool:
     return bool(os.environ.get("SSH_TTY", os.environ.get("SSH_CONNECTION")))
+
+
+def get_current_identity_id() -> str:
+    """
+    Return the current user's identity ID.
+    For a client-authorized invocation, that's the client ID.
+    """
+
+    if is_client_login():
+        return os.environ["GLOBUS_CLI_CLIENT_ID"]
+    else:
+        user_data = read_well_known_config("auth_user_data", allow_null=False)
+        return t.cast(str, user_data["sub"])


### PR DESCRIPTION
## What?
* Commands which attempt to infer the identity of the user running the command will now
  correctly use the client_id for confidential client based invocation patterns.

## Testing
* Invoked `globus collection create guest ...` with confidential client parameters got past previous erroring point.
