### PR TITLE
Delete a module-scoped name after its last use

### DIFF
--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -454,5 +454,6 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
 
 for service_name_ in CLI_SCOPE_REQUIREMENTS:
     api_command.add_command(build_command(service_name_))
+del service_name_
 
 api_command.add_command(build_command("gcs"))


### PR DESCRIPTION
Very minor cleanup, following fast after #913 