### PR TITLE
Rename Timers "jobs" to simply "timers"

### DIFF
--- a/changelog.d/20231211_183203_kurtmckee_rename_timer_jobs.md
+++ b/changelog.d/20231211_183203_kurtmckee_rename_timer_jobs.md
@@ -1,0 +1,5 @@
+### Other
+
+* User timers are now referred to as "timers" rather than as "jobs".
+  For example, the output of `globus timer list` now shows "Timer ID"
+  instead of "Job ID".

--- a/src/globus_cli/commands/timer/__init__.py
+++ b/src/globus_cli/commands/timer/__init__.py
@@ -13,4 +13,4 @@ from globus_cli.parsing import group
     },
 )
 def timer_command() -> None:
-    """Schedule and manage jobs in Globus Timers"""
+    """Schedule and manage timers in Globus Timers"""

--- a/src/globus_cli/commands/timer/_common.py
+++ b/src/globus_cli/commands/timer/_common.py
@@ -76,7 +76,7 @@ class ScheduleFormatter(formatters.FieldFormatter[t.Dict[str, t.Any]]):
 
 
 _COMMON_FIELDS = [
-    Field("Job ID", "job_id"),
+    Field("Timer ID", "job_id"),
     Field("Name", "name"),
     Field("Type", "callback_url", formatter=CallbackActionTypeFormatter()),
     Field("Submitted At", "submitted_at", formatter=formatters.Date),
@@ -85,7 +85,7 @@ _COMMON_FIELDS = [
 ]
 
 
-JOB_FORMAT_FIELDS = _COMMON_FIELDS + [
+TIMER_FORMAT_FIELDS = _COMMON_FIELDS + [
     Field("Status", "status"),
     Field("Last Run", "last_ran_at", formatter=formatters.Date),
     Field("Next Run", "next_run", formatter=formatters.Date),
@@ -95,7 +95,7 @@ JOB_FORMAT_FIELDS = _COMMON_FIELDS + [
     Field("Number of Timer Errors", "n_errors"),
 ]
 
-DELETED_JOB_FORMAT_FIELDS = _COMMON_FIELDS + [
+DELETED_TIMER_FORMAT_FIELDS = _COMMON_FIELDS + [
     Field("Status", "status"),
     Field("Stop After Date", "stop_after.date"),
     Field("Stop After Number of Runs", "stop_after.n_runs"),

--- a/src/globus_cli/commands/timer/create/__init__.py
+++ b/src/globus_cli/commands/timer/create/__init__.py
@@ -3,7 +3,7 @@ from globus_cli.parsing import group
 
 @group(
     "create",
-    short_help="Submit a Timer job",
+    short_help="Create a timer",
     lazy_subcommands={"transfer": (".transfer", "transfer_command")},
 )
 def create_command() -> None:

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -55,7 +55,7 @@ FORMAT_FIELDS = [
 
 
 INTERVAL_HELP = """\
-Interval at which the job should run. Expressed in weeks, days, hours, minutes, and
+Interval at which the timer should run. Expressed in weeks, days, hours, minutes, and
 seconds. Use 'w', 'd', 'h', 'm', and 's' as suffixes to specify.
 e.g. '1h30m', '500s', '10d'
 """
@@ -71,7 +71,7 @@ def resolve_optional_local_time(
     return start_with_tz
 
 
-@command("transfer", short_help="Create a recurring transfer job in Timer")
+@command("transfer", short_help="Create a recurring transfer timer")
 @click.argument(
     "source", metavar="SOURCE_ENDPOINT_ID[:SOURCE_PATH]", type=ENDPOINT_PLUS_OPTPATH
 )
@@ -90,18 +90,18 @@ def resolve_optional_local_time(
 @click.option(
     "--start",
     type=click.DateTime(formats=DATETIME_FORMATS),
-    help="Start time for the job. Defaults to current time.",
+    help="Start time for the timer. Defaults to current time.",
 )
 @click.option(
     "--interval",
     type=TimedeltaType(),
     help=INTERVAL_HELP,
 )
-@click.option("--name", type=str, help="A name for the Timer job.")
+@click.option("--name", type=str, help="A name for the timer.")
 @click.option(
     "--label",
     type=str,
-    help="A label for the Transfer tasks submitted by the Timer job.",
+    help="A label for the Transfer tasks submitted by the timer.",
 )
 @click.option(
     "--stop-after-date",
@@ -137,10 +137,10 @@ def transfer_command(
     notify: dict[str, bool],
 ) -> None:
     """
-    Create a Timer job which will run a transfer on a recurring schedule
+    Create a timer which will run a transfer on a recurring schedule
     according to the parameters provided.
 
-    For example, to create a job which runs a Transfer from /foo/ on one endpoint to
+    For example, to create a timer which runs a Transfer from /foo/ on one endpoint to
     /bar/ on another endpoint every day, with no end condition:
 
     \b
@@ -188,8 +188,8 @@ def transfer_command(
             "transfer requires either SOURCE_PATH and DEST_PATH or --batch"
         )
 
-    # Interval must be null iff the job is 'once', i.e. stop-after-runs == 1.
-    # and it must be non-null if the job is 'recurring'
+    # Interval must be null iff the timer is 'once', i.e. stop-after-runs == 1.
+    # and it must be non-null if the timer is 'recurring'
     schedule: globus_sdk.RecurringTimerSchedule | globus_sdk.OnceTimerSchedule
     start_ = resolve_optional_local_time(start)
     if stop_after_runs == 1:

--- a/src/globus_cli/commands/timer/delete.py
+++ b/src/globus_cli/commands/timer/delete.py
@@ -6,22 +6,22 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import TextMode, display
 
-from ._common import DELETED_JOB_FORMAT_FIELDS
+from ._common import DELETED_TIMER_FORMAT_FIELDS
 
 
-@command("delete", short_help="Delete a timer job")
-@click.argument("JOB_ID", type=click.UUID)
+@command("delete", short_help="Delete a timer")
+@click.argument("TIMER_ID", type=click.UUID)
 @LoginManager.requires_login("timer")
-def delete_command(login_manager: LoginManager, *, job_id: uuid.UUID) -> None:
+def delete_command(login_manager: LoginManager, *, timer_id: uuid.UUID) -> None:
     """
-    Delete a Timer job.
+    Delete a timer.
 
-    The contents of the deleted job is printed afterwards.
+    The contents of the deleted timer are printed afterward.
     """
     timer_client = login_manager.get_timer_client()
-    deleted = timer_client.delete_job(job_id)
+    deleted = timer_client.delete_job(timer_id)
     display(
         deleted,
         text_mode=TextMode.text_record,
-        fields=DELETED_JOB_FORMAT_FIELDS,
+        fields=DELETED_TIMER_FORMAT_FIELDS,
     )

--- a/src/globus_cli/commands/timer/list.py
+++ b/src/globus_cli/commands/timer/list.py
@@ -2,19 +2,19 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import TextMode, display
 
-from ._common import JOB_FORMAT_FIELDS
+from ._common import TIMER_FORMAT_FIELDS
 
 
-@command("list", short_help="List your jobs")
+@command("list", short_help="List your timers")
 @LoginManager.requires_login("timer")
 def list_command(login_manager: LoginManager) -> None:
     """
-    List your Timer jobs.
+    List your timers.
     """
     timer_client = login_manager.get_timer_client()
     response = timer_client.list_jobs(query_params={"order": "submitted_at asc"})
     display(
         response["jobs"],
         text_mode=TextMode.text_record_list,
-        fields=JOB_FORMAT_FIELDS,
+        fields=TIMER_FORMAT_FIELDS,
     )

--- a/src/globus_cli/commands/timer/pause.py
+++ b/src/globus_cli/commands/timer/pause.py
@@ -8,14 +8,14 @@ from globus_cli.termio import TextMode, display
 
 
 @command("pause", short_help="Pause a timer")
-@click.argument("JOB_ID", type=click.UUID)
+@click.argument("TIMER_ID", type=click.UUID)
 @LoginManager.requires_login("timer")
-def pause_command(login_manager: LoginManager, *, job_id: uuid.UUID) -> None:
+def pause_command(login_manager: LoginManager, *, timer_id: uuid.UUID) -> None:
     """
     Pause a timer.
     """
     timer_client = login_manager.get_timer_client()
-    paused = timer_client.pause_job(job_id)
+    paused = timer_client.pause_job(timer_id)
     display(
         paused,
         text_mode=TextMode.text_raw,

--- a/src/globus_cli/commands/timer/resume.py
+++ b/src/globus_cli/commands/timer/resume.py
@@ -43,9 +43,9 @@ def resume_command(
     Resume a timer.
     """
     timer_client = login_manager.get_timer_client()
-    job_doc = timer_client.get_job(timer_id)
+    timer_doc = timer_client.get_job(timer_id)
 
-    gare = _get_inactive_reason(job_doc)
+    gare = _get_inactive_reason(timer_doc)
     if not skip_inactive_reason_check:
         check_inactive_reason(login_manager, timer_id, gare)
 
@@ -105,16 +105,16 @@ def check_inactive_reason(
 
 
 def _get_inactive_reason(
-    job_doc: dict[str, t.Any] | globus_sdk.GlobusHTTPResponse
+    timer_doc: dict[str, t.Any] | globus_sdk.GlobusHTTPResponse
 ) -> GlobusAuthRequirementsError | None:
     from globus_sdk.experimental.auth_requirements_error import (
         to_auth_requirements_error,
     )
 
-    if job_doc.get("status") != "inactive":
+    if timer_doc.get("status") != "inactive":
         return None
 
-    reason = job_doc.get("inactive_reason", {})
+    reason = timer_doc.get("inactive_reason", {})
     if reason.get("cause") != "globus_auth_requirements":
         return None
 

--- a/src/globus_cli/commands/timer/show.py
+++ b/src/globus_cli/commands/timer/show.py
@@ -6,16 +6,16 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import TextMode, display
 
-from ._common import JOB_FORMAT_FIELDS
+from ._common import TIMER_FORMAT_FIELDS
 
 
-@command("show", short_help="Display a Timer job")
-@click.argument("JOB_ID", type=click.UUID)
+@command("show", short_help="Display a timer")
+@click.argument("TIMER_ID", type=click.UUID)
 @LoginManager.requires_login("timer")
-def show_command(login_manager: LoginManager, *, job_id: uuid.UUID) -> None:
+def show_command(login_manager: LoginManager, *, timer_id: uuid.UUID) -> None:
     """
-    Display information about a particular job.
+    Display information about a particular timer.
     """
     timer_client = login_manager.get_timer_client()
-    response = timer_client.get_job(job_id)
-    display(response, text_mode=TextMode.text_record, fields=JOB_FORMAT_FIELDS)
+    response = timer_client.get_job(timer_id)
+    display(response, text_mode=TextMode.text_record, fields=TIMER_FORMAT_FIELDS)

--- a/tests/functional/timer/test_job_operations.py
+++ b/tests/functional/timer/test_job_operations.py
@@ -5,15 +5,15 @@ import globus_sdk
 import pytest
 from globus_sdk._testing import RegisteredResponse, load_response, load_response_set
 
-from globus_cli.commands.timer._common import JOB_FORMAT_FIELDS
+from globus_cli.commands.timer._common import TIMER_FORMAT_FIELDS
 
-# NOTE: this is not quite the same as the "normal" job responses from
+# NOTE: this is not quite the same as the "normal" timer responses from
 # create/update—definitely something to consider revisiting on the Timer API.
-_job_id = "e304f241-b77a-4e75-89f6-c431ddafe497"
+_timer_id = "e304f241-b77a-4e75-89f6-c431ddafe497"
 DELETE_RESPONSE = RegisteredResponse(
-    metadata={"job_id": _job_id},
+    metadata={"timer_id": _timer_id},
     service="timer",
-    path=f"/jobs/{_job_id}",
+    path=f"/jobs/{_timer_id}",
     method="DELETE",
     json={
         "callback_body": {
@@ -46,9 +46,9 @@ DELETE_RESPONSE = RegisteredResponse(
         },
         "callback_url": "https://actions.automate.globus.org/transfer/transfer/run",
         "interval": None,
-        "job_id": _job_id,
+        "job_id": _timer_id,
         "n_tries": 1,
-        "name": "example-timer-job",
+        "name": "example-timer",
         "owner": "5276fa05-eedf-46c5-919f-ad2d0160d1a9",
         "refresh_token": None,
         "results": [],
@@ -62,44 +62,44 @@ DELETE_RESPONSE = RegisteredResponse(
 )
 
 
-def test_show_job(run_line):
+def test_show_timer(run_line):
     meta = load_response_set(globus_sdk.TimerClient.get_job).metadata
     assert meta
     result = run_line(["globus", "timer", "show", meta["job_id"]])
     assert result.exit_code == 0
     assert meta["job_id"] in result.output
-    for field in JOB_FORMAT_FIELDS:
+    for field in TIMER_FORMAT_FIELDS:
         assert field.name in result.output
 
 
-def test_list_jobs(run_line):
+def test_list_timers(run_line):
     meta = load_response_set(globus_sdk.TimerClient.list_jobs).metadata
     assert meta
     result = run_line(["globus", "timer", "list"])
     assert result.exit_code == 0
-    assert all(job_id in result.output for job_id in meta["job_ids"])
-    for field in JOB_FORMAT_FIELDS:
+    assert all(timer_id in result.output for timer_id in meta["job_ids"])
+    for field in TIMER_FORMAT_FIELDS:
         assert field.name in result.output
 
 
 @pytest.mark.parametrize("out_format", ["text", "json"])
-def test_delete_job(run_line, out_format):
+def test_delete_timer(run_line, out_format):
     meta = load_response(DELETE_RESPONSE).metadata
     add_args = []
     if out_format == "json":
         add_args = ["-F", "json"]
-    result = run_line(["globus", "timer", "delete", meta["job_id"]] + add_args)
+    result = run_line(["globus", "timer", "delete", meta["timer_id"]] + add_args)
     assert result.exit_code == 0
     if out_format == "json":
         assert json.loads(result.output) == DELETE_RESPONSE.json
     else:
         pattern = re.compile(
-            r"^Job ID:\s+" + re.escape(meta["job_id"]) + "$", flags=re.MULTILINE
+            r"^Timer ID:\s+" + re.escape(meta["timer_id"]) + "$", flags=re.MULTILINE
         )
         assert pattern.search(result.output) is not None
 
 
-def test_pause_job(run_line):
+def test_pause_timer(run_line):
     meta = load_response_set(globus_sdk.TimerClient.pause_job).metadata
     add_args = []
     run_line(

--- a/tests/functional/timer/test_job_resume.py
+++ b/tests/functional/timer/test_job_resume.py
@@ -5,52 +5,52 @@ import pytest
 from globus_sdk._testing import load_response, load_response_set, register_response_set
 
 
-def test_resume_job_active(run_line):
+def test_resume_timer_active(run_line):
     meta = load_response("timer.get_job").metadata
     load_response("timer.resume_job")
-    job_id = meta["job_id"]
+    timer_id = meta["job_id"]
     run_line(
-        ["globus", "timer", "resume", job_id],
-        search_stdout=f"Successfully resumed job {job_id}.",
+        ["globus", "timer", "resume", timer_id],
+        search_stdout=f"Successfully resumed job {timer_id}.",
     )
 
 
-def test_resume_job_inactive_user(run_line):
+def test_resume_timer_inactive_user(run_line):
     meta = load_response("timer.get_job", case="inactive_user").metadata
     load_response("timer.resume_job")
-    job_id = meta["job_id"]
+    timer_id = meta["job_id"]
     run_line(
-        ["globus", "timer", "resume", job_id],
-        search_stdout=f"Successfully resumed job {job_id}.",
+        ["globus", "timer", "resume", timer_id],
+        search_stdout=f"Successfully resumed job {timer_id}.",
     )
 
 
-def test_resume_job_inactive_gare_consent_missing(run_line):
+def test_resume_timer_inactive_gare_consent_missing(run_line):
     meta = load_response_set("cli.timer_resume.inactive_gare.consents_missing").metadata
-    job_id = meta["job_id"]
+    timer_id = meta["timer_id"]
     required_scope = meta["required_scope"]
     result = run_line(
-        ["globus", "timer", "resume", job_id],
+        ["globus", "timer", "resume", timer_id],
         assert_exit_code=4,
     )
     assert f"globus session consent '{required_scope}'" in result.output
 
 
-def test_resume_job_inactive_gare_consent_present(run_line):
+def test_resume_timer_inactive_gare_consent_present(run_line):
     meta = load_response_set("cli.timer_resume.inactive_gare.consents_present").metadata
-    job_id = meta["job_id"]
+    timer_id = meta["timer_id"]
     run_line(
-        ["globus", "timer", "resume", job_id],
-        search_stdout=f"Successfully resumed job {job_id}.",
+        ["globus", "timer", "resume", timer_id],
+        search_stdout=f"Successfully resumed timer {timer_id}.",
     )
 
 
-def test_resume_job_inactive_gare_consent_missing_but_skip_check(run_line):
+def test_resume_timer_inactive_gare_consent_missing_but_skip_check(run_line):
     meta = load_response_set("cli.timer_resume.inactive_gare.consents_missing").metadata
-    job_id = meta["job_id"]
+    timer_id = meta["timer_id"]
     run_line(
-        ["globus", "timer", "resume", "--skip-inactive-reason-check", job_id],
-        search_stdout=f"Successfully resumed job {job_id}.",
+        ["globus", "timer", "resume", "--skip-inactive-reason-check", timer_id],
+        search_stdout=f"Successfully resumed timer {timer_id}.",
     )
 
 
@@ -58,10 +58,10 @@ def test_resume_inactive_gare_session_identity(run_line):
     meta = load_response_set(
         "cli.timer_resume.inactive_gare.session_required_identities"
     ).metadata
-    job_id = meta["job_id"]
+    timer_id = meta["timer_id"]
     usernames = meta["session_required_identities"]
     run_line(
-        ["globus", "timer", "resume", job_id],
+        ["globus", "timer", "resume", timer_id],
         assert_exit_code=4,
         search_stdout=f"globus session update {' '.join(usernames)}",
     )
@@ -71,10 +71,10 @@ def test_resume_inactive_gare_session_identity_but_skip_check(run_line):
     meta = load_response_set(
         "cli.timer_resume.inactive_gare.session_required_identities"
     ).metadata
-    job_id = meta["job_id"]
+    timer_id = meta["timer_id"]
     run_line(
-        ["globus", "timer", "resume", "--skip-inactive-reason-check", job_id],
-        search_stdout=f"Successfully resumed job {job_id}.",
+        ["globus", "timer", "resume", "--skip-inactive-reason-check", timer_id],
+        search_stdout=f"Successfully resumed timer {timer_id}.",
     )
 
 
@@ -132,12 +132,12 @@ def _register_responses(mock_user_data):
 
     metadata = {
         "user_id": user_id,
-        "job_id": timer_id,
+        "timer_id": timer_id,
         "collection_id": collection_id,
         "required_scope": required_scope,
     }
 
-    get_job_json_consent_gare_body = {
+    get_timer_json_consent_gare_body = {
         **TIMER_JSON,
         "status": "inactive",
         "inactive_reason": {
@@ -170,17 +170,17 @@ def _register_responses(mock_user_data):
     register_response_set(
         "cli.timer_resume.inactive_gare.consents_missing",
         dict(
-            get_job=dict(
+            get_timer=dict(
                 service="timer",
                 path=f"/jobs/{timer_id}",
                 method="GET",
-                json=get_job_json_consent_gare_body,
+                json=get_timer_json_consent_gare_body,
             ),
             resume=dict(
                 service="timer",
                 path=f"/jobs/{timer_id}/resume",
                 method="POST",
-                json={"message": f"Successfully resumed job {timer_id}."},
+                json={"message": f"Successfully resumed timer {timer_id}."},
             ),
             consents=dict(
                 service="auth",
@@ -203,17 +203,17 @@ def _register_responses(mock_user_data):
     register_response_set(
         "cli.timer_resume.inactive_gare.consents_present",
         dict(
-            get_job=dict(
+            get_timer=dict(
                 service="timer",
                 path=f"/jobs/{timer_id}",
                 method="GET",
-                json=get_job_json_consent_gare_body,
+                json=get_timer_json_consent_gare_body,
             ),
             resume=dict(
                 service="timer",
                 path=f"/jobs/{timer_id}/resume",
                 method="POST",
-                json={"message": f"Successfully resumed job {timer_id}."},
+                json={"message": f"Successfully resumed timer {timer_id}."},
             ),
             consents=dict(
                 service="auth",
@@ -251,7 +251,7 @@ def _register_responses(mock_user_data):
     register_response_set(
         "cli.timer_resume.inactive_gare.session_required_identities",
         dict(
-            get_job=dict(
+            get_timer=dict(
                 service="timer",
                 path=f"/jobs/{timer_id}",
                 method="GET",
@@ -261,7 +261,7 @@ def _register_responses(mock_user_data):
                 service="timer",
                 path=f"/jobs/{timer_id}/resume",
                 method="POST",
-                json={"message": f"Successfully resumed job {timer_id}."},
+                json={"message": f"Successfully resumed timer {timer_id}."},
             ),
         ),
         metadata={


### PR DESCRIPTION
### Other

* User timers are now referred to as "timers" rather than as "jobs".


This results in output at the CLI that shows the term "Timer ID" instead of "Job ID", for example.