### PR TITLE
Cleanups

### DIFF
--- a/src/globus_cli/commands/login.py
+++ b/src/globus_cli/commands/login.py
@@ -102,7 +102,7 @@ class GCSEndpointType(click.ParamType):
 @click.option(
     "--force",
     is_flag=True,
-    help=("Do a fresh login, ignoring any existing credentials"),
+    help="Do a fresh login, ignoring any existing credentials",
 )
 @click.option(
     "gcs_servers",

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -80,10 +80,9 @@ class LoginManager:
         yield from CLI_SCOPE_REQUIREMENTS["auth"]["scopes"]
 
     def is_logged_in(self) -> bool:
-        res = []
-        for rs_name, _scopes in self.login_requirements:
-            res.append(self.has_login(rs_name))
-        return all(res)
+        return all(
+            self.has_login(rs_name) for rs_name, _scopes in self.login_requirements
+        )
 
     def _validate_token(self, token: str) -> bool:
         auth_client = internal_auth_client()


### PR DESCRIPTION
I stumbled across these while investigating the login code.

These can be summarized as:

* Remove unnecessary parentheses
* Use `all()`'s shortcircuit logic when passed a generator