### PR TITLE
Implement GCS mapped collection creation

### DIFF
--- a/changelog.d/20231213_172721_sirosen_mapped_collection_create.md
+++ b/changelog.d/20231213_172721_sirosen_mapped_collection_create.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Add `globus gcs collection create mapped` as a new command for creating
+  mapped collections

--- a/src/globus_cli/commands/collection/create/__init__.py
+++ b/src/globus_cli/commands/collection/create/__init__.py
@@ -5,6 +5,7 @@ from globus_cli.parsing import group
     "create",
     lazy_subcommands={
         "guest": (".guest", "collection_create_guest"),
+        "mapped": (".mapped", "collection_create_mapped"),
     },
 )
 def collection_create() -> None:

--- a/src/globus_cli/commands/collection/create/guest.py
+++ b/src/globus_cli/commands/collection/create/guest.py
@@ -47,12 +47,6 @@ from globus_cli.termio import TextMode, display
     help="User who should own the collection (defaults to the current user)",
 )
 @click.option(
-    "--public/--private",
-    "public",
-    default=True,
-    help="Set the collection to be public or private",
-)
-@click.option(
     "--enable-https/--disable-https",
     "enable_https",
     default=None,

--- a/src/globus_cli/commands/collection/create/guest.py
+++ b/src/globus_cli/commands/collection/create/guest.py
@@ -8,14 +8,15 @@ import globus_sdk
 import globus_sdk.experimental.auth_requirements_error
 
 from globus_cli.commands.collection._common import (
+    LazyCurrentIdentity,
     filter_fields,
+    identity_id_option,
     standard_collection_fields,
 )
 from globus_cli.constants import ExplicitNullType
 from globus_cli.endpointish import EntityType
 from globus_cli.login_manager import LoginManager, MissingLoginError
 from globus_cli.login_manager.context import LoginContext
-from globus_cli.login_manager.utils import get_current_identity_id
 from globus_cli.parsing import command, endpointish_params, mutex_option_group
 from globus_cli.services.gcs import CustomGCSClient
 from globus_cli.termio import TextMode, display
@@ -41,11 +42,7 @@ from globus_cli.termio import TextMode, display
 )
 @mutex_option_group("--user-credential-id", "--local-username")
 @endpointish_params.create(name="collection")
-@click.option(
-    "--identity-id",
-    default=None,
-    help="User who should own the collection (defaults to the current user)",
-)
+@identity_id_option
 @click.option(
     "--enable-https/--disable-https",
     "enable_https",
@@ -71,7 +68,7 @@ def collection_create_guest(
     display_name: str,
     enable_https: bool | None,
     force_encryption: bool | None,
-    identity_id: str | None,
+    identity_id: LazyCurrentIdentity,
     info_link: str | None | ExplicitNullType,
     keywords: list[str] | None,
     public: bool,
@@ -95,7 +92,7 @@ def collection_create_guest(
 
     if not user_credential_id:
         user_credential_id = _select_user_credential_id(
-            gcs_client, mapped_collection_id, local_username, identity_id
+            gcs_client, mapped_collection_id, local_username, identity_id.value
         )
 
     converted_kwargs: dict[str, t.Any] = ExplicitNullType.nullify_dict(
@@ -109,7 +106,7 @@ def collection_create_guest(
             "display_name": display_name,
             "enable_https": enable_https,
             "force_encryption": force_encryption,
-            "identity_id": identity_id,
+            "identity_id": identity_id.value,
             "info_link": info_link,
             "keywords": keywords,
             "mapped_collection_id": mapped_collection_id,
@@ -149,7 +146,7 @@ def _select_user_credential_id(
     gcs_client: CustomGCSClient,
     mapped_collection_id: uuid.UUID,
     local_username: str | None,
-    identity_id: str | None,
+    identity_id: str,
 ) -> uuid.UUID:
     """
     In the case that the user didn't specify a user credential id, see if we can select
@@ -160,9 +157,6 @@ def _select_user_credential_id(
     """
     mapped_collection = gcs_client.get_collection(mapped_collection_id)
     storage_gateway_id = mapped_collection["storage_gateway_id"]
-
-    if not identity_id:
-        identity_id = get_current_identity_id()
 
     # Grab the list of user credentials which match the endpoint, storage gateway,
     #   identity id, and local username (if specified)

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -31,11 +31,13 @@ def _make_multi_use_option_str(s: str) -> str:
 
 
 def _posix_policy_options_present(params: dict[str, t.Any]) -> bool:
-    return params["posix_sharing_group_allow"] or params["posix_sharing_group_deny"]
+    return bool(
+        params["posix_sharing_group_allow"] or params["posix_sharing_group_deny"]
+    )
 
 
 def _posix_staging_policy_options_present(params: dict[str, t.Any]) -> bool:
-    return (
+    return bool(
         params["posix_staging_sharing_group_allow"]
         or params["posix_staging_sharing_group_deny"]
     )

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import typing as t
+import uuid
+
+import click
+import globus_sdk
+
+from globus_cli.constants import EXPLICIT_NULL, ExplicitNullType
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import (
+    CommaDelimitedList,
+    JSONStringOrFile,
+    StringOrNull,
+    UrlOrNull,
+    command,
+    endpoint_id_arg,
+    mutex_option_group,
+    nullable_multi_callback,
+)
+from globus_cli.termio import Field, TextMode, display
+
+
+def _mkhelp(txt):
+    return f"{txt} the collection"
+
+
+def collection_create_params(f):
+    """
+    Collection of options consumed by GCS Collection update
+
+    Usage:
+
+    >>> @collection_create_and_update_params(create=False)
+    >>> def command_func(**kwargs):
+    >>>     ...
+    """
+    multi_use_option_str = "Give this option multiple times in a single command"
+
+    f = click.argument("DISPLAY_NAME")(f)
+    f = click.option(
+        "--public/--private",
+        "public",
+        default=True,
+        help="Set the collection to be public or private",
+    )(f)
+    f = click.option(
+        "--description", type=StringOrNull(), help=_mkhelp("Description for")
+    )(f)
+    f = click.option(
+        "--info-link", type=StringOrNull(), help=_mkhelp("Link for info about")
+    )(f)
+    f = click.option(
+        "--contact-info", type=StringOrNull(), help=_mkhelp("Contact Info for")
+    )(f)
+    f = click.option(
+        "--contact-email",
+        type=StringOrNull(),
+        help=_mkhelp("Contact email for"),
+    )(f)
+    f = click.option(
+        "--organization", type=StringOrNull(), help=_mkhelp("Organization for")
+    )(f)
+    f = click.option(
+        "--department", type=StringOrNull(), help=_mkhelp("Department which operates")
+    )(f)
+    f = click.option(
+        "--keywords",
+        type=CommaDelimitedList(),
+        help=_mkhelp("Comma separated list of keywords to help searches for"),
+    )(f)
+    f = click.option(
+        "--force-encryption/--no-force-encryption",
+        "force_encryption",
+        default=None,
+        help=(
+            "When set, all transfers to and from this collection are "
+            "always encrypted"
+        ),
+    )(f)
+    f = click.option(
+        "--sharing-restrict-paths",
+        type=JSONStringOrFile(null="null"),
+        help="Path restrictions for sharing data on guest collections "
+        "based on this collection. This option is only usable on Mapped "
+        "Collections",
+    )(f)
+    f = click.option(
+        "--allow-guest-collections/--no-allow-guest-collections",
+        default=None,
+        help=(
+            "Allow Guest Collections to be created on this Collection. This option "
+            "is only usable on Mapped Collections. If this option is disabled on a "
+            "Mapped Collection which already has associated Guest Collections, "
+            "those collections will no longer be accessible"
+        ),
+    )(f)
+    f = click.option(
+        "--disable-anonymous-writes/--enable-anonymous-writes",
+        default=None,
+        help=(
+            "Allow anonymous write ACLs on Guest Collections attached to this "
+            "Mapped Collection. This option is only usable on non high assurance "
+            "Mapped Collections and the setting is inherited by the hosted Guest "
+            "Collections. Anonymous write ACLs are enabled by default "
+            "(requires an endpoint with API v1.8.0)"
+        ),
+    )(f)
+    f = click.option(
+        "--domain-name",
+        help=(
+            "DNS host name for the collection (mapped "
+            "collections only). This may be either a host name "
+            "or a fully-qualified domain name, but if it is the latter "
+            "it must be a subdomain of the endpoint's domain"
+        ),
+    )(f)
+    f = click.option(
+        "--default-directory",
+        default=None,
+        help="Default directory when browsing the collection",
+    )(f)
+
+    f = click.option(
+        "--enable-https",
+        is_flag=True,
+        help=(
+            "Explicitly enable HTTPS supprt (requires a managed endpoint "
+            "with API v1.1.0)"
+        ),
+    )(f)
+    f = click.option(
+        "--disable-https",
+        is_flag=True,
+        help=(
+            "Explicitly disable HTTPS supprt (requires a managed endpoint "
+            "with API v1.1.0)"
+        ),
+    )(f)
+    f = mutex_option_group("--enable-https", "--disable-https")(f)
+
+    f = click.option(
+        "--user-message",
+        help=(
+            "A message for clients to display to users when interacting "
+            "with this collection"
+        ),
+        type=StringOrNull(),
+    )(f)
+    f = click.option(
+        "--user-message-link",
+        help=(
+            "Link to additional messaging for clients to display to users "
+            "when interacting with this endpoint, linked to an http or https URL "
+            "with this collection"
+        ),
+        type=UrlOrNull(),
+    )(f)
+    f = click.option(
+        "--sharing-user-allow",
+        "sharing_users_allow",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "Connector-specific username allowed to create guest collections."
+            f"{multi_use_option_str} to allow multiple users. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--sharing-user-deny",
+        "sharing_users_deny",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "Connector-specific username denied permission to create guest "
+            f"collections. {multi_use_option_str} to deny multiple users. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--posix-sharing-group-allow",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "POSIX group allowed access to create guest collections "
+            "(POSIX Connector Only). "
+            f"{multi_use_option_str} to allow multiple groups. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--posix-sharing-group-deny",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "POSIX group denied permission to create guest collections "
+            "(POSIX Connector Only). "
+            f"{multi_use_option_str} to deny multiple groups. "
+            + 'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--google-project-id",
+        help=(
+            "For Google Cloud Storage backed Collections only. The Google "
+            "Cloud Platform project ID which is used by this Collection"
+        ),
+        type=StringOrNull(),
+    )(f)
+
+    # POSIX Staging connector (GCS v5.4.10)
+    f = click.option(
+        "--posix-staging-sharing-group-allow",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "POSIX group allowed access to create guest collections "
+            "(POSIX Staging Connector Only). "
+            f"{multi_use_option_str} to allow multiple groups. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+    f = click.option(
+        "--posix-staging-sharing-group-deny",
+        multiple=True,
+        callback=nullable_multi_callback(""),
+        help=(
+            "POSIX group denied permission to create guest collections "
+            "(POSIX Staging Connector Only). "
+            f"{multi_use_option_str} to deny multiple groups. "
+            'Set a value of "" to clear this'
+        ),
+    )(f)
+
+    f = click.option(
+        "--verify",
+        type=click.Choice(["force", "disable", "default"], case_sensitive=False),
+        help=(
+            "Set the policy for this collection for file integrity verification "
+            "after transfer. 'force' requires all transfers to perform "
+            "verfication. 'disable' disables all verification checks. 'default' "
+            "allows the user to decide on verification at Transfer task submit  "
+            "time. When set on mapped collections, this policy is inherited by any "
+            "guest collections"
+        ),
+    )(f)
+    return f
+
+
+@command("create", short_help="Create a new Mapped Collection")
+@endpoint_id_arg
+@click.argument("STORAGE_GATEWAY_ID")
+@click.argument("BASE_PATH")
+@collection_create_params
+@click.option(
+    "--identity-id",
+    help=(
+        "Globus Auth identity to who acts as the owner of this Collection. This "
+        "identity must be an administrator on the Endpoint"
+    ),
+)
+@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+def collection_create_mapped(
+    *,
+    login_manager: LoginManager,
+    # positional args
+    endpoint_id: uuid.UUID,
+    storage_gateway_id: uuid.UUID,
+    base_path: str,
+    display_name: str,
+    # options
+    public: bool,
+    description: str | None,
+    info_link: str | None,
+    contact_info: str | None,
+    contact_email: str | None,
+    organization: str | None,
+    department: str | None,
+    keywords: str | None,
+    default_directory: str | None,
+    force_encryption: bool | None,
+    domain_name: str | None,
+    disable_anonymous_writes: bool | None,
+    identity_id: str | None,
+    google_project_id: str | None,
+    posix_sharing_group_allow: t.Iterable[str] | None,
+    posix_sharing_group_deny: t.Iterable[str] | None,
+    posix_staging_sharing_group_allow: t.Iterable[str] | None,
+    posix_staging_sharing_group_deny: t.Iterable[str] | None,
+    sharing_restrict_paths: t.Dict[str, t.Iterable[str]] | None | ExplicitNullType,
+    allow_guest_collections: bool | None,
+    sharing_users_allow: t.Iterable[str] | None,
+    sharing_users_deny: t.Iterable[str] | None,
+    user_message: str | None | ExplicitNullType,
+    user_message_link: str | None | ExplicitNullType,
+    enable_https: bool | None,
+    disable_https: bool | None,
+    verify: str | None,
+) -> None:
+    """
+    Create a new Mapped Collection, rooted on some given path within an
+    existing Storage Gateway.
+
+    The ENDPOINT_ID and STORAGE_GATEWAY_ID are both required in order to specify where
+    and how the collection is hosted.
+    """
+    gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
+
+    policies: t.Optional[globus_sdk.CollectionPolicies] = None
+    if google_project_id is not None:
+        policies = globus_sdk.GoogleCloudStorageCollectionPolicies(
+            project=google_project_id
+        )
+
+    if posix_sharing_group_allow is not None or posix_sharing_group_deny is not None:
+        if policies is not None:
+            raise click.UsageError("Incompatible policy options detected")
+        # Added in 5.4.8 for POSIX connector
+        policies = globus_sdk.POSIXCollectionPolicies(
+            posix_sharing_group_allow=posix_sharing_group_allow,
+            posix_sharing_group_deny=posix_sharing_group_deny,
+        )
+
+    if (
+        posix_staging_sharing_group_allow is not None
+        or posix_staging_sharing_group_deny is not None
+    ):
+        if policies is not None:
+            raise click.UsageError("Incompatible policy options detected")
+        # Added in 5.4.10 for POSIX staging connector
+        policies = globus_sdk.POSIXStagingStoragePolicies(
+            sharing_groups_allow=posix_staging_sharing_group_allow,
+            sharing_groups_deny=posix_staging_sharing_group_deny,
+        )
+
+    if sharing_restrict_paths == EXPLICIT_NULL:
+        sharing_restrict_paths = None
+    if user_message == EXPLICIT_NULL:
+        user_message = None
+    if user_message_link == EXPLICIT_NULL:
+        user_message_link = None
+
+    # These are added in GCS 5.4.4, so if neither --enable-https or
+    # --disable-https are set, then we'll not try to set the value for
+    # backward compatibility
+    if enable_https is False:
+        enable_https = None
+    if disable_https:
+        enable_https = False
+
+    force_verify: bool | None = None
+    disable_verify: bool | None = None
+    if verify is not None:
+        if verify.lower() == "force":
+            force_verify, disable_verify = True, False
+        elif verify.lower() == "disable":
+            force_verify, disable_verify = False, True
+        else:
+            force_verify, disable_verify = False, False
+
+    collection_doc = globus_sdk.MappedCollectionDocument(
+        storage_gateway_id=storage_gateway_id,
+        collection_base_path=base_path,
+        display_name=display_name,
+        public=public,
+        description=description,
+        info_link=info_link,
+        contact_info=contact_info,
+        contact_email=contact_email,
+        organization=organization,
+        department=department,
+        keywords=keywords,
+        default_directory=default_directory,
+        force_encryption=force_encryption,
+        domain_name=domain_name,
+        disable_anonymous_writes=disable_anonymous_writes,
+        identity_id=identity_id,
+        policies=policies,
+        allow_guest_collections=allow_guest_collections,
+        sharing_users_allow=sharing_users_allow,
+        sharing_users_deny=sharing_users_deny,
+        sharing_restrict_paths=sharing_restrict_paths,
+        user_message=user_message,
+        user_message_link=user_message_link,
+        enable_https=enable_https,
+        disable_verify=disable_verify,
+        force_verify=force_verify,
+    )
+    res = gcs_client.create_collection(collection_doc)
+
+    display(res, text_mode=TextMode.text_record, fields=[Field("Collection ID", "id")])

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -35,7 +35,7 @@ def _make_multi_use_option_str(s: str) -> str:
     help="The location within the storage gateway where the collection is rooted.",
 )
 @click.option(
-    "--storage-gateway",
+    "--storage-gateway-id",
     help=(
         "The storage gateway ID to host this collection. "
         "If no value is provided but the endpoint has exactly one gateway, "
@@ -189,7 +189,7 @@ def collection_create_mapped(
     sharing_restrict_paths: ParsedJSONData | None | ExplicitNullType,
     sharing_users_allow: tuple[str, ...],
     sharing_users_deny: tuple[str, ...],
-    storage_gateway: str | None,
+    storage_gateway_id: str | None,
     user_message: str | None | ExplicitNullType,
     user_message_link: str | None | ExplicitNullType,
     verify: dict[str, bool],
@@ -208,9 +208,7 @@ def collection_create_mapped(
         raise click.UsageError("--sharing-restrict-paths must be a JSON object")
 
     gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
-    if storage_gateway is not None:
-        storage_gateway_id = storage_gateway
-    else:
+    if storage_gateway_id is None:
         all_gateways = list(gcs_client.get_storage_gateway_list())
         if len(all_gateways) == 0:
             raise click.UsageError(

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -6,6 +6,10 @@ import uuid
 import click
 import globus_sdk
 
+from globus_cli.commands.collection._common import (
+    filter_fields,
+    standard_collection_fields,
+)
 from globus_cli.constants import ExplicitNullType
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
@@ -15,7 +19,7 @@ from globus_cli.parsing import (
     endpoint_id_arg,
     endpointish_params,
 )
-from globus_cli.termio import Field, TextMode, display
+from globus_cli.termio import TextMode, display
 
 
 def _make_multi_use_option_str(s: str) -> str:
@@ -292,4 +296,9 @@ def collection_create_mapped(
     )
     res = gcs_client.create_collection(collection_doc)
 
-    display(res, text_mode=TextMode.text_record, fields=[Field("Collection ID", "id")])
+    fields = standard_collection_fields(login_manager.get_auth_client())
+    display(
+        res,
+        text_mode=TextMode.text_record,
+        fields=filter_fields(fields, res),
+    )

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -10,238 +10,191 @@ from globus_cli.constants import ExplicitNullType
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import (
     JSONStringOrFile,
-    StringOrNull,
-    UrlOrNull,
+    ParsedJSONData,
     command,
     endpoint_id_arg,
     endpointish_params,
-    mutex_option_group,
-    nullable_multi_callback,
 )
 from globus_cli.termio import Field, TextMode, display
 
 
-def collection_create_params(f):
-    """
-    Collection of options consumed by GCS Collection create.
-    """
-    multi_use_option_str = "Give this option multiple times in a single command"
-    f = click.argument("BASE_PATH")(f)
-
-    f = click.option(
-        "--storage-gateway",
-        help=(
-            "The storage gateway ID to host this collection. "
-            "If no value is provided but the endpoint has exactly one gateway, "
-            "that gateway will be used by default."
-        ),
-    )(f)
-    f = click.option(
-        "--public/--private",
-        "public",
-        default=True,
-        help="Set the collection to be public or private",
-    )(f)
-    f = click.option(
-        "--sharing-restrict-paths",
-        type=JSONStringOrFile(null="null"),
-        help="Path restrictions for sharing data on guest collections "
-        "based on this collection. This option is only usable on Mapped "
-        "Collections",
-    )(f)
-    f = click.option(
-        "--allow-guest-collections/--no-allow-guest-collections",
-        default=None,
-        help=(
-            "Allow Guest Collections to be created on this Collection. This option "
-            "is only usable on Mapped Collections. If this option is disabled on a "
-            "Mapped Collection which already has associated Guest Collections, "
-            "those collections will no longer be accessible"
-        ),
-    )(f)
-    f = click.option(
-        "--disable-anonymous-writes/--enable-anonymous-writes",
-        default=None,
-        help=(
-            "Allow anonymous write ACLs on Guest Collections attached to this "
-            "Mapped Collection. This option is only usable on non high assurance "
-            "Mapped Collections and the setting is inherited by the hosted Guest "
-            "Collections. Anonymous write ACLs are enabled by default "
-            "(requires an endpoint with API v1.8.0)"
-        ),
-    )(f)
-    f = click.option(
-        "--domain-name",
-        help=(
-            "DNS host name for the collection (mapped "
-            "collections only). This may be either a host name "
-            "or a fully-qualified domain name, but if it is the latter "
-            "it must be a subdomain of the endpoint's domain"
-        ),
-    )(f)
-
-    f = click.option(
-        "--enable-https",
-        is_flag=True,
-        help=(
-            "Explicitly enable HTTPS supprt (requires a managed endpoint "
-            "with API v1.1.0)"
-        ),
-    )(f)
-    f = click.option(
-        "--disable-https",
-        is_flag=True,
-        help=(
-            "Explicitly disable HTTPS supprt (requires a managed endpoint "
-            "with API v1.1.0)"
-        ),
-    )(f)
-    f = mutex_option_group("--enable-https", "--disable-https")(f)
-
-    f = click.option(
-        "--user-message",
-        help=(
-            "A message for clients to display to users when interacting "
-            "with this collection"
-        ),
-        type=StringOrNull(),
-    )(f)
-    f = click.option(
-        "--user-message-link",
-        help=(
-            "Link to additional messaging for clients to display to users "
-            "when interacting with this endpoint, linked to an http or https URL "
-            "with this collection"
-        ),
-        type=UrlOrNull(),
-    )(f)
-    f = click.option(
-        "--sharing-user-allow",
-        "sharing_users_allow",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "Connector-specific username allowed to create guest collections."
-            f"{multi_use_option_str} to allow multiple users. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--sharing-user-deny",
-        "sharing_users_deny",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "Connector-specific username denied permission to create guest "
-            f"collections. {multi_use_option_str} to deny multiple users. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--posix-sharing-group-allow",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "POSIX group allowed access to create guest collections "
-            "(POSIX Connector Only). "
-            f"{multi_use_option_str} to allow multiple groups. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--posix-sharing-group-deny",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "POSIX group denied permission to create guest collections "
-            "(POSIX Connector Only). "
-            f"{multi_use_option_str} to deny multiple groups. "
-            + 'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--google-project-id",
-        help=(
-            "For Google Cloud Storage backed Collections only. The Google "
-            "Cloud Platform project ID which is used by this Collection"
-        ),
-        type=StringOrNull(),
-    )(f)
-
-    # POSIX Staging connector (GCS v5.4.10)
-    f = click.option(
-        "--posix-staging-sharing-group-allow",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "POSIX group allowed access to create guest collections "
-            "(POSIX Staging Connector Only). "
-            f"{multi_use_option_str} to allow multiple groups. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    f = click.option(
-        "--posix-staging-sharing-group-deny",
-        multiple=True,
-        callback=nullable_multi_callback(""),
-        help=(
-            "POSIX group denied permission to create guest collections "
-            "(POSIX Staging Connector Only). "
-            f"{multi_use_option_str} to deny multiple groups. "
-            'Set a value of "" to clear this'
-        ),
-    )(f)
-    return f
+def _make_multi_use_option_str(s: str) -> str:
+    return f"Give this option multiple times to {s}."
 
 
 @command("create", short_help="Create a new Mapped Collection")
 @endpoint_id_arg
-@endpointish_params.create(name="collection")
-@collection_create_params
+@click.option(
+    "--base-path",
+    default="/",
+    show_default=True,
+    help="The location within the storage gateway where the collection is rooted.",
+)
+@click.option(
+    "--storage-gateway",
+    help=(
+        "The storage gateway ID to host this collection. "
+        "If no value is provided but the endpoint has exactly one gateway, "
+        "that gateway will be used by default."
+    ),
+)
+@click.option(
+    "--public/--private",
+    "public",
+    default=True,
+    help="Set the collection to be public or private.",
+)
+@click.option(
+    "--sharing-restrict-paths",
+    type=JSONStringOrFile(null="null"),
+    help=(
+        "Path restrictions for sharing data on guest collections "
+        "based on this collection."
+    ),
+)
+@click.option(
+    "--allow-guest-collections/--no-allow-guest-collections",
+    default=None,
+    help=(
+        "Allow Guest Collections to be created on this Collection. "
+        "If this option is later disabled on a Mapped Collection which has associated "
+        "Guest Collections, those collections will no longer be accessible."
+    ),
+)
+@click.option(
+    "--disable-anonymous-writes/--enable-anonymous-writes",
+    default=None,
+    help=(
+        "Allow anonymous write ACLs on Guest Collections attached to this "
+        "Mapped Collection. This option is only usable on non high assurance "
+        "Mapped Collections and the setting is inherited by the hosted Guest "
+        "Collections. Anonymous write ACLs are enabled by default "
+        "(requires an endpoint with API v1.8.0)."
+    ),
+)
+@click.option(
+    "--domain-name",
+    help=(
+        "DNS host name for the collection. This may be either a host name "
+        "or a fully-qualified domain name, but if it is the latter "
+        "it must be a subdomain of the endpoint's domain."
+    ),
+)
 @click.option(
     "--identity-id",
     help=(
         "Globus Auth identity to who acts as the owner of this Collection. This "
-        "identity must be an administrator on the Endpoint"
+        "identity must be an administrator on the Endpoint."
     ),
 )
-@LoginManager.requires_login(LoginManager.TRANSFER_RS, LoginManager.AUTH_RS)
+@click.option(
+    "--enable-https/--disable-https",
+    "enable_https",
+    default=None,
+    help=(
+        "Explicitly enable or disable  HTTPS support (requires a managed endpoint "
+        "with API v1.1.0)"
+    ),
+)
+@click.option(
+    "--sharing-user-allow",
+    "sharing_users_allow",
+    multiple=True,
+    help=(
+        "Connector-specific username allowed to create guest collections."
+        + _make_multi_use_option_str("allow multiple users")
+    ),
+)
+@click.option(
+    "--sharing-user-deny",
+    "sharing_users_deny",
+    multiple=True,
+    help=(
+        "Connector-specific username denied permission to create guest collections. "
+        + _make_multi_use_option_str("deny multiple users")
+    ),
+)
+@click.option(
+    "--posix-sharing-group-allow",
+    multiple=True,
+    help=(
+        "POSIX group allowed access to create guest collections "
+        + "(POSIX Connector only). "
+        + _make_multi_use_option_str("allow multiple groups")
+    ),
+)
+@click.option(
+    "--posix-sharing-group-deny",
+    multiple=True,
+    help=(
+        "POSIX group denied permission to create guest collections "
+        + "(POSIX Connector only). "
+        + _make_multi_use_option_str("deny multiple groups")
+    ),
+)
+@click.option(
+    "--google-project-id",
+    help=(
+        "The Google Cloud Platform project ID which is used by this Collection "
+        "(Google Cloud Storage backed Collections only)."
+    ),
+)
+@click.option(
+    # POSIX Staging connector (GCS v5.4.10)
+    "--posix-staging-sharing-group-allow",
+    multiple=True,
+    help=(
+        "POSIX group allowed access to create guest collections "
+        + "(POSIX Staging Connector Only). "
+        + _make_multi_use_option_str("allow multiple groups")
+    ),
+)
+@click.option(
+    "--posix-staging-sharing-group-deny",
+    multiple=True,
+    help=(
+        "POSIX group denied permission to create guest collections "
+        + "(POSIX Staging Connector Only). "
+        + _make_multi_use_option_str("deny multiple groups")
+    ),
+)
+@endpointish_params.create(name="collection")
+@LoginManager.requires_login("auth", "transfer")
 def collection_create_mapped(
-    *,
     login_manager: LoginManager,
+    *,
     # positional args
-    endpoint_id: uuid.UUID,
     base_path: str,
     display_name: str,
+    endpoint_id: uuid.UUID,
     # options
-    storage_gateway: str | None,
-    public: bool,
-    description: str | None,
-    info_link: str | None,
-    contact_info: str | None,
-    contact_email: str | None,
-    organization: str | None,
-    department: str | None,
-    keywords: list[str] | None,
-    default_directory: str | None,
-    force_encryption: bool | None,
-    domain_name: str | None,
-    disable_anonymous_writes: bool | None,
-    identity_id: str | None,
-    google_project_id: str | None,
-    posix_sharing_group_allow: t.Iterable[str] | None,
-    posix_sharing_group_deny: t.Iterable[str] | None,
-    posix_staging_sharing_group_allow: t.Iterable[str] | None,
-    posix_staging_sharing_group_deny: t.Iterable[str] | None,
-    sharing_restrict_paths: t.Dict[str, t.Iterable[str]] | None | ExplicitNullType,
     allow_guest_collections: bool | None,
-    sharing_users_allow: t.Iterable[str] | None,
-    sharing_users_deny: t.Iterable[str] | None,
+    contact_email: str | None | ExplicitNullType,
+    contact_info: str | None | ExplicitNullType,
+    default_directory: str | None | ExplicitNullType,
+    department: str | None | ExplicitNullType,
+    description: str | None | ExplicitNullType,
+    disable_anonymous_writes: bool | None,
+    domain_name: str | None,
+    enable_https: bool | None,
+    force_encryption: bool | None,
+    google_project_id: str | None,
+    identity_id: str | None,
+    info_link: str | None | ExplicitNullType,
+    keywords: list[str] | None,
+    organization: str | None | ExplicitNullType,
+    posix_sharing_group_allow: tuple[str, ...],
+    posix_sharing_group_deny: tuple[str, ...],
+    posix_staging_sharing_group_allow: tuple[str, ...],
+    posix_staging_sharing_group_deny: tuple[str, ...],
+    public: bool,
+    sharing_restrict_paths: ParsedJSONData | None | ExplicitNullType,
+    sharing_users_allow: tuple[str, ...],
+    sharing_users_deny: tuple[str, ...],
+    storage_gateway: str | None,
     user_message: str | None | ExplicitNullType,
     user_message_link: str | None | ExplicitNullType,
-    enable_https: bool | None,
-    disable_https: bool | None,
-    verify: str | None,
+    verify: dict[str, bool],
 ) -> None:
     """
     Create a new Mapped Collection, rooted on some given path within an
@@ -251,6 +204,11 @@ def collection_create_mapped(
     and there is only one storage gateway on the endpoint, that gateway will be used.
     Otherwise, '--storage-gateway' is required.
     """
+    if isinstance(sharing_restrict_paths, ParsedJSONData) and not isinstance(
+        sharing_restrict_paths.data, dict
+    ):
+        raise click.UsageError("--sharing-restrict-paths must be a JSON object")
+
     gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
     if storage_gateway is not None:
         storage_gateway_id = storage_gateway
@@ -269,78 +227,68 @@ def collection_create_mapped(
                 "You must specify which one to use with the --storage-gateway option."
             )
 
-    policies: t.Optional[globus_sdk.CollectionPolicies] = None
+    policies: globus_sdk.CollectionPolicies | None = None
     if google_project_id is not None:
         policies = globus_sdk.GoogleCloudStorageCollectionPolicies(
             project=google_project_id
         )
 
-    if posix_sharing_group_allow is not None or posix_sharing_group_deny is not None:
+    if posix_sharing_group_allow or posix_sharing_group_deny:
         if policies is not None:
-            raise click.UsageError("Incompatible policy options detected")
+            raise click.UsageError("Incompatible policy options detected.")
         # Added in 5.4.8 for POSIX connector
         policies = globus_sdk.POSIXCollectionPolicies(
             sharing_groups_allow=posix_sharing_group_allow,
             sharing_groups_deny=posix_sharing_group_deny,
         )
 
-    if (
-        posix_staging_sharing_group_allow is not None
-        or posix_staging_sharing_group_deny is not None
-    ):
+    if posix_staging_sharing_group_allow or posix_staging_sharing_group_deny:
         if policies is not None:
-            raise click.UsageError("Incompatible policy options detected")
+            raise click.UsageError("Incompatible policy options detected.")
         # Added in 5.4.10 for POSIX staging connector
         policies = globus_sdk.POSIXStagingCollectionPolicies(
             sharing_groups_allow=posix_staging_sharing_group_allow,
             sharing_groups_deny=posix_staging_sharing_group_deny,
         )
 
-    # These are added in GCS 5.4.4, so if neither --enable-https or
-    # --disable-https are set, then we'll not try to set the value for
-    # backward compatibility
-    if enable_https is False:
-        enable_https = None
-    if disable_https:
-        enable_https = False
-
-    force_verify: bool | None = None
-    disable_verify: bool | None = None
-    if verify is not None:
-        if verify.lower() == "force":
-            force_verify, disable_verify = True, False
-        elif verify.lower() == "disable":
-            force_verify, disable_verify = False, True
-        else:
-            force_verify, disable_verify = False, False
+    converted_kwargs: dict[str, t.Any] = ExplicitNullType.nullify_dict(
+        {
+            # required arguments
+            "collection_base_path": base_path,
+            "display_name": display_name,
+            # options
+            "allow_guest_collections": allow_guest_collections,
+            "contact_email": contact_email,
+            "contact_info": contact_info,
+            "default_directory": default_directory,
+            "department": department,
+            "description": description,
+            "disable_anonymous_writes": disable_anonymous_writes,
+            "domain_name": domain_name,
+            "enable_https": enable_https,
+            "force_encryption": force_encryption,
+            "identity_id": identity_id,
+            "info_link": info_link,
+            "keywords": keywords,
+            "organization": organization,
+            "policies": policies,
+            "public": public,
+            "sharing_restrict_paths": (
+                sharing_restrict_paths.data
+                if isinstance(sharing_restrict_paths, ParsedJSONData)
+                else sharing_restrict_paths
+            ),
+            "sharing_users_allow": sharing_users_allow,
+            "sharing_users_deny": sharing_users_deny,
+            "storage_gateway_id": storage_gateway_id,
+            "user_message": user_message,
+            "user_message_link": user_message_link,
+        }
+    )
+    converted_kwargs.update(verify)
 
     collection_doc = globus_sdk.MappedCollectionDocument(
-        storage_gateway_id=storage_gateway_id,
-        collection_base_path=base_path,
-        display_name=display_name,
-        public=public,
-        description=description,
-        info_link=info_link,
-        contact_info=contact_info,
-        contact_email=contact_email,
-        organization=organization,
-        department=department,
-        keywords=keywords,
-        default_directory=default_directory,
-        force_encryption=force_encryption,
-        domain_name=domain_name,
-        disable_anonymous_writes=disable_anonymous_writes,
-        identity_id=identity_id,
-        policies=policies,
-        allow_guest_collections=allow_guest_collections,
-        sharing_users_allow=sharing_users_allow,
-        sharing_users_deny=sharing_users_deny,
-        sharing_restrict_paths=ExplicitNullType.nullify(sharing_restrict_paths),
-        user_message=ExplicitNullType.nullify(user_message),
-        user_message_link=ExplicitNullType.nullify(user_message_link),
-        enable_https=enable_https,
-        disable_verify=disable_verify,
-        force_verify=force_verify,
+        **converted_kwargs,
     )
     res = gcs_client.create_collection(collection_doc)
 

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -43,12 +43,6 @@ def _make_multi_use_option_str(s: str) -> str:
     ),
 )
 @click.option(
-    "--public/--private",
-    "public",
-    default=True,
-    help="Set the collection to be public or private.",
-)
-@click.option(
     "--sharing-restrict-paths",
     type=JSONStringOrFile(null="null"),
     help=(

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -7,7 +7,9 @@ import click
 import globus_sdk
 
 from globus_cli.commands.collection._common import (
+    LazyCurrentIdentity,
     filter_fields,
+    identity_id_option,
     standard_collection_fields,
 )
 from globus_cli.constants import ExplicitNullType
@@ -28,6 +30,8 @@ def _make_multi_use_option_str(s: str) -> str:
 
 @command("create", short_help="Create a new Mapped Collection")
 @endpoint_id_arg
+@endpointish_params.create(name="collection")
+@identity_id_option
 @click.option(
     "--base-path",
     default="/",
@@ -76,13 +80,6 @@ def _make_multi_use_option_str(s: str) -> str:
         "DNS host name for the collection. This may be either a host name "
         "or a fully-qualified domain name, but if it is the latter "
         "it must be a subdomain of the endpoint's domain."
-    ),
-)
-@click.option(
-    "--identity-id",
-    help=(
-        "Globus Auth identity to who acts as the owner of this Collection. This "
-        "identity must be an administrator on the Endpoint."
     ),
 )
 @click.option(
@@ -156,7 +153,6 @@ def _make_multi_use_option_str(s: str) -> str:
         + _make_multi_use_option_str("deny multiple groups")
     ),
 )
-@endpointish_params.create(name="collection")
 @LoginManager.requires_login("auth", "transfer")
 def collection_create_mapped(
     login_manager: LoginManager,
@@ -177,7 +173,7 @@ def collection_create_mapped(
     enable_https: bool | None,
     force_encryption: bool | None,
     google_project_id: str | None,
-    identity_id: str | None,
+    identity_id: LazyCurrentIdentity,
     info_link: str | None | ExplicitNullType,
     keywords: list[str] | None,
     organization: str | None | ExplicitNullType,
@@ -263,7 +259,7 @@ def collection_create_mapped(
             "domain_name": domain_name,
             "enable_https": enable_https,
             "force_encryption": force_encryption,
-            "identity_id": identity_id,
+            "identity_id": identity_id.value,
             "info_link": info_link,
             "keywords": keywords,
             "organization": organization,

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -36,12 +36,6 @@ class _FullDataField(Field):
 @collection_id_arg
 @endpointish_params.update(name="collection")
 @click.option(
-    "--public/--private",
-    "public",
-    default=None,
-    help="Set the collection to be public or private",
-)
-@click.option(
     "--force-encryption/--no-force-encryption",
     "force_encryption",
     default=None,

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -31,11 +31,8 @@ GCP_FIELDS = [Field("Setup Key", "globus_connect_setup_key")]
 
 @command("create", deprecated=True, hidden=True)
 @endpointish_params.create(
-    name="endpoint",
-    keyword_style="string",
-    verify_style="flag",
+    name="endpoint", keyword_style="string", verify_style="flag", add_legacy_params=True
 )
-@endpointish_params.legacy_transfer_params()
 @one_use_option(
     "--personal",
     is_flag=True,
@@ -94,7 +91,7 @@ def endpoint_create(
     organization: str | None | ExplicitNullType,
     preferred_concurrency: int | None,
     preferred_parallelism: int | None,
-    public: bool | None,
+    public: bool,
     subscription_id: uuid.UUID | None,
     user_message: str | None | ExplicitNullType,
     user_message_link: str | None | ExplicitNullType,

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -26,8 +26,9 @@ else:
 
 @command("update")
 @endpoint_id_arg
-@endpointish_params.update(name="endpoint", keyword_style="string", verify_style="flag")
-@endpointish_params.legacy_transfer_params()
+@endpointish_params.update(
+    name="endpoint", keyword_style="string", verify_style="flag", add_legacy_params=True
+)
 @click.option(
     "--no-default-directory",
     is_flag=True,

--- a/src/globus_cli/commands/gcp/create/guest.py
+++ b/src/globus_cli/commands/gcp/create/guest.py
@@ -16,7 +16,7 @@ from ._common import deprecated_verify_option
 @endpointish_params.create(
     name="collection",
     keyword_style="string",
-    skip=("user_message", "user_message_link"),
+    skip=("user_message", "user_message_link", "public"),
 )
 @click.argument("HOST_GCP_PATH", type=ENDPOINT_PLUS_REQPATH)
 @deprecated_verify_option

--- a/src/globus_cli/commands/gcp/create/mapped.py
+++ b/src/globus_cli/commands/gcp/create/mapped.py
@@ -16,7 +16,6 @@ from ._common import deprecated_verify_option
     "--subscription-id",
     help="Set the collection as managed with the given subscription ID",
 )
-@click.option("--public", is_flag=True, help="Set the collection to be public.")
 @deprecated_verify_option
 @LoginManager.requires_login("transfer")
 def mapped_command(

--- a/src/globus_cli/commands/gcp/update/guest.py
+++ b/src/globus_cli/commands/gcp/update/guest.py
@@ -13,7 +13,7 @@ from globus_cli.termio import TextMode, display
 @endpointish_params.update(
     name="collection",
     keyword_style="string",
-    skip=("user_message", "user_message_link"),
+    skip=("user_message", "user_message_link", "public"),
 )
 @LoginManager.requires_login("transfer")
 def guest_command(

--- a/src/globus_cli/commands/gcp/update/mapped.py
+++ b/src/globus_cli/commands/gcp/update/mapped.py
@@ -17,12 +17,6 @@ from globus_cli.termio import TextMode, display
     "--subscription-id",
     help="Set the collection as managed with the given subscription ID",
 )
-@click.option(
-    "--public/--private",
-    default=None,
-    is_flag=True,
-    help="Set the collection to be public or private.",
-)
 @LoginManager.requires_login("transfer")
 def mapped_command(
     login_manager: LoginManager,

--- a/tests/functional/collection/test_collection_create_mapped.py
+++ b/tests/functional/collection/test_collection_create_mapped.py
@@ -249,7 +249,7 @@ def test_mapped_collection_create(
 
     cmd = ["globus", "gcs", "collection", "create", "mapped", epid, "/"]
     if not implicit_storage_gateway:
-        cmd.extend(["--storage-gateway", create_meta["storage_gateway_id"]])
+        cmd.extend(["--storage-gateway-id", create_meta["storage_gateway_id"]])
 
     add_gcs_login(epid)
     run_line(

--- a/tests/functional/collection/test_collection_create_mapped.py
+++ b/tests/functional/collection/test_collection_create_mapped.py
@@ -1,0 +1,385 @@
+import uuid
+
+import pytest
+from globus_sdk._testing import load_response, register_response_set
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _register_responses():
+    storage_gateway_id = str(uuid.uuid4())
+    collection_id = str(uuid.uuid4())
+    domain = "globus.org"
+    username = f"gargamel@{domain}"
+    identity_id = str(uuid.uuid4())
+    endpoint_id = str(uuid.uuid4())
+
+    register_response_set(
+        "cli.collection_create_mapped.storage_gateway_list",
+        {
+            "default": {
+                "service": "gcs",
+                "path": "/storage_gateways",
+                "method": "GET",
+                "json": {
+                    "DATA_TYPE": "result#1.0.0",
+                    "code": "success",
+                    "data": [
+                        {
+                            "DATA_TYPE": "storage_gateway#1.2.0",
+                            "admin_managed_credentials": False,
+                            "allowed_domains": [domain],
+                            "authentication_timeout_mins": 15840,
+                            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                            "display_name": "localposix",
+                            "high_assurance": False,
+                            "id": storage_gateway_id,
+                            "policies": {"DATA_TYPE": "posix_storage_policies#1.0.0"},
+                            "require_high_assurance": False,
+                            "require_mfa": False,
+                        }
+                    ],
+                    "detail": "success",
+                    "has_next_page": False,
+                    "http_response_code": 200,
+                },
+                "metadata": {
+                    "storage_gateway_id": storage_gateway_id,
+                    "domain": domain,
+                },
+            },
+            "multiple": {
+                "service": "gcs",
+                "path": "/storage_gateways",
+                "method": "GET",
+                "json": {
+                    "DATA_TYPE": "result#1.0.0",
+                    "code": "success",
+                    "data": [
+                        {
+                            "DATA_TYPE": "storage_gateway#1.2.0",
+                            "admin_managed_credentials": False,
+                            "allowed_domains": [domain],
+                            "authentication_timeout_mins": 15840,
+                            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                            "display_name": "localposix",
+                            "high_assurance": False,
+                            "id": storage_gateway_id,
+                            "policies": {"DATA_TYPE": "posix_storage_policies#1.0.0"},
+                            "require_high_assurance": False,
+                            "require_mfa": False,
+                        },
+                        {
+                            "DATA_TYPE": "storage_gateway#1.2.0",
+                            "admin_managed_credentials": False,
+                            "allowed_domains": [domain],
+                            "authentication_timeout_mins": 15840,
+                            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                            "display_name": "localposix2",
+                            "high_assurance": False,
+                            "id": str(uuid.uuid4()),
+                            "policies": {"DATA_TYPE": "posix_storage_policies#1.0.0"},
+                            "require_high_assurance": False,
+                            "require_mfa": False,
+                        },
+                    ],
+                    "detail": "success",
+                    "has_next_page": False,
+                    "http_response_code": 200,
+                },
+                "metadata": {
+                    "storage_gateway_id": storage_gateway_id,
+                    "domain": domain,
+                },
+            },
+            "empty": {
+                "service": "gcs",
+                "path": "/storage_gateways",
+                "method": "GET",
+                "json": {
+                    "DATA_TYPE": "result#1.0.0",
+                    "code": "success",
+                    "data": [],
+                    "detail": "success",
+                    "has_next_page": False,
+                    "http_response_code": 200,
+                },
+            },
+        },
+    )
+
+    register_response_set(
+        "cli.collection_create_mapped.mapped_collection_create",
+        {
+            "default": {
+                "service": "gcs",
+                "path": "/collections",
+                "method": "POST",
+                "json": {
+                    "DATA_TYPE": "result#1.0.0",
+                    "code": "success",
+                    "data": [
+                        {
+                            "DATA_TYPE": "collection#1.9.0",
+                            "allow_guest_collections": False,
+                            "authentication_timeout_mins": 15840,
+                            "collection_type": "mapped",
+                            "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                            "contact_email": username,
+                            "created_at": "2023-12-12",
+                            "delete_protected": True,
+                            "disable_anonymous_writes": False,
+                            "disable_verify": False,
+                            "display_name": "myposix",
+                            "domain_name": "foo.abc.xyz.data.globus.org",
+                            "enable_https": True,
+                            "force_encryption": False,
+                            "force_verify": False,
+                            "high_assurance": False,
+                            "https_url": None,
+                            "id": collection_id,
+                            "identity_id": identity_id,
+                            "last_access": None,
+                            "manager_url": "https://abc.xyz.data.globus.org",
+                            "policies": {
+                                "DATA_TYPE": "posix_collection_policies#1.1.0"
+                            },
+                            "public": True,
+                            "require_mfa": False,
+                            "storage_gateway_id": storage_gateway_id,
+                            "tlsftp_url": "tlsftp://foo.abc.xyz.data.globus.org:443",
+                        }
+                    ],
+                    "detail": "success",
+                    "has_next_page": False,
+                    "http_response_code": 200,
+                },
+                "metadata": {
+                    "collection_id": collection_id,
+                    "username": username,
+                    "domain": domain,
+                    "identity_id": identity_id,
+                    "storage_gateway_id": storage_gateway_id,
+                },
+            }
+        },
+    )
+
+    register_response_set(
+        "cli.collection_create_mapped.get_endpoint",
+        {
+            "default": {
+                "service": "transfer",
+                "path": f"/endpoint/{endpoint_id}",
+                "method": "GET",
+                "json": {
+                    "DATA": [
+                        {"DATA_TYPE": "server", "hostname": "abc.xyz.data.globus.org"}
+                    ],
+                    "DATA_TYPE": "endpoint",
+                    "canonical_name": f"{endpoint_id}#{endpoint_id}",
+                    "description": "example gcsv5 endpoint",
+                    "display_name": "Happy Fun Endpoint",
+                    "entity_type": "GCSv5_endpoint",
+                    "gcs_manager_url": "https://abc.xyz.data.globus.org",
+                    "gcs_version": "5.4.71",
+                    "id": endpoint_id,
+                    "is_globus_connect": False,
+                    "non_functional": True,
+                    "owner_id": endpoint_id,
+                    "owner_string": f"{endpoint_id}@clients.auth.globus.org",
+                    "subscription_id": None,
+                },
+                "metadata": {"endpoint_id": endpoint_id},
+            }
+        },
+    )
+
+    register_response_set(
+        "cli.collection_create_mapped.get_identities",
+        {
+            "default": {
+                "service": "auth",
+                "path": "/v2/api/identities",
+                "method": "GET",
+                "json": {
+                    "identities": [
+                        {
+                            "email": username,
+                            "id": identity_id,
+                            "identity_provider": str(uuid.uuid4()),
+                            "name": "Gargamel Smurfnapper",
+                            # Azrael is his cat
+                            "organization": "Friends of Azrael",
+                            "status": "used",
+                            "username": username,
+                        }
+                    ]
+                },
+            }
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "only_one_storage_gateway, implicit_storage_gateway",
+    (
+        (False, False),
+        (True, False),
+        (True, True),
+    ),
+)
+def test_mapped_collection_create(
+    run_line,
+    add_gcs_login,
+    only_one_storage_gateway,
+    implicit_storage_gateway,
+):
+    load_response("cli.collection_create_mapped.get_identities")
+    load_response(
+        "cli.collection_create_mapped.storage_gateway_list",
+        case="default" if only_one_storage_gateway else "multiple",
+    )
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+    create_meta = load_response(
+        "cli.collection_create_mapped.mapped_collection_create"
+    ).metadata
+
+    owner_username = create_meta["username"]
+    epid = gcs_meta["endpoint_id"]
+
+    cmd = ["globus", "gcs", "collection", "create", "mapped", epid, "/"]
+    if not implicit_storage_gateway:
+        cmd.extend(["--storage-gateway", create_meta["storage_gateway_id"]])
+
+    add_gcs_login(epid)
+    run_line(
+        cmd,
+        search_stdout=[
+            ("Storage Gateway ID", create_meta["storage_gateway_id"]),
+            ("Owner", owner_username),
+        ],
+    )
+
+
+def test_mapped_collection_create_fails_on_multiple_storage_gateways_unspecified(
+    run_line, add_gcs_login
+):
+    load_response("cli.collection_create_mapped.storage_gateway_list", case="multiple")
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+    epid = gcs_meta["endpoint_id"]
+
+    add_gcs_login(epid)
+    run_line(
+        f"globus gcs collection create mapped {epid} /",
+        assert_exit_code=2,
+        search_stderr="This endpoint has multiple storage gateways.",
+    )
+
+
+def test_mapped_collection_create_fails_no_storage_gateways(run_line, add_gcs_login):
+    load_response("cli.collection_create_mapped.storage_gateway_list", case="empty")
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+    epid = gcs_meta["endpoint_id"]
+
+    add_gcs_login(epid)
+    run_line(
+        f"globus gcs collection create mapped {epid} /",
+        assert_exit_code=2,
+        search_stderr="This endpoint does not have any storage gateways.",
+    )
+
+
+def test_mapped_collection_create_invalid_sharing_restrict_paths(run_line):
+    run_line(
+        (
+            f"globus gcs collection create mapped {uuid.uuid4()} / "
+            "--sharing-restrict-paths 0"
+        ),
+        assert_exit_code=2,
+        search_stderr="--sharing-restrict-paths must be a JSON object",
+    )
+
+
+@pytest.mark.parametrize(
+    "add_opts",
+    (
+        ["--google-project-id", "fooid"],
+        ["--posix-sharing-group-allow", "foo", "--posix-sharing-group-deny", "bar"],
+        [
+            "--posix-staging-sharing-group-allow",
+            "foo",
+            "--posix-staging-sharing-group-deny",
+            "bar",
+        ],
+    ),
+)
+def test_mapped_collection_create_accepts_various_policy_options(
+    run_line,
+    add_gcs_login,
+    add_opts,
+):
+    load_response("cli.collection_create_mapped.get_identities")
+    load_response("cli.collection_create_mapped.storage_gateway_list")
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+    create_meta = load_response(
+        "cli.collection_create_mapped.mapped_collection_create"
+    ).metadata
+
+    owner_username = create_meta["username"]
+    epid = gcs_meta["endpoint_id"]
+
+    cmd = ["globus", "gcs", "collection", "create", "mapped", epid, "/"] + add_opts
+
+    add_gcs_login(epid)
+    run_line(
+        cmd,
+        search_stdout=[
+            ("Storage Gateway ID", create_meta["storage_gateway_id"]),
+            ("Owner", owner_username),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "add_opts",
+    (
+        pytest.param(
+            ["--google-project-id", "fooid", "--posix-sharing-group-allow", "foo"],
+            id="google+posix",
+        ),
+        pytest.param(
+            [
+                "--google-project-id",
+                "fooid",
+                "--posix-staging-sharing-group-allow",
+                "foo",
+            ],
+            id="google+posix-staging",
+        ),
+        pytest.param(
+            [
+                "--posix-sharing-group-allow",
+                "foo",
+                "--posix-staging-sharing-group-allow",
+                "foo",
+            ],
+            id="posix+posix-staging",
+        ),
+    ),
+)
+def test_mapped_collection_create_rejects_incompatible_policy_options(
+    run_line,
+    add_gcs_login,
+    add_opts,
+):
+    load_response("cli.collection_create_mapped.storage_gateway_list")
+    gcs_meta = load_response("cli.collection_create_mapped.get_endpoint").metadata
+
+    epid = gcs_meta["endpoint_id"]
+
+    cmd = ["globus", "gcs", "collection", "create", "mapped", epid, "/"] + add_opts
+
+    add_gcs_login(epid)
+    run_line(
+        cmd, assert_exit_code=2, search_stderr="Incompatible policy options detected."
+    )


### PR DESCRIPTION
Introduce a new command, `globus gcs collection create mapped` (also available under `globus collection`).

In addition to the new command and tests, the following related improvements have been introduced here:

- `--public/--private` is now implemented once in the whole CLI, and shared between the multiple endpoint and collection variants as appropriate.
- In service of the above, passing legacy parameters for `globus endpoint` commands has been slightly refactored.
- `--identity-id` (also used by `globus gcs collection create guest`) now uses a common option definition

Some particular notes on issues from past variants of this:

- An earlier draft used `--storage-gateway`, with some justification that this would be future compatible with various ways of selecting and specifying gateways.

Given how the Guest creation command has evolved in a similar space (user credentials), I don't think this is likely to be our future path.
The option is now named `--storage-gateway-id` to harmonize it with the API's field name.

- Further consolidation of options may be possible.

After doing `--public/--private` and `--identity-id` and seeing the level of impact those changes carry, I've decided not to make any more changes in this scope of work.

- `mutex_option_group` application makes policy options "cleanly" mutex, but doesn't solve the larger interface complexity.

Because different connectors carry different expectations and constraints, `--google-project-id` is an option to mapped collection creation, but "obviously" incompatible with a posix storage gateway.
Similarly, the POSIX options aren't sensible on a Google Cloud Storage or S3 backed collection.

This is a minor interface problem for a CLI -- mapped creation may or may not need various options, and they need to harmonize with the backend requirements, which means that users cannot use the CLI presentation of options to learn what they need to provide.
For now, we're following the lead of the GCS team in the prior art provided by the gcs-cli: mapped collection creation simply allows these various options as siblings and treats them as mutex.

---

The full commit history here reveals the fact that this is an older body of work which was rebased.

- Port 'collection create mapped' from gcs-cli
- Improve defaults for 'collection create mapped'
- Convert GCP mapped create to common params
- Update 'collection create mapped' after rebase
- Add testing of 'collection create mapped'
- Consolidate the `--public/--private` option
- Update mapped creation to use --storage-gateway-id
- Make `--identity-id` a common option definition
- Mapped collection mutex policies use proper mutex
- Add changelog for mapped collection create
