### PR TITLE
Update to SDK v3.34.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=[
-        "globus-sdk==3.33.0",
+        "globus-sdk==3.34.0",
         "click>=8.1.4,<9",
         "jmespath==1.0.1",
         "packaging>=17.0",

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -87,7 +87,9 @@ class LoginManager:
     def _validate_token(self, token: str) -> bool:
         auth_client = internal_auth_client()
         try:
-            res = auth_client.oauth2_validate_token(token)
+            res = auth_client.post(
+                "/v2/oauth2/token/validate", data={"token": token}, encoding="form"
+            )
         # if the instance client is invalid, an AuthAPIError will be raised
         except globus_sdk.AuthAPIError:
             return False

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -20,7 +20,7 @@ def test_login_validates_token(
     disable_login_manager_validate_token.undo()
 
     with mock.patch("globus_cli.login_manager.manager.internal_auth_client") as m:
-        ac = mock.MagicMock(spec=globus_sdk.NativeAppAuthClient)
+        ac = mock.MagicMock(spec=globus_sdk.ConfidentialAppAuthClient)
         m.return_value = ac
 
         run_line("globus login")
@@ -28,8 +28,12 @@ def test_login_validates_token(
         by_rs = mock_login_token_response.by_resource_server
         a_rt = by_rs["auth.globus.org"]["refresh_token"]
         t_rt = by_rs["transfer.api.globus.org"]["refresh_token"]
-        ac.oauth2_validate_token.assert_any_call(a_rt)
-        ac.oauth2_validate_token.assert_any_call(t_rt)
+        ac.post.assert_any_call(
+            "/v2/oauth2/token/validate", data={"token": a_rt}, encoding="form"
+        )
+        ac.post.assert_any_call(
+            "/v2/oauth2/token/validate", data={"token": t_rt}, encoding="form"
+        )
 
 
 class MockToken:


### PR DESCRIPTION
This version of the SDK deprecates `oauth2_validate_token`, so the
change replaces it with a direct form-encoded POST in order to
maintain the exact same behavior in the CLI for now.
