### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # we do not want a large number of windows and macos builds, so
         # enumerate them explicitly
         include:
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         id: setup-python
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: |
             .github/workflows/build.yaml
@@ -240,7 +240,7 @@ jobs:
   test-sdk-main:
     strategy:
       matrix:
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.8", "3.12"]
     runs-on: ubuntu-latest
     name: "sdk-main"
     steps:
@@ -283,7 +283,7 @@ jobs:
 
   # use the oldest python version we support for this build
   test-ancient-virtualenv:
-    name: "test on py3.7, using old virtualenv"
+    name: "test on py3.8, using old virtualenv"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -291,7 +291,7 @@ jobs:
         run: date +'%V' > week-number.txt
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: |
             .github/workflows/build.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   rev: v3.15.0
   hooks:
     - id: pyupgrade
-      args: ["--py36-plus"]
+      args: ["--py38-plus"]
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 23.12.1
   hooks:

--- a/changelog.d/20240109_104114_sirosen_drop_py37.md
+++ b/changelog.d/20240109_104114_sirosen_drop_py37.md
@@ -1,0 +1,3 @@
+### Other
+
+* Remove support for Python 3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,13 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "globus-sdk==3.34.0",
     "click>=8.1.4,<9",

--- a/src/globus_cli/_warnings.py
+++ b/src/globus_cli/_warnings.py
@@ -1,10 +1,5 @@
-import sys
+import typing as t
 import warnings
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 # this bool turns off all warning controls, handing control of python
 # warnings to the testsuite
@@ -13,7 +8,7 @@ _TEST_WARNING_CONTROL: bool = False
 
 
 def simplefilter(
-    filterstr: Literal["default", "error", "ignore", "always", "module", "once"]
+    filterstr: t.Literal["default", "error", "ignore", "always", "module", "once"]
 ) -> None:
     """
     wrap `warnings.simplefilter` with a check on `_TEST_WARNING_CONTROL`

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import sys
 import typing as t
 import uuid
 from collections import defaultdict
@@ -15,11 +14,6 @@ from globus_cli.login_manager.scopes import CLI_SCOPE_REQUIREMENTS
 from globus_cli.parsing import command, endpoint_id_arg, group, mutex_option_group
 from globus_cli.termio import display
 from globus_cli.types import ServiceNameLiteral
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
 
@@ -255,13 +249,13 @@ def _service_command_params(cmd: C) -> C:
 def _execute_service_command(
     client: globus_sdk.BaseClient,
     *,
-    method: Literal["HEAD", "GET", "PUT", "POST", "PATCH", "DELETE"],
+    method: t.Literal["HEAD", "GET", "PUT", "POST", "PATCH", "DELETE"],
     path: str,
     query_param: tuple[tuple[str, str], ...],
     header: tuple[tuple[str, str], ...],
     body: str | None,
     body_file: t.TextIO | None,
-    content_type: Literal["json", "form", "text", "none", "auto"],
+    content_type: t.Literal["json", "form", "text", "none", "auto"],
     allow_errors: bool,
     allow_redirects: bool,
     no_retry: bool,
@@ -356,7 +350,7 @@ def api_command() -> None:
 
 # note: this must be written as a separate call and not inlined into the loop body
 # this ensures that it acts as a closure over 'service_name'
-def build_command(service_name: ServiceNameLiteral | Literal["gcs"]) -> click.Command:
+def build_command(service_name: ServiceNameLiteral | t.Literal["gcs"]) -> click.Command:
     helptext = f"""\
 Make API calls to Globus {service_name.title()}
 
@@ -377,13 +371,13 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
         def service_command(
             login_manager: LoginManager,
             *,
-            method: Literal["HEAD", "GET", "PUT", "POST", "PATCH", "DELETE"],
+            method: t.Literal["HEAD", "GET", "PUT", "POST", "PATCH", "DELETE"],
             path: str,
             query_param: tuple[tuple[str, str], ...],
             header: tuple[tuple[str, str], ...],
             body: str | None,
             body_file: t.TextIO | None,
-            content_type: Literal["json", "form", "text", "none", "auto"],
+            content_type: t.Literal["json", "form", "text", "none", "auto"],
             allow_errors: bool,
             allow_redirects: bool,
             no_retry: bool,
@@ -419,13 +413,13 @@ sends a 'GET' request to '{_get_url(service_name)}foo/bar'
             login_manager: LoginManager,
             *,
             endpoint_id: uuid.UUID,
-            method: Literal["HEAD", "GET", "PUT", "POST", "PATCH", "DELETE"],
+            method: t.Literal["HEAD", "GET", "PUT", "POST", "PATCH", "DELETE"],
             path: str,
             query_param: tuple[tuple[str, str], ...],
             header: tuple[tuple[str, str], ...],
             body: str | None,
             body_file: t.TextIO | None,
-            content_type: Literal["json", "form", "text", "none", "auto"],
+            content_type: t.Literal["json", "form", "text", "none", "auto"],
             allow_errors: bool,
             allow_redirects: bool,
             no_retry: bool,

--- a/src/globus_cli/commands/collection/list.py
+++ b/src/globus_cli/commands/collection/list.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 import uuid
 
@@ -10,11 +9,6 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import Field, TextMode, display, formatters
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 class ChoiceSlugified(click.Choice):
     """
@@ -23,7 +17,7 @@ class ChoiceSlugified(click.Choice):
     """
 
     def get_type_annotation(self, param: click.Parameter) -> type:
-        return t.cast(type, Literal[tuple(self._slugify(c) for c in self.choices)])
+        return t.cast(type, t.Literal[tuple(self._slugify(c) for c in self.choices)])
 
     def convert(
         self, value: t.Any, param: click.Parameter | None, ctx: click.Context | None
@@ -95,7 +89,7 @@ def collection_list(
     endpoint_id: uuid.UUID,
     include_private_policies: bool,
     filters: tuple[
-        Literal[
+        t.Literal[
             "mapped_collections", "guest_collections", "managed_by_me", "created_by_me"
         ],
         ...,

--- a/src/globus_cli/commands/endpoint/create.py
+++ b/src/globus_cli/commands/endpoint/create.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 import uuid
 
 from globus_cli.constants import ExplicitNullType
@@ -16,11 +16,6 @@ from globus_cli.parsing import (
 from globus_cli.termio import Field, TextMode, display, print_command_hint
 
 from ._common import validate_endpoint_create_and_update_params
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 COMMON_FIELDS = [Field("Message", "message"), Field("Endpoint ID", "id")]
 
@@ -81,7 +76,7 @@ def endpoint_create(
     max_parallelism: int | None,
     myproxy_dn: str | None,
     myproxy_server: str | None,
-    network_use: Literal["normal", "minimal", "aggressive", "custom"] | None,
+    network_use: t.Literal["normal", "minimal", "aggressive", "custom"] | None,
     oauth_server: str | None,
     organization: str | None | ExplicitNullType,
     preferred_concurrency: int | None,

--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 import uuid
 
 import click
@@ -8,11 +8,6 @@ import click
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command, security_principal_opts
 from globus_cli.termio import Field, TextMode, display
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @command(
@@ -60,7 +55,7 @@ def create_command(
     login_manager: LoginManager,
     *,
     principal: tuple[str, str],
-    permissions: Literal["r", "rw"],
+    permissions: t.Literal["r", "rw"],
     endpoint_plus_path: tuple[uuid.UUID, str | None],
     notify_email: str | None,
     notify_message: str | None,

--- a/src/globus_cli/commands/endpoint/permission/update.py
+++ b/src/globus_cli/commands/endpoint/permission/update.py
@@ -1,4 +1,4 @@
-import sys
+import typing as t
 import uuid
 
 import click
@@ -6,11 +6,6 @@ import click
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import TextMode, display
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @command(
@@ -38,7 +33,7 @@ $ globus endpoint permission update $ep_id $rule_id --permissions r
 def update_command(
     login_manager: LoginManager,
     *,
-    permissions: Literal["r", "rw"],
+    permissions: t.Literal["r", "rw"],
     rule_id: str,
     endpoint_id: uuid.UUID,
 ) -> None:

--- a/src/globus_cli/commands/endpoint/role/create.py
+++ b/src/globus_cli/commands/endpoint/role/create.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 import uuid
 
 import click
@@ -8,11 +8,6 @@ import click
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg, security_principal_opts
 from globus_cli.termio import display
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @command(
@@ -47,7 +42,7 @@ $ globus endpoint role create 'aa752cea-8222-5bc8-acd9-555b090c0ccb' \
 def role_create(
     login_manager: LoginManager,
     *,
-    role: Literal[
+    role: t.Literal[
         "administrator", "access_manager", "activity_manager", "activity_monitor"
     ],
     principal: tuple[str, str],

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 
 import click
 from globus_sdk.paging import Paginator
@@ -9,11 +9,6 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import display
 from globus_cli.utils import PagingWrapper
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @command(
@@ -81,7 +76,7 @@ def endpoint_search(
     filter_fulltext: str | None,
     limit: int,
     filter_owner_id: str | None,
-    filter_scope: Literal[
+    filter_scope: t.Literal[
         "all",
         "administered-by-me",
         "my-endpoints",

--- a/src/globus_cli/commands/endpoint/server/add.py
+++ b/src/globus_cli/commands/endpoint/server/add.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 import uuid
 
 from globus_cli.login_manager import LoginManager
@@ -8,11 +8,6 @@ from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import TextMode, display
 
 from ._common import server_add_opts
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @command(
@@ -37,7 +32,7 @@ def server_add(
     endpoint_id: uuid.UUID,
     subject: str | None,
     port: int,
-    scheme: Literal["gsiftp", "ftp"],
+    scheme: t.Literal["gsiftp", "ftp"],
     hostname: str,
     incoming_data_ports: tuple[int | None, int | None] | None,
     outgoing_data_ports: tuple[int | None, int | None] | None,

--- a/src/globus_cli/commands/endpoint/server/delete.py
+++ b/src/globus_cli/commands/endpoint/server/delete.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 import uuid
 from textwrap import dedent
@@ -12,16 +11,11 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import TextMode, display
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 def _spec_to_matches(
     server_list: globus_sdk.IterableTransferResponse,
     server_spec: str,
-    mode: Literal["uri", "hostname", "hostname_port"],
+    mode: t.Literal["uri", "hostname", "hostname_port"],
 ) -> list[t.Mapping[str, t.Any]]:
     """
     mode is in {uri, hostname, hostname_port}
@@ -47,7 +41,7 @@ def _spec_to_matches(
     return [server_doc for server_doc in server_list if match(server_doc)]
 
 
-def _detect_mode(server: str) -> Literal["id", "uri", "hostname", "hostname_port"]:
+def _detect_mode(server: str) -> t.Literal["id", "uri", "hostname", "hostname_port"]:
     try:
         int(server)
         return "id"

--- a/src/globus_cli/commands/endpoint/server/update.py
+++ b/src/globus_cli/commands/endpoint/server/update.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 import uuid
 
 from globus_cli.login_manager import LoginManager
@@ -8,11 +8,6 @@ from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import TextMode, display
 
 from ._common import server_id_arg, server_update_opts
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @command(
@@ -40,7 +35,7 @@ def server_update(
     server_id: str,
     subject: str | None,
     port: int | None,
-    scheme: Literal["gsiftp", "ftp"] | None,
+    scheme: t.Literal["gsiftp", "ftp"] | None,
     hostname: str | None,
     incoming_data_ports: tuple[int | None, int | None] | None,
     outgoing_data_ports: tuple[int | None, int | None] | None,

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 import uuid
 
 import click
@@ -17,11 +17,6 @@ from globus_cli.parsing import (
 from globus_cli.termio import TextMode, display
 
 from ._common import validate_endpoint_create_and_update_params
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @command("update")
@@ -58,7 +53,7 @@ def endpoint_update(
     max_parallelism: int | None,
     myproxy_dn: str | None,
     myproxy_server: str | None,
-    network_use: Literal["normal", "minimal", "aggressive", "custom"] | None,
+    network_use: t.Literal["normal", "minimal", "aggressive", "custom"] | None,
     no_default_directory: bool | None,
     oauth_server: str | None,
     organization: str | None | ExplicitNullType,

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 
 import click
 from globus_sdk.paging import Paginator
@@ -9,11 +9,6 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ColonDelimitedChoiceTuple, command
 from globus_cli.termio import Field, display, formatters
 from globus_cli.utils import PagingWrapper
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 ORDER_BY_FIELDS = (
@@ -77,19 +72,19 @@ def list_command(
     login_manager: LoginManager,
     *,
     filter_role: (
-        Literal["flow_viewer", "flow_starter", "flow_administrator", "flow_owner"]
+        t.Literal["flow_viewer", "flow_starter", "flow_administrator", "flow_owner"]
         | None
     ),
     orderby: tuple[
         tuple[
-            Literal[
+            t.Literal[
                 "id",
                 "scope_string",
                 "title",
                 "created_at",
                 "updated_at",
             ],
-            Literal["ASC", "DESC"],
+            t.Literal["ASC", "DESC"],
         ],
         ...,
     ],

--- a/src/globus_cli/commands/group/invite/_common.py
+++ b/src/globus_cli/commands/group/invite/_common.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 import uuid
 
@@ -13,14 +12,9 @@ if t.TYPE_CHECKING:
 
     from globus_cli.services.auth import CustomAuthClient
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 def get_invite_formatter(
-    case: Literal["accept", "decline"]
+    case: t.Literal["accept", "decline"]
 ) -> t.Callable[[globus_sdk.GlobusHTTPResponse], None]:
     action_word = "Accepted" if case == "accept" else "Declined"
 
@@ -39,7 +33,7 @@ def get_invite_formatter(
 def build_invite_actions(
     auth_client: CustomAuthClient,
     groups_client: globus_sdk.GroupsClient,
-    action: Literal["accept", "decline"],
+    action: t.Literal["accept", "decline"],
     group_id: uuid.UUID,
     identity: ParsedIdentity | None,
 ) -> dict[str, list[dict[str, str]]]:

--- a/src/globus_cli/commands/group/member/add.py
+++ b/src/globus_cli/commands/group/member/add.py
@@ -1,4 +1,4 @@
-import sys
+import typing as t
 import uuid
 
 import click
@@ -8,11 +8,6 @@ from globus_cli.parsing import IdentityType, ParsedIdentity, command
 from globus_cli.termio import Field, TextMode, display
 
 from .._common import group_id_arg
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 ADD_USER_FIELDS = [
     Field("Group ID", "group_id"),
@@ -37,7 +32,7 @@ def member_add(
     *,
     group_id: uuid.UUID,
     user: ParsedIdentity,
-    role: Literal["member", "manager", "admin"],
+    role: t.Literal["member", "manager", "admin"],
 ) -> None:
     """
     Add a member to a group.

--- a/src/globus_cli/commands/group/member/invite.py
+++ b/src/globus_cli/commands/group/member/invite.py
@@ -1,4 +1,4 @@
-import sys
+import typing as t
 import uuid
 
 import click
@@ -8,11 +8,6 @@ from globus_cli.parsing import IdentityType, ParsedIdentity, command
 from globus_cli.termio import Field, TextMode, display
 
 from .._common import group_id_arg
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 INVITED_USER_FIELDS = [
     Field("Group ID", "group_id"),
@@ -43,7 +38,7 @@ def member_invite(
     group_id: uuid.UUID,
     user: ParsedIdentity,
     provision_identity: bool,
-    role: Literal["member", "manager", "admin"],
+    role: t.Literal["member", "manager", "admin"],
 ) -> None:
     """
     Invite a user to a group.

--- a/src/globus_cli/commands/group/set_policies.py
+++ b/src/globus_cli/commands/group/set_policies.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 import uuid
 
 import click
@@ -10,11 +10,6 @@ from globus_cli.parsing import CommaDelimitedList, command
 from globus_cli.termio import display
 
 from ._common import MEMBERSHIP_FIELDS, group_id_arg
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @click.option(
@@ -70,8 +65,8 @@ def group_set_policies(
     group_id: uuid.UUID,
     high_assurance: bool | None,
     authentication_timeout: int | None,
-    visibility: Literal["authenticated", "private"] | None,
-    members_visibility: Literal["members", "managers"] | None,
+    visibility: t.Literal["authenticated", "private"] | None,
+    members_visibility: t.Literal["members", "managers"] | None,
     join_requests: bool | None,
     signup_fields: list[str] | None,
 ) -> None:

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 import uuid
 
@@ -15,11 +14,6 @@ from globus_cli.parsing import (
     mutex_option_group,
 )
 from globus_cli.termio import Field, display, formatters, is_verbose, outformat_is_text
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 # Transfer supports all file fields, so this list is missing 'link_target'
 #
@@ -179,7 +173,7 @@ def ls_command(
     show_hidden: bool,
     orderby: tuple[
         tuple[
-            Literal[
+            t.Literal[
                 "group",
                 "last_modified",
                 "name",
@@ -188,7 +182,7 @@ def ls_command(
                 "type",
                 "user",
             ],
-            Literal["ASC", "DESC"],
+            t.Literal["ASC", "DESC"],
         ],
         ...,
     ],

--- a/src/globus_cli/commands/search/index/role/create.py
+++ b/src/globus_cli/commands/search/index/role/create.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys
+import typing as t
 import uuid
 
 import click
@@ -10,11 +10,6 @@ from globus_cli.parsing import command
 from globus_cli.termio import Field, TextMode, display
 
 from ..._common import index_id_arg, resolved_principals_field
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @command("create")
@@ -39,7 +34,7 @@ def create_command(
     index_id: uuid.UUID,
     role_name: str,
     principal: str,
-    principal_type: Literal["identity", "group"] | None,
+    principal_type: t.Literal["identity", "group"] | None,
 ) -> None:
     """
     Create a role (requires admin or owner)

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import collections.abc
 import datetime
-import sys
 import typing as t
 import uuid
 
@@ -13,11 +12,6 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import Field, display
 from globus_cli.utils import PagingWrapper
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 def _format_date_callback(
@@ -166,8 +160,8 @@ def task_list(
     *,
     limit: int,
     filter_task_id: tuple[uuid.UUID, ...],
-    filter_type: Literal["TRANSFER", "DELETE"] | None,
-    filter_status: tuple[Literal["ACTIVE", "INACTIVE", "FAILED", "SUCCEEDED"], ...],
+    filter_type: t.Literal["TRANSFER", "DELETE"] | None,
+    filter_status: tuple[t.Literal["ACTIVE", "INACTIVE", "FAILED", "SUCCEEDED"], ...],
     filter_label: tuple[str, ...],
     filter_not_label: tuple[str, ...],
     inexact: bool,

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import sys
 import typing as t
 import uuid
 
@@ -30,11 +29,6 @@ from globus_cli.parsing import (
 from globus_cli.termio import Field, TextMode, display, formatters
 
 from .._common import DATETIME_FORMATS, ScheduleFormatter
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if t.TYPE_CHECKING:
     from globus_cli.services.auth import CustomAuthClient
@@ -128,7 +122,7 @@ def transfer_command(
     label: str | None,
     stop_after_date: datetime.datetime | None,
     stop_after_runs: int | None,
-    sync_level: Literal["exists", "size", "mtime", "checksum"] | None,
+    sync_level: t.Literal["exists", "size", "mtime", "checksum"] | None,
     encrypt_data: bool,
     verify_checksum: bool,
     preserve_timestamp: bool,

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 import uuid
 
@@ -23,11 +22,6 @@ from globus_cli.parsing import (
     verify_checksum_option,
 )
 from globus_cli.termio import Field, TextMode, display
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 @command(
@@ -217,7 +211,7 @@ def transfer_command(
     login_manager: LoginManager,
     *,
     batch: t.TextIO | None,
-    sync_level: Literal["exists", "size", "mtime", "checksum"] | None,
+    sync_level: t.Literal["exists", "size", "mtime", "checksum"] | None,
     recursive: bool | None,
     source: tuple[uuid.UUID, str | None],
     destination: tuple[uuid.UUID, str | None],
@@ -225,7 +219,7 @@ def transfer_command(
     external_checksum: str | None,
     skip_source_errors: bool,
     fail_on_quota_errors: bool,
-    filter_rules: list[tuple[Literal["include", "exclude"], str]],
+    filter_rules: list[tuple[t.Literal["include", "exclude"], str]],
     label: str | None,
     preserve_timestamp: bool,
     verify_checksum: bool,

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 
 from globus_sdk.scopes import (
@@ -15,11 +14,6 @@ from globus_sdk.scopes import (
 )
 
 from globus_cli.types import ServiceNameLiteral
-
-if sys.version_info >= (3, 8):
-    from typing import Final, TypedDict
-else:
-    from typing_extensions import Final, TypedDict
 
 TRANSFER_AP_SCOPE_STR: str = (
     "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer"
@@ -48,7 +42,7 @@ def compute_timer_scope(
 TIMER_SCOPE_WITH_DEPENDENCIES = compute_timer_scope()
 
 
-class _ServiceRequirement(TypedDict):
+class _ServiceRequirement(t.TypedDict):
     min_contract_version: int
     resource_server: str
     nice_server_name: str
@@ -131,4 +125,4 @@ CLI_SCOPE_REQUIREMENTS = _CLIScopeRequirements()
 # version we were at when we got a token
 # it should be the max of the version numbers required by the various different
 # services
-CURRENT_SCOPE_CONTRACT_VERSION: Final[int] = 1
+CURRENT_SCOPE_CONTRACT_VERSION: t.Final[int] = 1

--- a/src/globus_cli/login_manager/tokenstore.py
+++ b/src/globus_cli/login_manager/tokenstore.py
@@ -9,11 +9,6 @@ import globus_sdk
 from .client_login import get_client_login, is_client_login
 from .scopes import CURRENT_SCOPE_CONTRACT_VERSION
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 if t.TYPE_CHECKING:
     from globus_sdk.tokenstorage import SQLiteAdapter
 
@@ -213,7 +208,7 @@ def delete_templated_client() -> None:
 
 
 def store_well_known_config(
-    name: Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
+    name: t.Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
     data: dict[str, t.Any],
     *,
     adapter: SQLiteAdapter | None = None,
@@ -224,17 +219,17 @@ def store_well_known_config(
 
 @t.overload
 def read_well_known_config(
-    name: Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
+    name: t.Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
     *,
     adapter: SQLiteAdapter | None = None,
-    allow_null: Literal[False],
+    allow_null: t.Literal[False],
 ) -> dict[str, t.Any]:
     ...
 
 
 @t.overload
 def read_well_known_config(
-    name: Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
+    name: t.Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
     *,
     adapter: SQLiteAdapter | None = None,
     allow_null: bool = True,
@@ -243,7 +238,7 @@ def read_well_known_config(
 
 
 def read_well_known_config(
-    name: Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
+    name: t.Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
     *,
     adapter: SQLiteAdapter | None = None,
     allow_null: bool = True,
@@ -264,7 +259,7 @@ def read_well_known_config(
 
 
 def remove_well_known_config(
-    name: Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
+    name: t.Literal["auth_client_data", "auth_user_data", "scope_contract_versions"],
     *,
     adapter: SQLiteAdapter | None = None,
 ) -> None:

--- a/src/globus_cli/parsing/param_types/delimited.py
+++ b/src/globus_cli/parsing/param_types/delimited.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 
 import click
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 class CommaDelimitedList(click.ParamType):
@@ -88,7 +82,7 @@ class ColonDelimitedChoiceTuple(click.Choice):
         unzipped_choices = zip(*self.unpacked_choices)
 
         # each tuple of choices becomes a Literal
-        literals = [Literal[choices] for choices in unzipped_choices]
+        literals = [t.Literal[choices] for choices in unzipped_choices]
 
         # runtime calls to __class_getitem__ require a single tuple argument
         # so we explicitly `tuple(...)` to get the right data shape

--- a/src/globus_cli/parsing/shared_options/endpointish.py
+++ b/src/globus_cli/parsing/shared_options/endpointish.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
-import sys
 import typing as t
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 import click
 
@@ -38,10 +32,10 @@ class endpointish_params:
     def create(
         cls,
         *,
-        name: Literal["endpoint", "collection"],
-        display_name_style: Literal["argument", "option"] = "argument",
-        keyword_style: Literal["string", "list"] = "list",
-        verify_style: Literal["flag", "choice"] = "choice",
+        name: t.Literal["endpoint", "collection"],
+        display_name_style: t.Literal["argument", "option"] = "argument",
+        keyword_style: t.Literal["string", "list"] = "list",
+        verify_style: t.Literal["flag", "choice"] = "choice",
         add_legacy_params: bool = False,
         skip: tuple[str, ...] = (),
     ) -> t.Callable[[C], C]:
@@ -62,10 +56,10 @@ class endpointish_params:
     def update(
         cls,
         *,
-        name: Literal["endpoint", "collection"],
-        display_name_style: Literal["argument", "option"] = "option",
-        keyword_style: Literal["string", "list"] = "list",
-        verify_style: Literal["flag", "choice"] = "choice",
+        name: t.Literal["endpoint", "collection"],
+        display_name_style: t.Literal["argument", "option"] = "option",
+        keyword_style: t.Literal["string", "list"] = "list",
+        verify_style: t.Literal["flag", "choice"] = "choice",
         add_legacy_params: bool = False,
         skip: tuple[str, ...] = (),
     ) -> t.Callable[[C], C]:
@@ -86,7 +80,7 @@ class endpointish_params:
 
 def _apply_endpointish_create_or_update_params(
     f: C,
-    name: Literal["endpoint", "collection"],
+    name: t.Literal["endpoint", "collection"],
     *,
     public_default: bool | None = True,
     display_name_style: str,

--- a/src/globus_cli/services/auth.py
+++ b/src/globus_cli/services/auth.py
@@ -1,17 +1,11 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 import uuid
 
 import globus_sdk
 import globus_sdk.scopes
 from globus_sdk.experimental.scope_parser import Scope
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, TypedDict
-else:
-    from typing_extensions import Literal, TypedDict
 
 
 def _is_uuid(s: str) -> bool:
@@ -22,7 +16,7 @@ def _is_uuid(s: str) -> bool:
         return False
 
 
-class GetIdentitiesKwargs(TypedDict, total=False):
+class GetIdentitiesKwargs(t.TypedDict, total=False):
     provision: bool
     usernames: str
     ids: str
@@ -33,7 +27,7 @@ class CustomAuthClient(globus_sdk.AuthClient):
         self,
         id_name: str | None = None,
         id_id: str | None = None,
-        field: Literal["id", "username"] = "id",
+        field: t.Literal["id", "username"] = "id",
         provision: bool = False,
     ) -> str | None:
         assert (id_name or id_id) and not (id_name and id_id)
@@ -68,7 +62,7 @@ class CustomAuthClient(globus_sdk.AuthClient):
 
     @t.overload
     def maybe_lookup_identity_id(
-        self, identity_name: str, provision: Literal[True]
+        self, identity_name: str, provision: t.Literal[True]
     ) -> str:
         ...
 

--- a/src/globus_cli/types.py
+++ b/src/globus_cli/types.py
@@ -13,11 +13,6 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 # all imports from globus_cli modules done here are done under TYPE_CHECKING
 # in order to ensure that the use of type annotations never introduces circular
 # imports at runtime
@@ -43,6 +38,6 @@ JsonValue: TypeAlias = t.Union[
 ]
 
 
-ServiceNameLiteral: TypeAlias = Literal[
+ServiceNameLiteral: TypeAlias = t.Literal[
     "auth", "transfer", "groups", "search", "timer", "flows"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     clean
-    py{312,311,310,39,38,37}
-    py37-mindeps
+    py{312,311,310,39,38}
+    py38-mindeps
     cov-combine
     cov-report
     mypy
@@ -29,13 +29,13 @@ deps =
 #
 # usage examples:
 #   GLOBUS_SDK_PATH=../globus-sdk tox -e py311-localsdk
-#   GLOBUS_SDK_PATH=../globus-sdk tox -e 'py{37,38,39,310,311,312}-localsdk'
+#   GLOBUS_SDK_PATH=../globus-sdk tox -e 'py{38,39,310,311,312}-localsdk'
 commands =
     localsdk: python -c 'import os, subprocess, sys; subprocess.run([sys.executable, "-m", "pip", "install", "-e", os.environ["GLOBUS_SDK_PATH"]])'
     coverage run -m pytest {posargs}
 depends =
-    py{37,38,39,310,311,312}{,-mindeps}: clean
-    cov-combine: py{37,38,39,310,311,312}{,-mindeps}
+    py{38,39,310,311,312}{,-mindeps}: clean
+    cov-combine: py{38,39,310,311,312}{,-mindeps}
     cov-report: cov-combine
 
 [testenv:clean]


### PR DESCRIPTION
3.7 reached EOL in June, 2023, so it has been over 6 months since EOL.
As requisite maintenance, we need to update the lower bounds for what we support.

Most of the changes here are isolated into the second commit, which touches pyupgrade config and then fixes up the results.
