### PR TITLE
Improve handling of clock skew when decoding a JWT

### DIFF
--- a/changelog.d/20240129_181132_sirosen_improve_jwt_clock_skew_tolerance.md
+++ b/changelog.d/20240129_181132_sirosen_improve_jwt_clock_skew_tolerance.md
@@ -1,0 +1,5 @@
+### Other
+
+* `globus login` and related commands are now more tolerant of clock drift, and
+  will emit a clearer error message when clock drift is severe enough to cause
+  errors during authentication attempts.

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -191,8 +191,9 @@ def _response_clock_delta(response: globus_sdk.GlobusHTTPResponse) -> float | No
     if not response_date_str:  # not present
         return None
 
-    response_date = email.utils.parsedate_to_datetime(response_date_str)
-    if not response_date:  # failed to parse
+    try:
+        response_date = email.utils.parsedate_to_datetime(response_date_str)
+    except ValueError:  # failed to parse
         return None
 
     return abs((now - response_date).total_seconds())

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -193,7 +193,7 @@ def _response_clock_delta(response: globus_sdk.GlobusHTTPResponse) -> float | No
 
     try:
         response_date = email.utils.parsedate_to_datetime(response_date_str)
-    except ValueError:  # failed to parse
+    except (ValueError, TypeError):  # failed to parse
         return None
 
     return abs((now - response_date).total_seconds())

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -119,7 +119,7 @@ def exchange_code_and_store(
     as, so to secure incremental auth flows, if the new tokens don't match the previous
     identity we revoke them and instruct the user to logout before continuing.
     """
-    import jwt
+    import jwt.exceptions
 
     adapter = token_storage_adapter()
     tkn = auth_client.oauth2_exchange_code_for_tokens(auth_code)

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -6,7 +6,6 @@ import typing as t
 
 import click
 import globus_sdk
-import jwt
 from globus_sdk.scopes import MutableScope
 
 from .tokenstore import (
@@ -120,6 +119,8 @@ def exchange_code_and_store(
     as, so to secure incremental auth flows, if the new tokens don't match the previous
     identity we revoke them and instruct the user to logout before continuing.
     """
+    import jwt
+
     adapter = token_storage_adapter()
     tkn = auth_client.oauth2_exchange_code_for_tokens(auth_code)
 


### PR DESCRIPTION
- increase leeway from 64s to 300s
- add a warning about clock skew vs the server on failure

Regarding the increase from 64s to 300s, this represents a refinement of the reasoning around what our tolerance should be, based on the same relevant data + the experience of users seeing errors even in the presence of this higher tolerance. As noted in the comments, the new conclusion drawn is that the tolerance value selected by Kerberos, an existing authn framework, is a reasonable default for us to use as well. That is chosen instead of the slightly arbitrary 64s from before.

The warning is emitted if the "Date" header in the response can be parsed to show us a delta between the local system clock and the server time. It is a simple echo to stderr, to guarantee that it appears in this failure mode.

These changes have been tested manually.
