### PR TITLE
Fix endpoint permission create principal flag value bug

### DIFF
--- a/changelog.d/20240125_145727_derek_endpoint_permission_create_bug_zd_381646.md
+++ b/changelog.d/20240125_145727_derek_endpoint_permission_create_bug_zd_381646.md
@@ -1,0 +1,6 @@
+
+
+### Bugfixes
+
+* Fixes a bug which would not allow users to utilize "--anonymous" or
+  "--all-authenticated-users" when creating an endpoint permission.

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -313,6 +313,7 @@ def security_principal_opts(
             f = click.option(
                 "--anonymous",
                 "principal",
+                type=click.Tuple([str, str]),
                 flag_value=("anonymous", ""),
                 help=(
                     "Allow anyone access, even without logging in "
@@ -323,6 +324,7 @@ def security_principal_opts(
             f = click.option(
                 "--all-authenticated",
                 "principal",
+                type=click.Tuple([str, str]),
                 flag_value=("all_authenticated_users", ""),
                 help=(
                     "Allow anyone access, as long as they login "

--- a/tests/files/api_fixtures/endpoint_operations.yaml
+++ b/tests/files/api_fixtures/endpoint_operations.yaml
@@ -561,3 +561,14 @@ transfer:
         "request_id": "X8AlP9Ned",
         "resource": "/endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15"
       }
+  - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15/access
+    method: post
+    json:
+      {
+        "DATA_TYPE": "access_create_result",
+        "code": "Created",
+        "resource": "/endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15/access",
+        "request_id": "abc123",
+        "access_id": 12345,
+        "message": "Access rule created successfully."
+      }

--- a/tests/functional/endpoint/permission/test_endpoint_permission_create.py
+++ b/tests/functional/endpoint/permission/test_endpoint_permission_create.py
@@ -1,0 +1,30 @@
+import pytest
+from globus_sdk._testing import load_response_set
+
+
+@pytest.mark.parametrize(
+    "principal",
+    (
+        "--anonymous",
+        "--all-authenticated",
+        "--group 2c9a8a6b-b0b7-4f30-acc4-37e741a311c7",
+        "--identity 7c939269-fafe-43d4-bbb5-d4e6321643a8",
+    ),
+)
+def test_endpoint_permission_create_with_standard_principals(run_line, principal):
+    meta = load_response_set("cli.endpoint_operations").metadata
+    ep_id = meta["endpoint_id"]
+
+    result = run_line(
+        f"globus endpoint permission create {ep_id}:/ --permissions r {principal}"
+    )
+    assert "Access rule created successfully" in result.output
+
+
+def test_endpoint_permission_create_with_no_principal(run_line):
+    ep_id = "4c799ca5-6525-44d0-8887-a4bece7f4e09"
+
+    run_line(
+        f"globus endpoint permission create {ep_id}:/ --permissions r",
+        assert_exit_code=2,
+    )


### PR DESCRIPTION
## What?
Fixes a bug identified in user ticket [zd-381646](https://globusonline.zendesk.com/agent/tickets/381646) where `globus endpoint permission create` failed to correctly parse the flag input values for `--anonymous` and `--all-authenticated` options.

## Testing
Added unit tests which invoke `globus endpoint permission create` with the 4 standard principal types & verifies they are passed through as expected to transfer.