### PR TITLE
Fix incorrect parameter value specified in changelog

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -6,8 +6,8 @@
 
 Bugfixes
 
-* Fixes a bug which would not allow users to utilize ``--anonymous`` or
-  ``--all-authenticated`` when creating an endpoint permission.
+* Fixes a bug which would not allow users to utilize `--anonymous` or
+  `--all-authenticated` when creating an endpoint permission.
 
 Other
 

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -6,8 +6,8 @@
 
 Bugfixes
 
-* Fixes a bug which would not allow users to utilize "--anonymous" or
-  "--all-authenticated-users" when creating an endpoint permission.
+* Fixes a bug which would not allow users to utilize ``--anonymous`` or
+  ``--all-authenticated`` when creating an endpoint permission.
 
 Other
 


### PR DESCRIPTION
## What?
Update the changelog to accurately specify correct flag value.

The value passed through to transfer is `all-authenticated-users` but the flag in the cli is `--all-authenticated` ([ref](https://github.com/derek-globus/globus-cli/blob/439793725fb74c794bb34852fed475c8094ad922/src/globus_cli/parsing/shared_options/__init__.py#L324-L332))