### PR TITLE
Update to slyp v0.2.1 and apply fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
   hooks:
     - id: isort
 - repo: https://github.com/sirosen/slyp
-  rev: 0.1.2
+  rev: 0.2.1
   hooks:
     - id: slyp
 - repo: https://github.com/codespell-project/codespell

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -37,7 +37,7 @@ from globus_cli.termio import TextMode, display
 @click.option(
     "--myproxy-username",
     "-U",
-    help=("Give a username to use with --myproxy"),
+    help="Give a username to use with --myproxy",
 )
 @click.option("--myproxy-password", "-P", hidden=True)
 @click.option(

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -157,7 +157,7 @@ fi
     "--checksum-algorithm",
     default=None,
     show_default=True,
-    help=("Specify an algorithm for --external-checksum or --verify-checksum"),
+    help="Specify an algorithm for --external-checksum or --verify-checksum",
 )
 @click.option(
     "--include",

--- a/tests/functional/endpoint/test_endpoint_update.py
+++ b/tests/functional/endpoint/test_endpoint_update.py
@@ -170,7 +170,7 @@ def test_invalid_gcs_only_options(run_line, ep_type):
     ]
     for opt in options:
         result = run_line(
-            (f"globus endpoint update {epid} {opt} "),
+            f"globus endpoint update {epid} {opt} ",
             assert_exit_code=2,
         )
         assert "Globus Connect Server" in result.stderr
@@ -193,7 +193,7 @@ def test_invalid_managed_only_options(run_line):
     ]
     for opt in options:
         result = run_line(
-            (f"globus endpoint update {epid} {opt} "),
+            f"globus endpoint update {epid} {opt} ",
             assert_exit_code=2,
         )
         assert "managed endpoints" in result.stderr

--- a/tests/functional/test_jmespath_output.py
+++ b/tests/functional/test_jmespath_output.py
@@ -65,6 +65,6 @@ def test_jmespath_invalid_expression_error(run_line):
     that it gives a JMESPath ParseError.
     """
     result = run_line(
-        ("globus endpoint search 'Tutorial' --jmespath '{}'"), assert_exit_code=1
+        "globus endpoint search 'Tutorial' --jmespath '{}'", assert_exit_code=1
     )
     assert "ParseError:" in result.stderr

--- a/tests/unit/param_types/test_comma_delimited.py
+++ b/tests/unit/param_types/test_comma_delimited.py
@@ -30,7 +30,7 @@ def test_comma_delimited_list_help_with_choices(runner):
     "add_args, expect_output",
     (
         # absent, it returns None
-        ([], ("nil\n")),
+        ([], "nil\n"),
         # given empty string (this is ambiguous!) returns empty array
         (["--foo", ""], "0\n"),
         # given one or more values, it listifies them

--- a/tests/unit/param_types/test_json_inputs.py
+++ b/tests/unit/param_types/test_json_inputs.py
@@ -42,9 +42,9 @@ def test_v2_json_string_or_file(runner, tmpdir):
     valid_file = tmpdir.mkdir("valid").join("file1.json")
     valid_file.write('{"foo": 1}\n')
     result = runner.invoke(foo, ["--bar", "file:" + str(valid_file)])
-    assert result.output == (f'filename: {valid_file}\ndata: {{"foo": 1}}\n')
+    assert result.output == f'filename: {valid_file}\ndata: {{"foo": 1}}\n'
     result = runner.invoke(foo, ["--bar", str(valid_file)])
-    assert result.output == (f'filename: {valid_file}\ndata: {{"foo": 1}}\n')
+    assert result.output == f'filename: {valid_file}\ndata: {{"foo": 1}}\n'
 
     # given the path to a file with invalid JSON, it raises an error
     invalid_file = tmpdir.mkdir("invalid").join("file1.json")


### PR DESCRIPTION
The new fixer in `slyp` version 0.2.x automatically unwraps unnecessarily parenthesized expressions.
