### PR TITLE
Fix helptext for `--preserve-timestamp`

### DIFF
--- a/src/globus_cli/parsing/shared_options/transfer_task_options.py
+++ b/src/globus_cli/parsing/shared_options/transfer_task_options.py
@@ -94,7 +94,10 @@ def preserve_timestamp_option(*, aliases: tuple[str, ...] = ()) -> t.Callable[[C
             *aliases,
             is_flag=True,
             default=False,
-            help="Preserve file and directory modification times.",
+            help=(
+                "Preserve file modification times. "
+                "Directory modification times are not preserved."
+            ),
         )(f)
 
     return decorator


### PR DESCRIPTION
Transfer documentation indicates that dir mtimes are not preserved.
Because Transfer is doing async batch file processing, there are
correctness and performance issues with preserving timestamps -- it
requires an extra pass over the dir tree to retroactively set mtime on
each dir entry after the transfer completes -- and it is therefore not
included in `preserve_timestamp=True` behavior service-side.
