### PR TITLE
Update pinned dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "globus-sdk==3.35.0",
+    "globus-sdk==3.37.0",
     "click>=8.1.4,<9",
     "jmespath==1.0.1",
     "packaging>=17.0",
@@ -50,7 +50,7 @@ test = [
     "pytest-xdist<4",
     "pytest-timeout<3",
     "click-type-test==0.0.7;python_version>='3.10'",
-    "responses==0.24.1",
+    "responses==0.25.0",
     # loading test fixture data
     "ruamel.yaml==0.18.6",
     # Python 3.12 needs setuptools.

--- a/scripts/update_dependencies.py
+++ b/scripts/update_dependencies.py
@@ -44,11 +44,11 @@ def bump_pkg_version_on_file(
 
 
 _all_pkgs = {
-    "jmespath": "setup.py",
-    "scriv": "setup.py",
-    "responses": "setup.py",
-    "ruamel.yaml": "setup.py",
-    "globus-sdk": "setup.py",
+    "jmespath": "pyproject.toml",
+    "responses": "pyproject.toml",
+    "ruamel.yaml": "pyproject.toml",
+    "globus-sdk": "pyproject.toml",
+    "pre-commit": "tox.ini",
     "mypy": "tox.ini",
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,8 @@ commands_pre = coverage html --fail-under=0
 commands = coverage report
 
 [testenv:lint]
-deps = pre-commit==3.6.1
+deps = pre-commit
+recreate = true
 skip_install = true
 commands = pre-commit run --all-files
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands_pre = coverage html --fail-under=0
 commands = coverage report
 
 [testenv:lint]
-deps = pre-commit~=2.9.2
+deps = pre-commit==3.6.1
 skip_install = true
 commands = pre-commit run --all-files
 
@@ -69,7 +69,7 @@ base_python =
     python3.11
     python3.10
 deps =
-    mypy==1.7.1
+    mypy==1.8.0
     types-jwt
     types-requests
     types-jmespath


### PR DESCRIPTION
- update the updater script (a pre-dependabot tool for updating our various pinned dependencies; still useful for a manual update) to handle changes to where dependencies are declared
- pin the `pre-commit` version in `tox.ini` -- more reproducible runs and valid as a target of the updater
- run the updater