### PR TITLE
Make `--format=JSON` output on errors "raw"

### DIFF
--- a/changelog.d/20240214_225218_sirosen_fix_json_error_presentation.md
+++ b/changelog.d/20240214_225218_sirosen_fix_json_error_presentation.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* `--format=JSON` output now offers greater detail when API errors are
+  encountered with JSON bodies. Rather than re-encoding error details, the
+  original error body is now shown in these cases.

--- a/src/globus_cli/termio/errors.py
+++ b/src/globus_cli/termio/errors.py
@@ -38,10 +38,10 @@ class PrintableErrorField:
         return val
 
 
-def write_error_info(error_name, fields, message=None):
+def write_error_info(error_name, fields):
     if outformat_is_json():
         # dictify joined tuple lists and dump to json string
-        message = click.style(
+        click.style(
             json.dumps(
                 dict(
                     [("error_name", error_name)]
@@ -53,7 +53,7 @@ def write_error_info(error_name, fields, message=None):
             ),
             fg="yellow",
         )
-    if not message:
+    else:
         message = "A{} {} Occurred.\n{}".format(
             "n" if error_name[0] in "aeiouAEIOU" else "",
             click.style(error_name, bold=True, fg="red"),

--- a/tests/functional/test_exception_hooks.py
+++ b/tests/functional/test_exception_hooks.py
@@ -1,7 +1,23 @@
+import json
 import uuid
 
 import pytest
 from globus_sdk._testing import RegisteredResponse, load_response, load_response_set
+
+
+def test_base_json_hook(run_line):
+    """
+    confirms that the base json hook captures the error JSON and prints it verbatim
+    """
+    response = RegisteredResponse(
+        service="transfer",
+        path="/foo",
+        status=400,
+        json={"bar": "baz"},
+    )
+    response.add()
+    result = run_line("globus api transfer GET /foo -Fjson", assert_exit_code=1)
+    assert response.json == json.loads(result.stderr)
 
 
 @pytest.mark.parametrize("num_policies", (1, 3))


### PR DESCRIPTION
When JSON output is requested, error responses are no longer reformulated by the globus-cli's error presentation code if the error data is JSON-formatted. Instead, in these cases the JSON output of the CLI is the complete error output.

Also simplify a slightly overcomplicated path by which `write_error_info` becomes a simple `click.echo` wrapper.

---

This is a relatively significant change in outputs, but only under error scenarios.
Manual testing demonstrates that this works well for complex error outputs (e.g. Flow validation failures, Search errors, etc).
