### PR TITLE
Fix encoding of payloads as UTF-8 for `globus api`

### DIFF
--- a/changelog.d/20240223_150902_sirosen_api_always_utf8.md
+++ b/changelog.d/20240223_150902_sirosen_api_always_utf8.md
@@ -1,0 +1,5 @@
+### Bugfixes
+
+* Payloads sent with `globus api` commands are now always encoded as UTF-8.
+  This fixes an issue on certain platforms in which encoding could fail on
+  specific payloads.

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -317,7 +317,7 @@ def _execute_service_command(
             method.upper(),
             path,
             query_params=query_params_d,
-            data=body,
+            data=body.encode("utf-8") if body is not None else None,
             headers=headers_d,
             allow_redirects=allow_redirects,
         )


### PR DESCRIPTION
Payloads are now encoded before being passed to the SDK, which ensures
that UTF-8 is used. This fixes an issue in which `urllib3` version 1.x
could attempt to encode data using Latin-1 and fail. The urllib3
version used is tied to the underlying supported openssl version, so
it just appears as a "platform dependent bug".

This is tricky to describe in the changelog, so it's just noted as
"encoding could fail", without full detail.
