### PR TITLE
Enable wrapping of group 'description' output + expand width of wrapped record outputs

### DIFF
--- a/changelog.d/20240226_123238_sirosen_enable_wrapped_group_desc.md
+++ b/changelog.d/20240226_123238_sirosen_enable_wrapped_group_desc.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Text-wrapped fields in record-style text output now use a larger percentage
+  of the available space in wide terminals.

--- a/src/globus_cli/commands/group/show.py
+++ b/src/globus_cli/commands/group/show.py
@@ -21,7 +21,7 @@ def group_show(login_manager: LoginManager, *, group_id: uuid.UUID) -> None:
         text_mode=TextMode.text_record,
         fields=[
             Field("Name", "name"),
-            Field("Description", "description"),
+            Field("Description", "description", wrap_enabled=True),
             Field("Type", "group_type"),
             Field("Visibility", "policies.group_visibility"),
             Field("Membership Visibility", "policies.group_members_visibility"),

--- a/tests/unit/test_termio.py
+++ b/tests/unit/test_termio.py
@@ -1,5 +1,7 @@
 import os
 import re
+import textwrap
+from unittest import mock
 
 import click
 import pytest
@@ -49,3 +51,56 @@ def test_format_record_list(capsys):
     # and one empty line between the records
     assert "" in output.splitlines()
     assert re.match(r"Bird:\s+Killdeer", output)
+
+
+def test_format_record_with_text_wrapping(capsys, monkeypatch):
+    # fake the terminal width at 120
+    fake_dimensions = mock.Mock()
+    fake_dimensions.columns = 120
+    monkeypatch.setattr("shutil.get_terminal_size", lambda *_, **__: fake_dimensions)
+    expected_width = int(0.8 * 120)
+
+    # based on info from wikipedia
+    data = {
+        "bird": "Franklin's Gull",
+        "description": textwrap.dedent(
+            """
+            A migratory gull with a range spanning from Chile and
+            Argentina up to Canada and Alaska.
+            Named after the Arctic explorer Sir John Franklin, it
+            has a white body, dark grey wings, and a black hood.
+            The black hood plumage, developed in the breeding season,
+            is lost in the winter.
+            """
+        )
+        .replace("\n", " ")
+        .strip(),
+    }
+    fields = [
+        Field("Bird", "bird"),
+        Field("Description", "description", wrap_enabled=True),
+    ]
+
+    with click.Context(click.Command("fake-command")) as _:
+        display(data, text_mode=TextMode.text_record, fields=fields)
+    output_lines = capsys.readouterr().out.splitlines()
+
+    # output should be more than two lines
+    assert len(output_lines) > 2
+    # the first line is the name field
+    assert re.match(r"^Bird:\s+Franklin's Gull$", output_lines[0])
+    # second line starts with the description field name,
+    # but is limited in width for the value
+    # give it a lower bound to show that it's not tightly wrapped (most of the words
+    # in the description text are < 10 chars)
+    assert re.match(r"^Description:\s+.*$", output_lines[1])
+    assert (expected_width - 10) < len(output_lines[1]) <= expected_width
+
+    # check the rest of the output against a manual wrap of the description text
+    # exactly in the way in which it is expected to be wrapped (but without the indent)
+    wrapped_description_lines = textwrap.fill(
+        data["description"], width=expected_width - len("Description: ")
+    ).splitlines()
+
+    for i, line in enumerate(wrapped_description_lines[1:]):
+        assert output_lines[i + 2].endswith(line)


### PR DESCRIPTION
For `group show`, this makes the description text wrap.

Sample before and after:

```
### before ###

Name:                  Rosen Alt Internal Subscription
Description:           This is the self managed subscription group for the Rosen Alt Internal Subscription Globus Subscription.  This description field is intended to be a source of information for affiliates of an institution or organization to acquire additional information about this Globus Subscription and request membership in this group. As such, Administrators are strongly encouraged to edit this description field to reflect specific information about this Globus Subscription, including contact information for local Globus experts, information regarding various file systems (both on prem and cloud) that are existing Globus Collections available to researchers, and for subscription Administrators to include any web links that further describe the implementation of Globus at the institution or organization.  If you are affiliated with the institution or organization that owns this subscription, depending on how your subscription administrator has configured the group, you may request to join this group to gain access to subscription features.  As a member of a subscription group, your identity will be able to take advantage of premium Globus features. For example, you will be able to create more than one Globus Flow, enable data sharing from your Globus Connect Personal or Globus Connect Server mapped collections, and initiate GCP to GCP transfers.  Administrators and Managers of this subscription group are able to subscribe Globus resources to this subscription, regardless of administrative rights on that resource. Administrators and Managers can also add, invite, and approve group members. Administrators can change some subscription group configurations and can promote members to Manager or Administrator roles.
Type:                  plus

### after ###

Name:                  Rosen Alt Internal Subscription
Description:           This is the self managed subscription group for
                       the Rosen Alt Internal Subscription Globus
                       Subscription.  This description field is
                       intended to be a source of information for
                       affiliates of an institution or organization to
                       acquire additional information about this
                       Globus Subscription and request membership in
                       this group. As such, Administrators are
                       strongly encouraged to edit this description
                       field to reflect specific information about
                       this Globus Subscription, including contact
                       information for local Globus experts,
                       information regarding various file systems
                       (both on prem and cloud) that are existing
                       Globus Collections available to researchers,
                       and for subscription Administrators to include
                       any web links that further describe the
                       implementation of Globus at the institution or
                       organization.  If you are affiliated with the
                       institution or organization that owns this
                       subscription, depending on how your
                       subscription administrator has configured the
                       group, you may request to join this group to
                       gain access to subscription features.  As a
                       member of a subscription group, your identity
                       will be able to take advantage of premium
                       Globus features. For example, you will be able
                       to create more than one Globus Flow, enable
                       data sharing from your Globus Connect Personal
                       or Globus Connect Server mapped collections,
                       and initiate GCP to GCP transfers.
                       Administrators and Managers of this
                       subscription group are able to subscribe Globus
                       resources to this subscription, regardless of
                       administrative rights on that resource.
                       Administrators and Managers can also add,
                       invite, and approve group members.
                       Administrators can change some subscription
                       group configurations and can promote members to
                       Manager or Administrator roles.
Type:                  plus
```

Truth be told, both are a bit unpleasant, which is why I'm opening this as a draft. We have some terminal width detection in our helptext formatting. I want to try applying the same here.