### PR TITLE
Add 'group get-by-subscription' command

### DIFF
--- a/changelog.d/20240226_144957_sirosen_get_group_by_subscription_id.md
+++ b/changelog.d/20240226_144957_sirosen_get_group_by_subscription_id.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Add `globus group get-by-subscription` for looking up Subscription Groups
+  based on their subscription IDs.

--- a/src/globus_cli/commands/group/__init__.py
+++ b/src/globus_cli/commands/group/__init__.py
@@ -13,6 +13,7 @@ from globus_cli.parsing import group
         "member": (".member", "group_member"),
         "set-policies": (".set_policies", "group_set_policies"),
         "show": (".show", "group_show"),
+        "get-by-subscription": (".get_by_subscription", "group_get_by_subscription"),
         "update": (".update", "group_update"),
     },
 )

--- a/src/globus_cli/commands/group/get_by_subscription.py
+++ b/src/globus_cli/commands/group/get_by_subscription.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import uuid
+
+import click
+import globus_sdk
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import (
+    Field,
+    TextMode,
+    display,
+    formatters,
+    outformat_is_text,
+    print_command_hint,
+)
+
+from ._common import SESSION_ENFORCEMENT_FIELD
+
+_COMMON_FIELDS = [
+    Field("BAA", "subscription_info.is_baa", formatter=formatters.Bool),
+    Field(
+        "High Assurance",
+        "subscription_info.is_high_assurance",
+        formatter=formatters.Bool,
+    ),
+]
+
+
+@click.argument("subscription_id", type=click.UUID)
+@command("get-by-subscription")
+@LoginManager.requires_login("groups")
+def group_get_by_subscription(
+    login_manager: LoginManager, *, subscription_id: uuid.UUID
+) -> None:
+    """Show the Group which provides a specific Subscription.
+
+    If the Group is not visible to the current user, only the Group ID will be shown.
+    """
+    groups_client = login_manager.get_groups_client()
+
+    subscription_data = groups_client.get_group_by_subscription_id(subscription_id)
+
+    # for text output only, attempt to fetch the Group data
+    if outformat_is_text():
+        group_data: globus_sdk.GlobusHTTPResponse | None = try_resolve_group(
+            groups_client, subscription_data["group_id"]
+        )
+    # for JSON or unix-formatted output, do not look up the Group
+    else:
+        group_data = None
+
+    # if text output was wanted *and* we successfully got the group data
+    # then we will display Group data
+    if group_data:
+        display(
+            group_data,
+            text_mode=TextMode.text_record,
+            fields=(
+                [Field("Group ID", "id")]
+                + _COMMON_FIELDS
+                + [
+                    Field("Name", "name"),
+                    Field("Description", "description", wrap_enabled=True),
+                    Field("Type", "group_type"),
+                    Field("Visibility", "policies.group_visibility"),
+                    Field("Membership Visibility", "policies.group_members_visibility"),
+                    SESSION_ENFORCEMENT_FIELD,
+                    Field("Join Requests Allowed", "policies.join_requests"),
+                    Field(
+                        "Signup Fields",
+                        "policies.signup_fields",
+                        formatter=formatters.SortedArray,
+                    ),
+                    Field(
+                        "Roles",
+                        "my_memberships[].role",
+                        formatter=formatters.SortedArray,
+                    ),
+                ]
+            ),
+        )
+    # otherwise, display the subscription data and text-mode will be just the Group ID
+    else:
+        # if text mode was requested and we're in this branch, it means an attempt to
+        # grab the group itself failed, so show a warning/hint
+        if outformat_is_text():
+            print_command_hint(
+                "The Group for this Subscription is not visible to you.\n"
+            )
+        display(
+            subscription_data,
+            text_mode=TextMode.text_record,
+            fields=[Field("Group ID", "group_id")] + _COMMON_FIELDS,
+        )
+
+
+def try_resolve_group(
+    groups_client: globus_sdk.GroupsClient, group_id: str
+) -> globus_sdk.GlobusHTTPResponse | None:
+    """Attempt to get a group"""
+    try:
+        return groups_client.get_group(group_id, include="my_memberships")
+    except globus_sdk.GlobusAPIError as e:
+        if e.http_status == 403:
+            return None
+        raise

--- a/tests/functional/groups/test_get_by_subscription.py
+++ b/tests/functional/groups/test_get_by_subscription.py
@@ -1,0 +1,208 @@
+import json
+import re
+import uuid
+
+import pytest
+from globus_sdk._testing import load_response, register_response_set
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _register_responses():
+    group_id = str(uuid.uuid4())
+    group_name = "My Subscription Group"
+    group_description = "One group to rule them all."
+
+    user_identity_id = str(uuid.uuid4())
+
+    subscription_id = str(uuid.uuid4())
+    connector_id = str(uuid.uuid4())
+
+    register_response_set(
+        "cli.group_get_by_subscription",
+        dict(
+            default=dict(
+                service="groups",
+                path=f"/subscription_info/{subscription_id}",
+                json={
+                    "group_id": group_id,
+                    "subscription_id": subscription_id,
+                    "subscription_info": {
+                        "connectors": {
+                            connector_id: {
+                                "is_baa": False,
+                                "is_ha": True,
+                            }
+                        },
+                        "is_baa": False,
+                        "is_high_assurance": False,
+                    },
+                },
+            ),
+            get_group=dict(
+                service="groups",
+                path=f"/groups/{group_id}",
+                json={
+                    "id": group_id,
+                    "subscription_id": subscription_id,
+                    "subscription_info": {
+                        "connectors": {
+                            connector_id: {
+                                "is_baa": False,
+                                "is_ha": True,
+                            }
+                        },
+                        "is_baa": False,
+                        "is_high_assurance": False,
+                    },
+                    "name": group_name,
+                    "description": group_description,
+                    "group_type": "regular",
+                    "enforce_session": False,
+                    "my_memberships": [
+                        {
+                            "group_id": group_id,
+                            "identity_id": user_identity_id,
+                            "username": "jurt@example.com",
+                            "role": "admin",
+                        }
+                    ],
+                    "policies": {
+                        "authentication_assurance_timeout": 28800,
+                        "group_members_visibility": "managers",
+                        "group_visibility": "private",
+                        "is_high_assurance": False,
+                        "join_requests": False,
+                        "signup_fields": [],
+                    },
+                },
+            ),
+            get_group_not_visible=dict(
+                service="groups",
+                path=f"/groups/{group_id}",
+                json={"message": "forbidden!"},
+                status=403,
+            ),
+            get_group_fails=dict(
+                service="groups",
+                path=f"/groups/{group_id}",
+                json={"message": "boom!"},
+                status=409,
+                metadata={"message": "boom!"},
+            ),
+        ),
+        metadata={
+            "group_id": group_id,
+            "group_name": group_name,
+            "group_description": group_description,
+            "user_identity_id": user_identity_id,
+            "subscription_id": subscription_id,
+            "connector_id": connector_id,
+        },
+    )
+
+
+@pytest.mark.parametrize("group_visible", (True, False))
+def test_group_get_by_subscription_json_output(run_line, group_visible):
+    """
+    JSON output shows the subscription info regardless of
+    whether or not the group is visible
+    """
+    meta = load_response("cli.group_get_by_subscription").metadata
+    if group_visible:
+        load_response("cli.group_get_by_subscription", case="get_group")
+    else:
+        load_response("cli.group_get_by_subscription", case="get_group_not_visible")
+
+    result = run_line(
+        f"globus group get-by-subscription -Fjson {meta['subscription_id']}"
+    )
+
+    data = json.loads(result.stdout)
+    assert data["group_id"] == meta["group_id"]
+    assert data["subscription_id"] == meta["subscription_id"]
+
+
+def test_group_get_by_subscription_text(run_line):
+    meta = load_response("cli.group_get_by_subscription").metadata
+    load_response("cli.group_get_by_subscription", case="get_group")
+
+    run_line(
+        f"globus group get-by-subscription {meta['subscription_id']}",
+        search_stdout=[
+            ("Group ID", meta["group_id"]),
+            ("Name", meta["group_name"]),
+            ("Description", meta["group_description"]),
+        ],
+    )
+
+
+@pytest.mark.parametrize("output_format", ("text", "json", "unix"))
+def test_group_get_by_subscription_non_visible_group(
+    run_line, monkeypatch, output_format
+):
+    """
+    Test that when the group is not visible:
+    - text output shows just the group ID
+    - a warning/hint will be shown in text mode (if interactive)
+    - the hint will not be shown in non-text modes
+    """
+    # force interactive and patch detection methods to get command hints to print
+    monkeypatch.setenv("GLOBUS_CLI_INTERACTIVE", "1")
+    monkeypatch.setattr("globus_cli.termio.err_is_terminal", lambda: True)
+    monkeypatch.setattr("globus_cli.termio.out_is_terminal", lambda: True)
+
+    meta = load_response("cli.group_get_by_subscription").metadata
+    load_response("cli.group_get_by_subscription", case="get_group_not_visible")
+
+    result = run_line(
+        f"globus group get-by-subscription {meta['subscription_id']} -F{output_format}",
+    )
+    # in text output, only the subscription info fields are shown and the hint gets
+    # printed to stderr
+    if output_format == "text":
+        assert re.match(
+            r"The Group for this Subscription is not visible to you\.", result.stderr
+        )
+        result_lines = result.stdout.splitlines()
+        assert len(result_lines) == 3
+        assert re.match(r"Group ID:\s+" + re.escape(meta["group_id"]), result_lines[0])
+        assert {r.partition(":")[0] for r in result_lines} == {
+            "Group ID",
+            "BAA",
+            "High Assurance",
+        }
+    # for non-text output, there is no such hint
+    else:
+        assert result.stderr == ""
+
+
+def test_group_get_by_subscription_errors_if_unexpected_error_on_group_lookup(run_line):
+    """
+    We're handling exceptions in the group lookup; ensure that we don't capture things
+    like 500s, 502s, 409s, etc
+    """
+    meta = load_response("cli.group_get_by_subscription").metadata
+    error_meta = load_response(
+        "cli.group_get_by_subscription", case="get_group_fails"
+    ).metadata
+    expect_error = error_meta["message"]
+
+    result = run_line(
+        f"globus group get-by-subscription {meta['subscription_id']}",
+        assert_exit_code=1,
+    )
+    assert expect_error in result.stderr
+
+
+def test_group_get_by_subscription_skips_group_lookup_for_json_output(run_line):
+    """
+    Assume the lookup is broken in some way.
+    Ensure that `--format json` does not hit that error at all.
+    """
+    meta = load_response("cli.group_get_by_subscription").metadata
+    load_response("cli.group_get_by_subscription", case="get_group_fails")
+
+    # ensure success
+    run_line(
+        f"globus group get-by-subscription {meta['subscription_id']} -Fjson",
+    )


### PR DESCRIPTION
The behavior of this command is specced out currently as follows:
- first, it will fetch the subscription_info document
- next, it will check: has text output been requested?
  - only in this case, fetch the relevant group
  - display the group info
- if fetching the group failed OR we weren't asked for text output, display the subscription_info document
  - if fetching failed, show a hint to stderr that the group is not visible

Tests attempt to exercise all of the relevant cases.

Some important nuances:
- we detect "could not fetch the group" via a 403 -- all other errors, including 404s, are treated as "true errors"
- make sure we don't print the command hint when someone runs with `--format=json` and we didn't even try a lookup
- this behavior ensures that JSON output will work even if fetching the group would fail hard
- for initial display, we include no connector info (it can always be added later)

For now this is implemented without using an underlying SDK method for getting subscription_info (as that is not yet released), but this can be updated as soon as support is available.
