### PR TITLE
Add `get-subscription-info` command + share fields

### DIFF
--- a/changelog.d/20240304_114521_sirosen_get_subscription_info.md
+++ b/changelog.d/20240304_114521_sirosen_get_subscription_info.md
@@ -1,5 +1,5 @@
 ### Enhancements
 
 * Add `globus group get-subscription-info` command to display a subscription.
-* `globus group show` now displays subscription related information for groups
-  when present
+* `globus group show` now displays subscription-related information for groups
+  when present.

--- a/changelog.d/20240304_114521_sirosen_get_subscription_info.md
+++ b/changelog.d/20240304_114521_sirosen_get_subscription_info.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* Add `globus group get-subscription-info` command to display a subscription.
+* `globus group show` now displays subscription related information for groups
+  when present

--- a/src/globus_cli/commands/group/__init__.py
+++ b/src/globus_cli/commands/group/__init__.py
@@ -13,6 +13,10 @@ from globus_cli.parsing import group
         "member": (".member", "group_member"),
         "set-policies": (".set_policies", "group_set_policies"),
         "show": (".show", "group_show"),
+        "get-subscription-info": (
+            ".get_subscription_info",
+            "group_get_subscription_info",
+        ),
         "get-by-subscription": (".get_by_subscription", "group_get_by_subscription"),
         "update": (".update", "group_update"),
     },

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -28,12 +28,47 @@ MEMBERSHIP_FIELDS = {
 }
 
 
-def group_id_arg(f: C) -> C:
-    return click.argument("GROUP_ID", type=click.UUID)(f)
-
-
 SESSION_ENFORCEMENT_FIELD = Field(
     "Session Enforcement",
     "enforce_session",
     formatter=formatters.FuzzyBoolFormatter(true_str="strict", false_str="not strict"),
 )
+
+SUBSCRIPTION_FIELDS = [
+    Field("Subscription ID", "subscription_id"),
+    Field("BAA", "subscription_info.is_baa", formatter=formatters.Bool),
+    Field(
+        "High Assurance",
+        "subscription_info.is_high_assurance",
+        formatter=formatters.Bool,
+    ),
+]
+
+# fields for display of groups with and without a subscription
+_BASE_GROUP_RECORD_FIELDS = [
+    Field("Name", "name"),
+    Field("Description", "description", wrap_enabled=True),
+    Field("Type", "group_type"),
+    Field("Visibility", "policies.group_visibility"),
+    Field("Membership Visibility", "policies.group_members_visibility"),
+    SESSION_ENFORCEMENT_FIELD,
+    Field("Join Requests Allowed", "policies.join_requests"),
+    Field(
+        "Signup Fields",
+        "policies.signup_fields",
+        formatter=formatters.SortedArray,
+    ),
+    Field(
+        "Roles",
+        "my_memberships[].role",
+        formatter=formatters.SortedArray,
+    ),
+]
+GROUP_FIELDS = [Field("Group ID", "id")] + _BASE_GROUP_RECORD_FIELDS
+GROUP_FIELDS_W_SUBSCRIPTION = (
+    [Field("Group ID", "id")] + SUBSCRIPTION_FIELDS + _BASE_GROUP_RECORD_FIELDS
+)
+
+
+def group_id_arg(f: C) -> C:
+    return click.argument("GROUP_ID", type=click.UUID)(f)

--- a/src/globus_cli/commands/group/get_by_subscription.py
+++ b/src/globus_cli/commands/group/get_by_subscription.py
@@ -11,21 +11,11 @@ from globus_cli.termio import (
     Field,
     TextMode,
     display,
-    formatters,
     outformat_is_text,
     print_command_hint,
 )
 
-from ._common import SESSION_ENFORCEMENT_FIELD
-
-_COMMON_FIELDS = [
-    Field("BAA", "subscription_info.is_baa", formatter=formatters.Bool),
-    Field(
-        "High Assurance",
-        "subscription_info.is_high_assurance",
-        formatter=formatters.Bool,
-    ),
-]
+from ._common import GROUP_FIELDS_W_SUBSCRIPTION, SUBSCRIPTION_FIELDS
 
 
 @click.argument("subscription_id", type=click.UUID)
@@ -57,29 +47,7 @@ def group_get_by_subscription(
         display(
             group_data,
             text_mode=TextMode.text_record,
-            fields=(
-                [Field("Group ID", "id")]
-                + _COMMON_FIELDS
-                + [
-                    Field("Name", "name"),
-                    Field("Description", "description", wrap_enabled=True),
-                    Field("Type", "group_type"),
-                    Field("Visibility", "policies.group_visibility"),
-                    Field("Membership Visibility", "policies.group_members_visibility"),
-                    SESSION_ENFORCEMENT_FIELD,
-                    Field("Join Requests Allowed", "policies.join_requests"),
-                    Field(
-                        "Signup Fields",
-                        "policies.signup_fields",
-                        formatter=formatters.SortedArray,
-                    ),
-                    Field(
-                        "Roles",
-                        "my_memberships[].role",
-                        formatter=formatters.SortedArray,
-                    ),
-                ]
-            ),
+            fields=GROUP_FIELDS_W_SUBSCRIPTION,
         )
     # otherwise, display the subscription data and text-mode will be just the Group ID
     else:
@@ -92,7 +60,7 @@ def group_get_by_subscription(
         display(
             subscription_data,
             text_mode=TextMode.text_record,
-            fields=[Field("Group ID", "group_id")] + _COMMON_FIELDS,
+            fields=[Field("Group ID", "group_id")] + SUBSCRIPTION_FIELDS,
         )
 
 

--- a/src/globus_cli/commands/group/get_subscription_info.py
+++ b/src/globus_cli/commands/group/get_subscription_info.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+
+import click
+
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import command
+from globus_cli.termio import Field, TextMode, display
+
+from ._common import SUBSCRIPTION_FIELDS
+
+
+@click.argument("subscription_id", type=click.UUID)
+@command("get-subscription-info")
+@LoginManager.requires_login("groups")
+def group_get_subscription_info(
+    login_manager: LoginManager, *, subscription_id: uuid.UUID
+) -> None:
+    """Show data about a specific Subscription."""
+    groups_client = login_manager.get_groups_client()
+
+    subscription_data = groups_client.get(f"/subscription_info/{subscription_id}")
+    display(
+        subscription_data,
+        text_mode=TextMode.text_record,
+        fields=[Field("Group ID", "group_id")] + SUBSCRIPTION_FIELDS,
+    )

--- a/src/globus_cli/commands/group/show.py
+++ b/src/globus_cli/commands/group/show.py
@@ -2,9 +2,9 @@ import uuid
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
-from globus_cli.termio import Field, TextMode, display, formatters
+from globus_cli.termio import TextMode, display
 
-from ._common import SESSION_ENFORCEMENT_FIELD, group_id_arg
+from ._common import GROUP_FIELDS, GROUP_FIELDS_W_SUBSCRIPTION, group_id_arg
 
 
 @group_id_arg
@@ -16,22 +16,9 @@ def group_show(login_manager: LoginManager, *, group_id: uuid.UUID) -> None:
 
     group = groups_client.get_group(group_id, include="my_memberships")
 
-    display(
-        group,
-        text_mode=TextMode.text_record,
-        fields=[
-            Field("Name", "name"),
-            Field("Description", "description", wrap_enabled=True),
-            Field("Type", "group_type"),
-            Field("Visibility", "policies.group_visibility"),
-            Field("Membership Visibility", "policies.group_members_visibility"),
-            SESSION_ENFORCEMENT_FIELD,
-            Field("Join Requests Allowed", "policies.join_requests"),
-            Field(
-                "Signup Fields",
-                "policies.signup_fields",
-                formatter=formatters.SortedArray,
-            ),
-            Field("Roles", "my_memberships[].role", formatter=formatters.SortedArray),
-        ],
-    )
+    if group.get("subscription_id") is not None:
+        fields = GROUP_FIELDS_W_SUBSCRIPTION
+    else:
+        fields = GROUP_FIELDS
+
+    display(group, text_mode=TextMode.text_record, fields=fields)

--- a/tests/functional/groups/test_get_by_subscription.py
+++ b/tests/functional/groups/test_get_by_subscription.py
@@ -164,10 +164,11 @@ def test_group_get_by_subscription_non_visible_group(
             r"The Group for this Subscription is not visible to you\.", result.stderr
         )
         result_lines = result.stdout.splitlines()
-        assert len(result_lines) == 3
+        assert len(result_lines) == 4
         assert re.match(r"Group ID:\s+" + re.escape(meta["group_id"]), result_lines[0])
         assert {r.partition(":")[0] for r in result_lines} == {
             "Group ID",
+            "Subscription ID",
             "BAA",
             "High Assurance",
         }

--- a/tests/functional/groups/test_get_subscription_info.py
+++ b/tests/functional/groups/test_get_subscription_info.py
@@ -1,0 +1,38 @@
+import uuid
+
+from globus_sdk._testing import RegisteredResponse
+
+
+def test_group_get_subscription_info_text(run_line):
+    subscription_id = str(uuid.uuid1())
+    group_id = str(uuid.uuid1())
+    connector_id = str(uuid.uuid1())
+
+    RegisteredResponse(
+        service="groups",
+        path=f"/subscription_info/{subscription_id}",
+        json={
+            "group_id": group_id,
+            "subscription_id": subscription_id,
+            "subscription_info": {
+                "connectors": {
+                    connector_id: {
+                        "is_baa": False,
+                        "is_ha": True,
+                    }
+                },
+                "is_baa": False,
+                "is_high_assurance": False,
+            },
+        },
+    ).add()
+
+    run_line(
+        f"globus group get-subscription-info {subscription_id}",
+        search_stdout=[
+            ("Group ID", group_id),
+            ("Subscription ID", subscription_id),
+            ("BAA", "False"),
+            ("High Assurance", "False"),
+        ],
+    )


### PR DESCRIPTION
This is a simpler variant of the `get-by-subscription` code which only
ever fetches the subscription info, not the underlying group. It
therefore:
- won't print a hint to stderr for text mode; if you really just
  wanted to get the group ID this is the simplest way
- has the same JSON output as `get-by-subscription`
- won't even try to fetch the group document (no network behavior)

Additionally, share some fields across commands in Groups a bit
better. `get-subscription-info` and `get-by-subscription` share
several fields, and `get-by-subscription` shares fields now with
`group show`.

As a result, there are some minor additional changes:
- `get-by-subscription` now shows the subscription ID in its text
  output
- `group show` shows subscription info *conditionally* if
  subscription_id is present and set
