### PR TITLE
Release v3.27.0

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -2,6 +2,27 @@
 
 // scriv-insert-here
 
+== 3.27.0 (2024-03-28)
+
+Enhancements:
+
+* Add `globus group get-by-subscription` for looking up Subscription Groups
+  based on their subscription IDs.
+
+* Add `--parent-id` to `globus group create`, allowing group administrators to
+  create subgroups.
+
+* Add `globus group get-subscription-info` command to display a subscription.
+* `globus group show` now displays subscription-related information for groups
+  when present.
+
+* Add `globus stat` for getting the status of a path on a collection.
+
+Other:
+
+* Remove implicit `autoactivate` calls from various Transfer operations.
+  They are no longer needed and incur a minor performance penalty.
+
 == 3.26.0 (2024-03-01)
 
 Bugfixes:

--- a/changelog.d/20240226_144957_sirosen_get_group_by_subscription_id.md
+++ b/changelog.d/20240226_144957_sirosen_get_group_by_subscription_id.md
@@ -1,4 +1,0 @@
-### Enhancements
-
-* Add `globus group get-by-subscription` for looking up Subscription Groups
-  based on their subscription IDs.

--- a/changelog.d/20240301_153447_sirosen_groups_parent_id.md
+++ b/changelog.d/20240301_153447_sirosen_groups_parent_id.md
@@ -1,4 +1,0 @@
-### Enhancements
-
-* Add `--parent-id` to `globus group create`, allowing group administrators to
-  create subgroups.

--- a/changelog.d/20240301_165700_sirosen_remove_implicit_autoactivate.md
+++ b/changelog.d/20240301_165700_sirosen_remove_implicit_autoactivate.md
@@ -1,4 +1,0 @@
-### Other
-
-* Remove implicit `autoactivate` calls from various Transfer operations.
-  They are no longer needed and incur a minor performance penalty.

--- a/changelog.d/20240304_114521_sirosen_get_subscription_info.md
+++ b/changelog.d/20240304_114521_sirosen_get_subscription_info.md
@@ -1,5 +1,0 @@
-### Enhancements
-
-* Add `globus group get-subscription-info` command to display a subscription.
-* `globus group show` now displays subscription-related information for groups
-  when present.

--- a/changelog.d/20240304_132149_aaschaer.md
+++ b/changelog.d/20240304_132149_aaschaer.md
@@ -1,3 +1,0 @@
-### Enhancements
-
-* Add `globus stat` command for getting the status of a path on a collection

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -7,7 +7,7 @@ if t.TYPE_CHECKING:
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.26.0"
+__version__ = "3.27.0"
 
 # app name to send as part of SDK requests
 app_name = f"Globus CLI v{__version__}"


### PR DESCRIPTION
Enhancements:

* Add `globus group get-by-subscription` for looking up Subscription Groups
  based on their subscription IDs.

* Add `--parent-id` to `globus group create`, allowing group administrators to
  create subgroups.

* Add `globus group get-subscription-info` command to display a subscription.
* `globus group show` now displays subscription-related information for groups
  when present.

* Add `globus stat` for getting the status of a path on a collection.

Other:

* Remove implicit `autoactivate` calls from various Transfer operations.
  They are no longer needed and incur a minor performance penalty.
