### PR TITLE
Allow subscriptions to be assigned to existing flows

### DIFF
--- a/changelog.d/20240408_154039_kurtmckee_flows_update_subscriptions_sc_30164.md
+++ b/changelog.d/20240408_154039_kurtmckee_flows_update_subscriptions_sc_30164.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Allow subscriptions to be assigned to existing flows
+  using the `globus flows update --subscription-id` option.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "globus-sdk==3.39.0",
+    "globus-sdk==3.40.0",
     "click>=8.1.4,<9",
     "jmespath==1.0.1",
     "packaging>=17.0",

--- a/src/globus_cli/commands/flows/_common.py
+++ b/src/globus_cli/commands/flows/_common.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import typing as t
+import uuid
+
 import click
 
 from globus_cli.parsing import JSONStringOrFile
@@ -100,5 +105,32 @@ keywords_option = click.option(
 
         This option can be specified multiple times
         to create a list of keywords.
+    """,
+)
+
+
+class SubscriptionIdType(click.ParamType):
+    name = "SUBSCRIPTION_ID"
+
+    def convert(
+        self, value: str, param: click.Parameter | None, ctx: click.Context | None
+    ) -> uuid.UUID | t.Literal["DEFAULT"]:
+        if value.upper() == "DEFAULT":
+            return "DEFAULT"
+        try:
+            return uuid.UUID(value)
+        except ValueError:
+            self.fail(f"{value} must be either a UUID or 'DEFAULT'", param, ctx)
+
+
+subscription_id_option = click.option(
+    "--subscription-id",
+    "subscription_id",
+    type=SubscriptionIdType(),
+    multiple=False,
+    help="""
+        A subscription ID to assign to the flow.
+
+        The value may be a UUID or the word "DEFAULT".
     """,
 )

--- a/src/globus_cli/commands/flows/update.py
+++ b/src/globus_cli/commands/flows/update.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import typing as t
 import uuid
 
 import click
+from globus_sdk.utils import MISSING
 
 from globus_cli.commands.flows._common import (
     description_option,
     input_schema_option,
+    subscription_id_option,
     subtitle_option,
 )
 from globus_cli.login_manager import LoginManager
@@ -104,6 +107,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
         Passing an empty string will clear any existing keywords.
     """,
 )
+@subscription_id_option
 @LoginManager.requires_login("flows")
 def update_command(
     login_manager: LoginManager,
@@ -119,6 +123,7 @@ def update_command(
     starters: list[str] | None,
     viewers: list[str] | None,
     keywords: list[str] | None,
+    subscription_id: uuid.UUID | t.Literal["DEFAULT"] | None,
 ) -> None:
     """
     Update a flow.
@@ -154,6 +159,7 @@ def update_command(
         flow_starters=starters,
         flow_viewers=viewers,
         keywords=keywords,
+        subscription_id=subscription_id or MISSING,
     )
 
     # Configure formatters for principals
@@ -170,6 +176,7 @@ def update_command(
         Field("Description", "description"),
         Field("Keywords", "keywords", formatter=formatters.ArrayFormatter()),
         Field("Owner", "flow_owner", formatter=principal_formatter),
+        Field("Subscription ID", "subscription_id"),
         Field("Created At", "created_at", formatter=formatters.Date),
         Field("Updated At", "updated_at", formatter=formatters.Date),
         Field(

--- a/tests/functional/flows/test_update_flow.py
+++ b/tests/functional/flows/test_update_flow.py
@@ -58,6 +58,7 @@ def test_update_flow_text_output(run_line):
         ("--starters", ",".join(flow_starters)),
         ("--viewers", ",".join(flow_viewers)),
         ("--keywords", ",".join(keywords)),
+        ("--subscription-id", str(uuid.uuid4())),
     ]
 
     command = ["globus", "flows", "update", flow_id, *chain.from_iterable(options)]
@@ -72,6 +73,7 @@ def test_update_flow_text_output(run_line):
         "Description",
         "Keywords",
         "Owner",
+        "Subscription ID",
         "Created At",
         "Updated At",
         "Administrators",
@@ -150,7 +152,13 @@ def test_omitted_options(run_line):
     run_line(command)
 
     request = get_last_request()
-    omitted_keys = {"flow_administrators", "flow_starters", "flow_viewers", "keywords"}
+    omitted_keys = {
+        "flow_administrators",
+        "flow_starters",
+        "flow_viewers",
+        "keywords",
+        "subscription_id",
+    }
     assert json.loads(request.body).keys() & omitted_keys == set()
 
 


### PR DESCRIPTION
### Enhancements

* Allow subscriptions to be assigned to existing flows
  using the `globus flows update --subscription-id` option.
