### PR TITLE
Fix a regression in handling of EPIPE

### DIFF
--- a/changelog.d/20240427_163628_sirosen_fix_epipe_regression.md
+++ b/changelog.d/20240427_163628_sirosen_fix_epipe_regression.md
@@ -1,0 +1,6 @@
+### Bugfixes
+
+* In certain conditions, the CLI would not handle Broken Pipe errors (EPIPE)
+  correctly, resulting in error messages on stderr when commands were piped to
+  commands like `head`. The handling of broken pipes has been improved to avoid
+  these spurious error messages.

--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -212,6 +212,10 @@ class TopLevelGroup(GlobusCommandGroup):
     def invoke(self, ctx: click.Context) -> t.Any:
         try:
             return super().invoke(ctx)
+        # explicitly re-raise any IOError (e.g. broken pipe) in order to engage
+        # click's existing handling of broken pipes
+        except OSError:
+            raise
         except Exception:
             # mypy thinks that exc_info could be (None, None, None), but... nope. False.
             custom_except_hook(sys.exc_info())  # type: ignore[arg-type]

--- a/tests/unit/test_command_decorators.py
+++ b/tests/unit/test_command_decorators.py
@@ -1,6 +1,36 @@
+import errno
+from unittest import mock
+
 import click
 
-from globus_cli.parsing import command
+from globus_cli.parsing import command, main_group
+
+
+def test_main_group_is_always_named_globus():
+    @main_group()
+    def foo():
+        pass
+
+    assert foo.name == "globus"
+
+
+def test_main_group_reraises_epipe_errors_without_invoking_custom_handler(runner):
+    @main_group()
+    def foo():
+        click.echo("hi")
+        # simulate a broken pipe, as would happen if a command is piped to a command
+        # which only reads some of the output before closing the stream, like `head`
+        raise OSError("broken pipe", errno=errno.EPIPE)
+
+    # we want to assert not only that the command exits successfully, but specifically
+    # that it does not invoke the CLI's custom exception handler
+    #
+    # if it does, that means we won't get click's cleanup for EPIPE, which includes
+    # special wrapping of `sys.stdout` and `sys.stderr`
+    with mock.patch("globus_cli.parsing.commands.custom_except_hook") as mock_handler:
+        result = runner.invoke(foo, [])
+    assert result.exit_code == 0
+    assert mock_handler.call_count == 0
 
 
 def test_custom_command_missing_param_helptext(runner):


### PR DESCRIPTION
In click 7.0, a body of work introduced some specialty EPIPE handling.
At the time, we picked up the benefit and it worked under several test
scenarios. click's handling has not changed, but at some point we
updated the way we were passing exceptions to our custom excepthook.
In the course of that work, we accidentally broke the EPIPE handling,
which expects the error to ascend from `Command.invoke()` to
`Command.main()`.

We have no current need to invoke our excepthooks on OSError of any
flavor, so as the immediate fix, we can start reraising those
immediately.

In the future, we could refine this to only reraise on EPIPE,
specifically, if necessary. The unit test for this behavior specifies
EPIPE, to be robust to such an improvement.

The error can be verified and confirmed fixed with a usage like

    globus endpoint search tutorial | head -n1

Prior to this fix, broken pipe errors are sent to stderr. With the
fix, they do not appear.
