### PR TITLE
Add `globus flows validate` command

### DIFF
--- a/changelog.d/20240501_093852_ada_add_flows_validate_command_sc_33101.md
+++ b/changelog.d/20240501_093852_ada_add_flows_validate_command_sc_33101.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* Added a new *beta* command `globus flows validate` to validate a provided flow
+  definition and optional input schema without creating a flow. This command provides
+  extended validation and analysis of the provided flow definition.

--- a/src/globus_cli/commands/flows/__init__.py
+++ b/src/globus_cli/commands/flows/__init__.py
@@ -6,6 +6,7 @@ from globus_cli.parsing import group
     lazy_subcommands={
         "create": (".create", "create_command"),
         "update": (".update", "update_command"),
+        "validate": (".validate", "validate_command"),
         "delete": (".delete", "delete_command"),
         "list": (".list", "list_command"),
         "show": (".show", "show_command"),

--- a/src/globus_cli/commands/flows/_common.py
+++ b/src/globus_cli/commands/flows/_common.py
@@ -7,11 +7,7 @@ import click
 
 from globus_cli.parsing import JSONStringOrFile
 
-input_schema_option = click.option(
-    "--input-schema",
-    "input_schema",
-    type=JSONStringOrFile(),
-    help="""
+_input_schema_helptext = """
         The JSON input schema that governs the parameters
         used to start the flow.
 
@@ -26,11 +22,22 @@ input_schema_option = click.option(
 
         \b
             --input-schema schema.json
+    """
 
-        If unspecified, the default is an empty JSON object ('{}').
-    """,
+input_schema_option = click.option(
+    "--input-schema",
+    "input_schema",
+    type=JSONStringOrFile(),
+    help=_input_schema_helptext,
 )
 
+input_schema_option_with_default = click.option(
+    "--input-schema",
+    "input_schema",
+    type=JSONStringOrFile(),
+    help=_input_schema_helptext
+    + "\n    If unspecified, the default is an empty JSON object ('{}').",
+)
 
 subtitle_option = click.option(
     "--subtitle",

--- a/src/globus_cli/commands/flows/create.py
+++ b/src/globus_cli/commands/flows/create.py
@@ -7,7 +7,7 @@ import click
 from globus_cli.commands.flows._common import (
     administrators_option,
     description_option,
-    input_schema_option,
+    input_schema_option_with_default,
     keywords_option,
     starters_option,
     subtitle_option,
@@ -31,7 +31,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
     type=JSONStringOrFile(),
     metavar="DEFINITION",
 )
-@input_schema_option
+@input_schema_option_with_default
 @subtitle_option
 @description_option
 @administrators_option

--- a/src/globus_cli/commands/flows/update.py
+++ b/src/globus_cli/commands/flows/update.py
@@ -8,7 +8,7 @@ from globus_sdk.utils import MISSING
 
 from globus_cli.commands.flows._common import (
     description_option,
-    input_schema_option,
+    input_schema_option_with_default,
     subscription_id_option,
     subtitle_option,
 )
@@ -63,7 +63,7 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 )
 @subtitle_option
 @description_option
-@input_schema_option
+@input_schema_option_with_default
 @click.option(
     "--administrators",
     type=CommaDelimitedList(),

--- a/src/globus_cli/commands/flows/validate.py
+++ b/src/globus_cli/commands/flows/validate.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import click
+import globus_sdk
+
+from globus_cli.commands.flows._common import input_schema_option
+from globus_cli.login_manager import LoginManager
+from globus_cli.parsing import JSONStringOrFile, ParsedJSONData, command
+from globus_cli.termio import Field, display
+
+
+@command("validate", short_help="Validate a flow definition")
+@click.argument(
+    "definition",
+    type=JSONStringOrFile(),
+    metavar="DEFINITION",
+)
+@input_schema_option
+@LoginManager.requires_login("flows")
+def validate_command(
+    login_manager: LoginManager,
+    *,
+    definition: ParsedJSONData,
+    input_schema: ParsedJSONData | None,
+) -> None:
+    """
+    Validate a flow definition (BETA).
+
+    DEFINITION is the JSON document that defines the flow's instructions.
+    The definition document may be specified inline, or it may be
+    a path to a JSON file.
+
+        Example: Inline JSON:
+
+        \b
+            globus flows validate \\
+            '{{"StartAt": "a", "States": {{"a": {{"Type": "Pass", "End": true}}}}}}'
+
+        Example: Path to JSON file:
+
+        \b
+            globus flows validate definition.json
+    """
+    payload = {}
+
+    # Ensure that the definition is a JSON object
+    if not isinstance(definition.data, dict):
+        raise click.UsageError("Flow definition must be a JSON object")
+    payload["definition"] = definition.data
+
+    # Ensure the input schema, if provided, is a JSON object
+    if input_schema is not None:
+        if not isinstance(input_schema.data, dict):
+            raise click.UsageError("--input-schema must be a JSON object")
+        payload["input_schema"] = input_schema.data
+
+    # Configure client
+    flows_client = login_manager.get_flows_client()
+
+    res = flows_client.validate_flow(**payload)
+
+    display(
+        res,
+        text_mode=_validate_flow_output_handler,
+    )
+
+
+def _validate_flow_output_handler(result: globus_sdk.GlobusHTTPResponse) -> None:
+    # Discovered scopes output
+    scopes_response = result.get("scopes")
+    # Beta API: Defend against the case where 'scopes' is no longer returned
+    if scopes_response is not None:
+        _validate_flow_scope_output_handler(scopes_response)
+
+
+def _validate_flow_scope_output_handler(scopes_response: dict[str, str]) -> None:
+    # Always include User and Flow scopes
+    scopes_fields = [Field("Identity", "identity"), Field("Scope", "scope")]
+    scope_entries = [
+        {"identity": k, "scope": scope}
+        for k, scopes in scopes_response.items()
+        for scope in scopes
+    ]
+    click.echo("Discovered Scopes")
+    click.echo("=================")
+    if scope_entries:
+        display.render_table(
+            scope_entries,
+            fields=scopes_fields,
+        )
+    else:
+        click.echo("No scopes discovered")

--- a/src/globus_cli/commands/flows/validate.py
+++ b/src/globus_cli/commands/flows/validate.py
@@ -75,9 +75,9 @@ def _validate_flow_output_handler(result: globus_sdk.GlobusHTTPResponse) -> None
 
 def _validate_flow_scope_output_handler(scopes_response: dict[str, str]) -> None:
     # Always include User and Flow scopes
-    scopes_fields = [Field("Identity", "identity"), Field("Scope", "scope")]
+    scopes_fields = [Field("RunAs", "RunAs"), Field("Scope", "scope")]
     scope_entries = [
-        {"identity": k, "scope": scope}
+        {"RunAs": k, "scope": scope}
         for k, scopes in scopes_response.items()
         for scope in scopes
     ]

--- a/src/globus_cli/termio/printer.py
+++ b/src/globus_cli/termio/printer.py
@@ -199,7 +199,7 @@ class Renderer:
             sort_json_keys=sort_json_keys,
         )
 
-    def render_table(self, iterable, fields, print_headers=True):
+    def render_table(self, iterable, fields, print_headers=True) -> None:
         print_table(iterable, fields, print_headers)
 
 

--- a/src/globus_cli/termio/printer.py
+++ b/src/globus_cli/termio/printer.py
@@ -170,7 +170,6 @@ class Renderer:
     TABLE = TextMode.text_table
     SILENT = TextMode.silent
     JSON = TextMode.json
-    TABLE = TextMode.text_table
     RECORD = TextMode.text_record
     RECORD_LIST = TextMode.text_record_list
     RAW = TextMode.text_raw
@@ -199,6 +198,9 @@ class Renderer:
             response_key=response_key,
             sort_json_keys=sort_json_keys,
         )
+
+    def render_table(self, iterable, fields, print_headers=True):
+        print_table(iterable, fields, print_headers)
 
 
 display = Renderer()

--- a/src/globus_cli/termio/printer.py
+++ b/src/globus_cli/termio/printer.py
@@ -199,7 +199,12 @@ class Renderer:
             sort_json_keys=sort_json_keys,
         )
 
-    def render_table(self, iterable, fields, print_headers=True) -> None:
+    def render_table(
+        self,
+        iterable: t.Iterable[t.Any],
+        fields: list[Field],
+        print_headers: bool = True,
+    ) -> None:
         print_table(iterable, fields, print_headers)
 
 

--- a/tests/functional/flows/test_validate_flow.py
+++ b/tests/functional/flows/test_validate_flow.py
@@ -111,7 +111,7 @@ def test_validate_flow_output(response_set, expected_table_data, run_line):
         # Get the rows of the table
         headers, table_data = _parse_table_content(result.output)[0]
         # Check all fields are present
-        assert headers == ["Identity", "Scope"]
+        assert headers == ["RunAs", "Scope"]
         # Check the entries
         assert len(table_data) == len(expected_table_data)
         assert len(table_data[0]) == 2

--- a/tests/functional/flows/test_validate_flow.py
+++ b/tests/functional/flows/test_validate_flow.py
@@ -1,0 +1,186 @@
+import json
+import re
+from itertools import chain
+
+import pytest
+from globus_sdk._testing import (
+    get_last_request,
+    load_response_set,
+    register_response_set,
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _register_responses():
+    # Missing (defensive case for beta API)
+    register_response_set(
+        "cli.flow_validate.missing",
+        dict(
+            default=dict(
+                service="flows",
+                path="/flows/validate",
+                method="POST",
+                json={},
+            ),
+        ),
+    )
+    # Empty scopes
+    register_response_set(
+        "cli.flow_validate.none",
+        dict(
+            default=dict(
+                service="flows",
+                path="/flows/validate",
+                method="POST",
+                json={"scopes": {}},
+            ),
+        ),
+    )
+    # User scopes
+    register_response_set(
+        "cli.flow_validate.user",
+        dict(
+            default=dict(
+                service="flows",
+                path="/flows/validate",
+                method="POST",
+                json={
+                    "scopes": {
+                        "User": ["urn:globus:auth:scope:transfer.api.globus.org:all"]
+                    }
+                },
+            ),
+        ),
+    )
+    # Multiple Flow and User scopes
+    register_response_set(
+        "cli.flow_validate.multi",
+        dict(
+            default=dict(
+                service="flows",
+                path="/flows/validate",
+                method="POST",
+                json={
+                    "scopes": {
+                        "User": ["urn:globus:auth:scope:foo.api.globus.org:all"],
+                        "Flow": [
+                            "urn:globus:auth:scope:bar.api.globus.org:all",
+                            "urn:globus:auth:scope:baz.api.globus.org:all",
+                        ],
+                    },
+                },
+            ),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "response_set, expected_table_data",
+    [
+        pytest.param("cli.flow_validate.none", [], id="no_scopes"),
+        pytest.param(
+            "cli.flow_validate.user",
+            [["User", "urn:globus:auth:scope:transfer.api.globus.org:all"]],
+            id="user_scopes",
+        ),
+        pytest.param(
+            "cli.flow_validate.multi",
+            [
+                ["User", "urn:globus:auth:scope:foo.api.globus.org:all"],
+                ["Flow", "urn:globus:auth:scope:bar.api.globus.org:all"],
+                ["Flow", "urn:globus:auth:scope:baz.api.globus.org:all"],
+            ],
+            id="multi_scopes",
+        ),
+    ],
+)
+def test_validate_flow_output(response_set, expected_table_data, run_line):
+    # Load the response mock and extract metadata
+    load_response_set(response_set)
+    definition = {"StartAt": "a", "States": {"a": {"Type": "Pass", "End": True}}}
+
+    # Construct the command line
+    command = ["globus", "flows", "validate", json.dumps(definition)]
+
+    result = run_line(command)
+
+    if not expected_table_data:
+        # Check for the "No scopes discovered" message
+        assert "No scopes discovered" in result.output
+    else:
+        # Get the rows of the table
+        headers, table_data = _parse_table_content(result.output)[0]
+        # Check all fields are present
+        assert headers == ["Identity", "Scope"]
+        # Check the entries
+        assert len(table_data) == len(expected_table_data)
+        assert len(table_data[0]) == 2
+        assert table_data == expected_table_data
+
+
+def test_validate_flow_output_missing(run_line):
+    load_response_set("cli.flow_validate.missing")
+    result = run_line(["globus", "flows", "validate", "{}"])
+    assert "Discovered Scopes" not in result.output
+
+
+@pytest.mark.parametrize("input_schema", [None, {}])
+def test_validate_flow_input_schema(input_schema, run_line):
+    load_response_set("cli.flow_validate.none")
+    definition = {"StartAt": "a", "States": {"a": {"Type": "Pass", "End": True}}}
+
+    # Construct the command line
+    options = [(json.dumps(definition),)]
+    if input_schema is not None:
+        options.append(("--input-schema", json.dumps(input_schema)))
+
+    command = ["globus", "flows", "validate", *chain.from_iterable(options)]
+    result = run_line(command)
+
+    assert "No scopes discovered" in result.output
+
+    if input_schema is None:
+        # We should not have sent the input schema in the request
+        assert json.loads(get_last_request().body) == {"definition": definition}
+    else:
+        # We should have sent the input schema in the request
+        assert json.loads(get_last_request().body) == {
+            "definition": definition,
+            "input_schema": input_schema,
+        }
+
+
+def _parse_table_content(output):
+    """
+    Parse the output of a command, searching for tables in the output and returning
+    a list of headers and a list of rows (which are lists of cell values).
+
+    Expects a table with divider lines of the form `--- | --- | ---` and rows of the
+    form `value | value | value`.
+
+    Returns a list of tuples where each tuple represents a parsed table and is
+    comprised of a list of headers and a list of rows.
+
+    Raises a ValueError if no table is found in the output.
+    """
+    # Find the table divider
+    lines = output.split("\n")
+    divider_indices = [
+        i for i, line in enumerate(lines) if re.fullmatch(r"[-| ]*", line)
+    ]
+
+    if not divider_indices:
+        raise ValueError("No table found in output")
+
+    tables = []
+    for divider_index in divider_indices:
+        # Parse the headers and rows
+        headers = [header.strip() for header in lines[divider_index - 1].split(" | ")]
+        rows = lines[divider_index + 1 :]
+        # Turn the rows into a table data as a list of lists
+        table_data = [
+            [cell.strip() for cell in row.split(" | ")] for row in rows if row
+        ]
+        tables.append((headers, table_data))
+
+    return tables

--- a/tests/functional/flows/test_validate_flow.py
+++ b/tests/functional/flows/test_validate_flow.py
@@ -166,7 +166,7 @@ def _parse_table_content(output):
     # Find the table divider
     lines = output.split("\n")
     divider_indices = [
-        i for i, line in enumerate(lines) if re.fullmatch(r"[-| ]*", line)
+        i for i, line in enumerate(lines) if re.fullmatch(r"-+ \| [-| ]*", line)
     ]
 
     if not divider_indices:


### PR DESCRIPTION
Some affordances are provided for anticipated future output. In particular, the non-error output includes a way to render multiple sections corresponding to different analyses that were performed during the `/flows/validate` call. Importantly, `display()` is only called once, insuring proper behavior when formats (like JSON) are specifically requested.

## Expected Output (User scopes)

```
Discovered Scopes
=================
Identity | Scope
-------- | --------------------------------------------------------------------------------------------
User     | https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/transfer_collection_info
User     | https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/transfer_mkdir
User     | https://auth.globus.org/scopes/5fac2e64-c734-4e6b-90ea-ff12ddbf9653/transfer_ls
User     | https://auth.globus.org/scopes/actions.globus.org/transfer/delete
User     | https://auth.globus.org/scopes/actions.globus.org/transfer/transfer
```

## Expected Output (No scopes)

```
Discovered Scopes
=================
No scopes discovered
```