### PR TITLE
Further refine error reporting for /flows/validate

### DIFF
--- a/changelog.d/20240502_124425_sirosen_flows_error_refinement.md
+++ b/changelog.d/20240502_124425_sirosen_flows_error_refinement.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Improve the reporting of errors found by `globus flows validate`

--- a/tests/functional/exception_handling/test_flows_hooks.py
+++ b/tests/functional/exception_handling/test_flows_hooks.py
@@ -96,6 +96,7 @@ def test_flows_generic_hook_on_detail_array(run_line):
     assert "This flow contains errors in 1 wait state." in result.stderr
     assert "detail:" in result.stderr
     assert (
+        "InvalidAccessPath $.definition.States.y.SecondsPath: "
         "Improper access to data in this wait state with expression: $.foo[0]"
         in result.stderr
     )


### PR DESCRIPTION
This API produces non-422 errors with a details array of objects,
which is frequently overwhelming in terms of sheer information
returned.

For the textual presentation of errors, select specific fields to show
from suberror objects.

The logic runs as follows:
- if the 'detail' is an array, try to generate a better string

  - if its an array of {'loc': ..., 'msg': ...} blobs, then
    - format each element to a string
    - if there is only one, show it
    - if there are multiple, newline join them and show them

  - otherwise (not the "right shape")
    - produce the previous, compact format

This dramatically improves the presentation of validation errors
raised through our schema evaluations.
