### PR TITLE
Fix handling of API errors with null JSON data

### DIFF
--- a/changelog.d/20240502_155411_sirosen_handle_null_errors.md
+++ b/changelog.d/20240502_155411_sirosen_handle_null_errors.md
@@ -1,0 +1,3 @@
+### Bugfixes
+
+* Fix printing of API errors which do not contain JSON data

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -64,7 +64,18 @@ _DEFAULT_CONSENT_REAUTH_MESSAGE = (
 
 @sdk_error_handler(
     error_class="GlobusAPIError",
-    condition=lambda err: outformat_is_json() and err.raw_json is not None,
+    condition=lambda err: err.raw_json is None,
+)
+def null_data_error_handler(exception: globus_sdk.GlobusAPIError) -> None:
+    write_error_info(
+        "GlobusAPINullDataError",
+        [PrintableErrorField("error_type", exception.__class__.__name__)],
+    )
+
+
+@sdk_error_handler(
+    error_class="GlobusAPIError",
+    condition=lambda err: outformat_is_json(),
 )
 def json_error_handler(exception: globus_sdk.GlobusAPIError) -> None:
     click.echo(

--- a/src/globus_cli/termio/errors.py
+++ b/src/globus_cli/termio/errors.py
@@ -45,7 +45,7 @@ class PrintableErrorField:
 def write_error_info(error_name: str, fields: list[PrintableErrorField]) -> None:
     if outformat_is_json():
         # dictify joined tuple lists and dump to json string
-        click.style(
+        message = click.style(
             json.dumps(
                 dict(
                     [("error_name", error_name)]

--- a/tests/functional/exception_handling/test_json_output.py
+++ b/tests/functional/exception_handling/test_json_output.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from globus_sdk._testing import RegisteredResponse
 
 
@@ -15,3 +16,33 @@ def test_base_json_hook(run_line):
     ).add()
     result = run_line("globus api transfer GET /foo -Fjson", assert_exit_code=1)
     assert response.json == json.loads(result.stderr)
+
+
+@pytest.mark.parametrize("output_format", ("json", "text"))
+def test_base_json_hook_when_no_body_is_present(run_line, output_format):
+    """
+    confirms that the base json hook captures the error JSON and prints it verbatim
+    """
+    RegisteredResponse(
+        service="transfer",
+        path="/foo",
+        status=500,
+        json=None,
+    ).add()
+
+    add_opts = []
+    if output_format == "json":
+        add_opts = ["-Fjson"]
+
+    result = run_line(
+        ["globus", "api", "transfer", "GET", "/foo", *add_opts], assert_exit_code=1
+    )
+
+    if output_format == "json":
+        assert json.loads(result.stderr) == {
+            "error_name": "GlobusAPINullDataError",
+            "error_type": "TransferAPIError",
+        }
+    else:
+        assert "GlobusAPINullDataError" in result.stderr
+        assert "TransferAPIError" in result.stderr


### PR DESCRIPTION
1. Before the JSON printing hook, add a generic hook for any data with
   a null body.

This lets the JSON printing hook stay small and single-purpose, but
avoids passing a null bodied error to any subsequent hook.

2. Fix a dropped assignment in write_error_info() when the output is
   JSON.

This was broken at some point in the past, but is basically
unreachable when a normal error occurs, now that we have a dedicated
JSON-printing hook as one of the first hooks.

It needs to either be fixed or removed, and for the immediate change
it is fixed and used by the null data printer.

A couple of test cases are included for the GlobusAPINullDataError
case, which should be easy to identify if it occurs in the wild in the
future.
