### PR TITLE
Fixed timer creation no-end rendering

### DIFF
--- a/changelog.d/20240513_143239_derek_timer_schedule_null_check.md
+++ b/changelog.d/20240513_143239_derek_timer_schedule_null_check.md
@@ -1,0 +1,3 @@
+### Bugfixes
+
+* Fixed a bug which would break rendering if a user created a timer with no end.

--- a/src/globus_cli/commands/timer/_common.py
+++ b/src/globus_cli/commands/timer/_common.py
@@ -66,7 +66,7 @@ class ScheduleFormatter(formatters.FieldFormatter[t.Dict[str, t.Any]]):
             start = value.get("start")
             if start:
                 start = formatters.Date.render(formatters.Date.parse(start))
-            end = value.get("end", {})
+            end = value.get("end") or {}
 
             ret = f"every {interval} seconds, starting {start}"
             if end.get("datetime"):


### PR DESCRIPTION
## What?
* Fixed a bug in timer-transfer creation which would cause the rendering to break if no end time was specified for a recurring timer.

## CLI Usage

### Current Behavior
```
> export GLOBUS_SDK_ENVIRONMENT=test
> globus timer create transfer --interval 1m 7707a06d-535c-41fe-bf2b-b69294c334ae:/derek-test-src 7707a06d-535c-41fe-bf2b-b69294c334ae:/derek-test-dest
Timer ID:               2b6a55f2-ad48-462d-8592-8895e17026eb
Name:                   CLI Created Timer [2024-05-13T14:35:58.554371]
Type:                   None
Submitted At:           2024-05-13 14:35:59
Status:                 loaded
Last Run:               None
Next Run:               2024-05-13 14:35:59
AttributeError: 'NoneType' object has no attribute 'get'
```

### New Behavior
```
> export GLOBUS_SDK_ENVIRONMENT=test
> globus timer create transfer --interval 1m 7707a06d-535c-41fe-bf2b-b69294c334ae:/derek-test-src 7707a06d-535c-41fe-bf2b-b69294c334ae:/derek-test-dest
Timer ID:               27a7e8e0-16aa-462f-8203-7aa0f68632bf
Name:                   CLI Created Timer [2024-05-13T14:37:07.273340]
Type:                   None
Submitted At:           2024-05-13 14:37:08
Status:                 loaded
Last Run:               None
Next Run:               2024-05-13 14:37:08
Schedule:               every 60 seconds, starting 2024-05-13 14:37:08
Number of Runs:         0
Number of Timer Errors: 0
```