### PR TITLE
Release v3.28.3

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -2,6 +2,14 @@
 
 // scriv-insert-here
 
+== 3.28.3 (2024-06-14)
+
+Bugfixes:
+
+* Fix a bug which would break rendering if a user created a timer with no end.
+
+* Resolve a `KeyError` that can happen if scope resolution fails during flow validation.
+
 == 3.28.2 (2024-05-02)
 
 Bugfixes:

--- a/changelog.d/20240513_143239_derek_timer_schedule_null_check.md
+++ b/changelog.d/20240513_143239_derek_timer_schedule_null_check.md
@@ -1,3 +1,0 @@
-### Bugfixes
-
-* Fixed a bug which would break rendering if a user created a timer with no end.

--- a/changelog.d/20240514_150809_kurtmckee_resolve_message_key_error_sc_33613.md
+++ b/changelog.d/20240514_150809_kurtmckee_resolve_message_key_error_sc_33613.md
@@ -1,3 +1,0 @@
-### Bugfixes
-
-* Resolve a `KeyError` that can happen if scope resolution fails during flow validation.

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -7,7 +7,7 @@ if t.TYPE_CHECKING:
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.28.2"
+__version__ = "3.28.3"
 
 # app name to send as part of SDK requests
 app_name = f"Globus CLI v{__version__}"


### PR DESCRIPTION
Bugfixes:

* Fix a bug which would break rendering if a user created a timer with no end.

* Resolve a `KeyError` that can happen if scope resolution fails during flow validation.
