### PR TITLE
Add a '--quiet' option as an inverse of '-v/--verbose'

### DIFF
--- a/changelog.d/20240614_150311_sirosen_add_quiet_option.md
+++ b/changelog.d/20240614_150311_sirosen_add_quiet_option.md
@@ -1,5 +1,5 @@
 ### Enhancements
 
-* All commands now support a `--quiet` option which decreases verbosity. For
+* All commands now support a `--quiet` option which minimizes verbosity. For
   most commands, this option will not change the default output, but
   it will counteract the `-v/--verbose` option.

--- a/changelog.d/20240614_150311_sirosen_add_quiet_option.md
+++ b/changelog.d/20240614_150311_sirosen_add_quiet_option.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* All commands now support a `--quiet` option which decreases verbosity. For
+  most commands, this option will not change the default output, but
+  it will counteract the `-v/--verbose` option.

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -66,6 +66,27 @@ class CommandState:
     def is_verbose(self) -> bool:
         return self.verbosity > 0
 
+    def set_verbosity(self, value: int) -> None:
+        self.verbosity = value
+
+        # verbosity level 0: never warn, never log normal events
+        # (also covers negative/quiet modes, e.g. `--quiet`)
+        if value <= 0:
+            _warnings.simplefilter("ignore")
+            _setup_logging(level="CRITICAL")
+        # verbosity level 1: warn minimally, log errors
+        elif value == 1:
+            _warnings.simplefilter("once")
+            _setup_logging(level="ERROR")
+        # verbosity level 2: warn once per usage, log info
+        elif value == 2:
+            _warnings.simplefilter("default")
+            _setup_logging(level="INFO")
+        # verbosity level 3+: warn always, log debug
+        elif value >= 3:
+            _warnings.simplefilter("always")
+            _setup_logging(level="DEBUG")
+
 
 def format_option(f: F) -> F:
     def callback(ctx: click.Context, param: click.Parameter, value: t.Any) -> None:
@@ -118,16 +139,13 @@ def format_option(f: F) -> F:
 
 
 def debug_option(f: F) -> F:
-    def callback(ctx: click.Context, param: click.Parameter, value: t.Any) -> None:
-        if not value or ctx.resilient_parsing:
-            # turn off warnings altogether
-            _warnings.simplefilter("ignore")
+    def callback(ctx: click.Context, param: click.Parameter, value: bool) -> None:
+        if not value:
             return
 
-        _warnings.simplefilter("default")
         state = ctx.ensure_object(CommandState)
+        state.set_verbosity(max(state.verbosity, 3))
         state.debug = True
-        _setup_logging(level="DEBUG")
 
     return click.option(
         "--debug",
@@ -140,39 +158,10 @@ def debug_option(f: F) -> F:
 
 
 def verbose_option(f: F) -> F:
-    def callback(ctx: click.Context, param: click.Parameter, value: t.Any) -> None:
+    def callback(ctx: click.Context, param: click.Parameter, value: int) -> None:
         # set state verbosity value from option
         state = ctx.ensure_object(CommandState)
-        state.verbosity = value
-
-        # no verbosity
-        # all warnings are ignored
-        # logging is not turned on
-        if value == 0:
-            _warnings.simplefilter("ignore")
-
-        # verbosity level 1
-        # warnings set to once
-        # logging set to error
-        if value == 1:
-            _warnings.simplefilter("once")
-            _setup_logging(level="ERROR")
-
-        # verbosity level 2
-        # warnings set to default
-        # logging set to info
-        if value == 2:
-            _warnings.simplefilter("default")
-            _setup_logging(level="INFO")
-
-        # verbosity level 3+
-        # warnings set to always
-        # logging set to debug
-        # sets debug flag to true
-        if value >= 3:
-            _warnings.simplefilter("always")
-            state.debug = True
-            _setup_logging(level="DEBUG")
+        state.set_verbosity(state.verbosity + value)
 
     return click.option(
         "--verbose",
@@ -181,7 +170,23 @@ def verbose_option(f: F) -> F:
         expose_value=False,
         callback=callback,
         is_eager=True,
-        help="Control level of output.",
+        help="Control level of output, make it more verbose.",
+    )(f)
+
+
+def quiet_option(f: F) -> F:
+    def callback(ctx: click.Context, param: click.Parameter, value: int) -> None:
+        # set state verbosity value from option
+        state = ctx.ensure_object(CommandState)
+        state.set_verbosity(state.verbosity - value)
+
+    return click.option(
+        "--quiet",
+        count=True,
+        expose_value=False,
+        callback=callback,
+        is_eager=True,
+        help="Control level of output, make it less verbose.",
     )(f)
 
 

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -11,6 +11,7 @@ from globus_cli.parsing.command_state import (
     debug_option,
     format_option,
     map_http_status_option,
+    quiet_option,
     show_server_timing_option,
     verbose_option,
 )
@@ -46,6 +47,7 @@ def common_options(*, disable_options: list[str] | None = None) -> t.Callable[[C
         f = debug_option(f)
         f = show_server_timing_option(f)
         f = verbose_option(f)
+        f = quiet_option(f)
         f = click.help_option("-h", "--help")(f)
 
         # if the format option is being allowed, it needs to be applied to `f`

--- a/tests/unit/test_common_options.py
+++ b/tests/unit/test_common_options.py
@@ -31,11 +31,11 @@ def test_common_options_are_not_exposed(runner):
         pytest.param(["-vv"], 2, id="vv"),
         pytest.param(["-vvv"], 3, id="vvv"),
         pytest.param(["--quiet"], -1, id="quiet"),
-        pytest.param(["-v", "--quiet"], 0, id="v-quiet"),
-        pytest.param(["-vv", "--quiet"], 1, id="vv-quiet"),
-        pytest.param(["-vv", "--quiet", "--quiet"], 0, id="vv-quiet-quiet"),
+        pytest.param(["-v", "--quiet"], -1, id="v-quiet"),
+        pytest.param(["-vv", "--quiet"], -1, id="vv-quiet"),
+        pytest.param(["-vv", "--quiet", "--quiet"], -1, id="vv-quiet-quiet"),
         pytest.param(["--debug"], 3, id="debug"),
-        pytest.param(["--debug", "--quiet"], 2, id="debug-quiet"),
+        pytest.param(["--debug", "--quiet"], -1, id="debug-quiet"),
     ),
 )
 def test_verbosity_control(runner, add_args, expect_verbosity):

--- a/tests/unit/test_common_options.py
+++ b/tests/unit/test_common_options.py
@@ -1,0 +1,51 @@
+import click
+import pytest
+
+from globus_cli.parsing.command_state import CommandState
+from globus_cli.parsing.shared_options import common_options
+
+
+def test_common_options_are_not_exposed(runner):
+    """
+    The common options decorator only produces options which are stored to the
+    CommandState object via callbacks.
+
+    Therefore, a command with no arguments should work.
+    """
+
+    @common_options()
+    @click.command
+    def foo():
+        pass
+
+    result = runner.invoke(foo, [])
+    assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "add_args, expect_verbosity",
+    (
+        pytest.param([], 0, id="default"),
+        pytest.param(["-v"], 1, id="v"),
+        pytest.param(["--verbose"], 1, id="verbose"),
+        pytest.param(["-vv"], 2, id="vv"),
+        pytest.param(["-vvv"], 3, id="vvv"),
+        pytest.param(["--quiet"], -1, id="quiet"),
+        pytest.param(["-v", "--quiet"], 0, id="v-quiet"),
+        pytest.param(["-vv", "--quiet"], 1, id="vv-quiet"),
+        pytest.param(["-vv", "--quiet", "--quiet"], 0, id="vv-quiet-quiet"),
+        pytest.param(["--debug"], 3, id="debug"),
+        pytest.param(["--debug", "--quiet"], 2, id="debug-quiet"),
+    ),
+)
+def test_verbosity_control(runner, add_args, expect_verbosity):
+    @common_options()
+    @click.command
+    def foo():
+        ctx = click.get_current_context()
+        state = ctx.ensure_object(CommandState)
+        print(state.verbosity)
+
+    result = runner.invoke(foo, add_args)
+    assert result.exit_code == 0
+    assert int(result.output) == expect_verbosity


### PR DESCRIPTION
This introduces `--quiet` and refactors the verbosity control code to ensure good behavior.
Commit messages have full detail.

`-q` is not supported because it would conflict with some commands today (at least with `globus search query`).

This change is preparatory -- we have a feature request open for `--quiet` mode on `globus login` having specific effects.
I intend to satisfy that by making that behavior driven by `verbosity < 0`.
