### PR TITLE
Fix JSONStringOrFile to complete on filenames

### DIFF
--- a/changelog.d/20240614_174134_sirosen_improve_completion_on_jsonorfile.md
+++ b/changelog.d/20240614_174134_sirosen_improve_completion_on_jsonorfile.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* Completion support has been added for inputs which are JSON strings or files.
+  These will autocomplete to filenames when possible, for users leveraging tab
+  completion.

--- a/src/globus_cli/parsing/param_types/json_strorfile.py
+++ b/src/globus_cli/parsing/param_types/json_strorfile.py
@@ -11,6 +11,9 @@ import click
 from globus_cli.constants import EXPLICIT_NULL, ExplicitNullType
 from globus_cli.types import JsonValue
 
+if t.TYPE_CHECKING:
+    from click.shell_completion import CompletionItem
+
 
 @dataclasses.dataclass
 class ParsedJSONData:
@@ -56,6 +59,13 @@ class JSONStringOrFile(click.ParamType):
 
     def get_metavar(self, param: click.Parameter) -> str:
         return "[JSON_FILE|JSON|file:JSON_FILE]"
+
+    def shell_complete(
+        self, ctx: click.Context, param: click.Parameter, incomplete: str
+    ) -> list[CompletionItem]:
+        from click.shell_completion import CompletionItem
+
+        return [CompletionItem(incomplete, type="file")]
 
     def get_type_annotation(self, param: click.Parameter) -> type:
         if self.null is not None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from click.shell_completion import ShellComplete
 from click.testing import CliRunner
 
 
@@ -15,3 +16,35 @@ def run_command(runner):
         return result
 
     return _run
+
+
+@pytest.fixture
+def get_completions():
+    """
+    This fixture provides a function which accepts a command,
+    arguments, and an incomplete string (the last, partial arg).
+
+    It then uses test helpers defined in click's own testsuite to
+    render this to a list of strings.
+    """
+
+    def complete(cli, args, incomplete, *, as_strings: bool = True):
+        if as_strings:
+            return _get_words(cli, args, incomplete)
+        else:
+            return _get_completions(cli, args, incomplete)
+
+    return complete
+
+
+# NOTE: this function was lifted directly from click test_shell_completion.py
+# https://github.com/pallets/click/blob/923d197b56caa9ffea21edeef5baf1816585b099/tests/test_shell_completion.py#L21-L22
+def _get_words(cli, args, incomplete):
+    return [c.value for c in _get_completions(cli, args, incomplete)]
+
+
+# NOTE: this function was lifted directly from click test_shell_completion.py
+# https://github.com/pallets/click/blob/923d197b56caa9ffea21edeef5baf1816585b099/tests/test_shell_completion.py#L16-L18
+def _get_completions(cli, args, incomplete):
+    comp = ShellComplete(cli, {}, cli.name, "_CLICK_COMPLETE")
+    return comp.get_completions(args, incomplete)


### PR DESCRIPTION
1. Add a very simple completion implementation (`shell_complete`)
2. Add a test fixture, largely lifted from `click`, for testing
   completions
3. Add a single test case using that fixture to test the new
   completion
