### PR TITLE
Add silent mode for `globus login --quiet`

### DIFF
--- a/changelog.d/20240620_202050_sirosen_quiet_login.md
+++ b/changelog.d/20240620_202050_sirosen_quiet_login.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* When `globus login` is run with the `--quiet` flag, it will print no output
+  if you are already logged in.

--- a/src/globus_cli/commands/login.py
+++ b/src/globus_cli/commands/login.py
@@ -10,6 +10,7 @@ from globus_sdk.services.flows import SpecificFlowClient
 
 from globus_cli.login_manager import LoginManager, is_client_login
 from globus_cli.parsing import command, no_local_server_option
+from globus_cli.termio import verbosity
 
 _SHARED_EPILOG = """\
 
@@ -184,7 +185,8 @@ def login_command(
 
     # if not forcing, stop if user already logged in
     if not force and manager.is_logged_in():
-        click.echo(_LOGGED_IN_RESPONSE)
+        if verbosity() >= 0:
+            click.echo(_LOGGED_IN_RESPONSE)
         return
 
     manager.run_login_flow(

--- a/tests/functional/test_login_command.py
+++ b/tests/functional/test_login_command.py
@@ -2,6 +2,7 @@ import uuid
 from unittest import mock
 
 import globus_sdk
+import pytest
 from globus_sdk._testing import load_response_set
 
 from globus_cli.login_manager import (
@@ -121,3 +122,12 @@ def test_login_with_flow(monkeypatch, run_line):
     client = globus_sdk.SpecificFlowClient(uuid1)
     expected_rs_name_and_scope = (client.scopes.resource_server, [client.scopes.user])
     assert expected_rs_name_and_scope in list(manager.login_requirements)
+
+
+@pytest.mark.parametrize("quiet_mode", (True, False))
+def test_login_quiet_mode_suppresses_output(run_line, quiet_mode):
+    result = run_line(["globus", "login"] + (["--quiet"] if quiet_mode else []))
+    if quiet_mode:
+        assert result.output == ""
+    else:
+        assert "You are already logged in!" in result.output


### PR DESCRIPTION
When `globus login --quiet` is run and the user is already logged in,
no output will be shown. Effectively, this "enables quiet mode" for
logins.
