### PR TITLE
Fix mypy disallow-untyped-defs on Transfer module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,6 @@ disallow_incomplete_defs = false
 module = [
     "globus_cli.services.gcs",
     "globus_cli.services.transfer.activation",
-    "globus_cli.services.transfer.client",
     "globus_cli.services.transfer.delegate_proxy",
     "globus_cli.services.transfer.recursive_ls",
     "globus_cli.termio",

--- a/src/globus_cli/services/transfer/client.py
+++ b/src/globus_cli/services/transfer/client.py
@@ -44,8 +44,13 @@ def _retry_client_consent(ctx: RetryContext) -> RetryCheckResult:
 
 
 class CustomTransferClient(globus_sdk.TransferClient):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        *,
+        authorizer: globus_sdk.GlobusAuthorizer,
+        app_name: str,
+    ) -> None:
+        super().__init__(authorizer=authorizer, app_name=app_name)
         self.transport.register_retry_check(_retry_client_consent)
 
     # TODO: Remove this function when endpoints natively support recursive ls
@@ -78,7 +83,7 @@ class CustomTransferClient(globus_sdk.TransferClient):
         return RecursiveLsResponse(self, endpoint_id, params, max_depth=depth)
 
     def get_endpoint_w_server_list(
-        self, endpoint_id
+        self, endpoint_id: str | uuid.UUID
     ) -> tuple[
         globus_sdk.GlobusHTTPResponse, str | globus_sdk.IterableTransferResponse
     ]:


### PR DESCRIPTION
- Remove `services.transfer.client` from the allow-list
- Fix one missing annotation on a method
- Update the init signature to have explicit parameters -- the only ones which are actually used
