### PR TITLE
Paginate `globus gcs collection list` command

### DIFF
--- a/changelog.d/20240703_105235_ada_paginate_collection_list_command.md
+++ b/changelog.d/20240703_105235_ada_paginate_collection_list_command.md
@@ -1,0 +1,5 @@
+### Enhancements
+
+* `globus gcs collection list` can now return results in excess of the GCS default
+  page size; control over the number of results returned is available
+  via the `--limit` option.

--- a/tests/files/api_fixtures/collection_operations.yaml
+++ b/tests/files/api_fixtures/collection_operations.yaml
@@ -286,6 +286,47 @@ gcs:
             "authentication_assurance_timeout": 15840,
             "authentication_timeout_mins": 15840,
           },
+        ],
+        "has_next_page": true,
+        "marker": "there"
+      }
+  - path: /collections
+    method: get
+    query_params:
+      marker: "there"
+    json:
+      {
+        "DATA_TYPE": "result#1.0.0",
+        "code": "success",
+        "detail": "success",
+        "http_response_code": 200,
+        "data": [
+          {
+            "DATA_TYPE": "collection#1.0.0",
+            "public": True,
+            "id": "1405823f-0597-4a16-b296-46d4f0ae4b15",
+            "display_name": "Happy Fun Collection Name 1",
+            "identity_id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+            "collection_type": "mapped",
+            "storage_gateway_id": "6ebdbaa3-9c60-4637-9d26-1bcfa3921f6b",
+            "require_high_assurance": false,
+            "high_assurance": false,
+            "authentication_assurance_timeout": 15840,
+            "authentication_timeout_mins": 15840,
+          },
+          {
+            "DATA_TYPE": "collection#1.0.0",
+            "public": True,
+            "id": "0ff9d369-0c8b-4405-93c1-a6ce04ebe946",
+            "display_name": "Happy Fun Collection Name 2",
+            "identity_id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+            "collection_type": "mapped",
+            "storage_gateway_id": "678239fa-1678-4687-b749-5e045c5506b7",
+            "require_high_assurance": false,
+            "high_assurance": false,
+            "authentication_assurance_timeout": 15840,
+            "authentication_timeout_mins": 15840,
+          },
         ]
       }
   - path: /collections/0e4a77f8-b778-4d5c-abaa-e1254e71427f

--- a/tests/functional/collection/test_collection_list.py
+++ b/tests/functional/collection/test_collection_list.py
@@ -30,6 +30,16 @@ def test_collection_list(run_line, add_gcs_login, base_command):
         assert name in result.stdout
 
 
+def test_collection_list_limit(run_line, add_gcs_login, base_command):
+    meta = load_response_set("cli.collection_operations").metadata
+    epid = meta["endpoint_id"]
+    add_gcs_login(epid)
+    result = run_line(f"{base_command} {epid} --limit 1")
+    lines = result.stdout.splitlines()
+    assert len(lines) == 3  # header + 1 collection
+    assert "Happy Fun Collection Name 1" in lines[2]
+
+
 def test_collection_list_opts(run_line, add_gcs_login, base_command):
     meta = load_response_set("cli.collection_operations").metadata
     epid = meta["endpoint_id"]

--- a/tests/functional/collection/test_collection_list.py
+++ b/tests/functional/collection/test_collection_list.py
@@ -30,13 +30,14 @@ def test_collection_list(run_line, add_gcs_login, base_command):
         assert name in result.stdout
 
 
-def test_collection_list_limit(run_line, add_gcs_login, base_command):
+@pytest.mark.parametrize("limit", (1, 3))
+def test_collection_list_limit(limit, run_line, add_gcs_login, base_command):
     meta = load_response_set("cli.collection_operations").metadata
     epid = meta["endpoint_id"]
     add_gcs_login(epid)
-    result = run_line(f"{base_command} {epid} --limit 1")
+    result = run_line(f"{base_command} {epid} --limit {limit}")
     lines = result.stdout.splitlines()
-    assert len(lines) == 3  # header + 1 collection
+    assert len(lines) == limit + 2  # two header lines
     assert "Happy Fun Collection Name 1" in lines[2]
 
 


### PR DESCRIPTION
Additionally, add a `--limit` option.

"Tutorial Collection 1" now has enough guest collections to exceed the GCS default of 16.

For posterity:
```
for i in $(seq 1 15); do
  globus collection create guest 6c54cade-bde5-45c1-bdea-f4bd71dba2cc /home/u_5ovepnp5hbhaxflmbikcgve27e/ "Ada Guest Test $i";
done
```

Signed-off-by: Ada <ada@globus.org>
