### PR TITLE
Improve mypy strictness on printing modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,5 @@ disallow_untyped_defs = false
 disallow_incomplete_defs = false
 module = [
     "globus_cli.services.transfer.recursive_ls",
-    "globus_cli.termio",
-    "globus_cli.termio.printer",
     "globus_cli.termio.awscli_text",
 ]

--- a/src/globus_cli/termio/__init__.py
+++ b/src/globus_cli/termio/__init__.py
@@ -17,7 +17,7 @@ from .field import Field
 from .printer import display
 
 
-def print_command_hint(message: str, *, color: str = "yellow"):
+def print_command_hint(message: str, *, color: str = "yellow") -> None:
     """
     Wrapper around echo that checks terminal state
     before printing a given command hint message


### PR DESCRIPTION
The main drive of this changeset is to remove mypy-disallow rules for two listed modules (`termio/__init__.py` and `termio/printer.py`).

In the course of adding annotations, several small functions, defined inline, were trivially moved into module scope. This probably doesn't enhance performance (or at least, not noticeably) because the inlined functions aren't used in tight loops, though it may make the testsuite marginally faster.

One of the helpers (`_assert_fields`) has changed in its usage, acting more like a type guard. This makes it easier to use it in a more strictly typed context.

Two internal helpers (`_print_as_json` and `_print_as_unix`) seem to be unnecessary wrappers, and are removed. The third helper in this family, `_print_as_text` could also be removed, but requires a larger edit and is therefore omitted from this change.

In the various annotations, `Any` is used liberally but not recklessly to make initial annotations simple to add. Types declared with `Any` can always be narrowed in the future, if appropriate.
