### PR TITLE
Add more flake8 plugin rules to enforce short_help consistency

### DIFF
--- a/src/globus_cli/_warnings.py
+++ b/src/globus_cli/_warnings.py
@@ -11,7 +11,7 @@ def simplefilter(
     filterstr: t.Literal["default", "error", "ignore", "always", "module", "once"]
 ) -> None:
     """
-    wrap `warnings.simplefilter` with a check on `_TEST_WARNING_CONTROL`
+    Wrap `warnings.simplefilter` with a check on `_TEST_WARNING_CONTROL`.
     """
     if not _TEST_WARNING_CONTROL:
         warnings.simplefilter(filterstr)

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -345,7 +345,7 @@ def _handle_scope_string(
 
 @group("api")
 def api_command() -> None:
-    """Make API calls to Globus services"""
+    """Make API calls to Globus services."""
 
 
 # note: this must be written as a separate call and not inlined into the loop body

--- a/src/globus_cli/commands/bookmark/__init__.py
+++ b/src/globus_cli/commands/bookmark/__init__.py
@@ -12,4 +12,4 @@ from globus_cli.parsing import group
     },
 )
 def bookmark_command() -> None:
-    """Manage endpoint bookmarks"""
+    """Manage endpoint bookmarks."""

--- a/src/globus_cli/commands/bookmark/create.py
+++ b/src/globus_cli/commands/bookmark/create.py
@@ -32,7 +32,7 @@ $ globus bookmark create \
      -F unix --jmespath 'id'
 ----
 """,
-    short_help="Create a bookmark for the current user",
+    short_help="Create a bookmark for the current user.",
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
 @click.argument("bookmark_name")

--- a/src/globus_cli/commands/bookmark/delete.py
+++ b/src/globus_cli/commands/bookmark/delete.py
@@ -20,7 +20,7 @@ from ._common import resolve_id_or_name
 $ globus bookmark delete "Bookmark Name"
 ----
 """,
-    short_help="Delete a bookmark",
+    short_help="Delete a bookmark.",
 )
 @click.argument("bookmark_id_or_name")
 @LoginManager.requires_login("transfer")

--- a/src/globus_cli/commands/bookmark/list.py
+++ b/src/globus_cli/commands/bookmark/list.py
@@ -45,11 +45,11 @@ output:
 $ globus bookmark list --jmespath='DATA[*].[name, endpoint_id]' --format=unix
 ----
 """,
-    short_help="List your bookmarks",
+    short_help="List your bookmarks.",
 )
 @LoginManager.requires_login("transfer")
 def bookmark_list(login_manager: LoginManager) -> None:
-    """List all bookmarks for the current user"""
+    """List all bookmarks for the current user."""
     from globus_cli.services.transfer import iterable_response_to_dict
 
     transfer_client = login_manager.get_transfer_client()

--- a/src/globus_cli/commands/bookmark/rename.py
+++ b/src/globus_cli/commands/bookmark/rename.py
@@ -28,7 +28,7 @@ $ globus bookmark rename oldname newname
 def bookmark_rename(
     login_manager: LoginManager, *, bookmark_id_or_name: str, new_bookmark_name: str
 ) -> None:
-    """Change a bookmark's name"""
+    """Change a bookmark's name."""
     transfer_client = login_manager.get_transfer_client()
     bookmark_id = resolve_id_or_name(transfer_client, bookmark_id_or_name)["id"]
 

--- a/src/globus_cli/commands/bookmark/show.py
+++ b/src/globus_cli/commands/bookmark/show.py
@@ -28,7 +28,7 @@ If *-v* or *--verbose* is given, output has the following fields:
 $ globus ls "$(globus bookmark show BOOKMARK_NAME)"
 ----
 """,
-    short_help="Resolve a bookmark name or ID to an endpoint:path",
+    short_help="Resolve a bookmark name or ID to an endpoint:path.",
 )
 @click.argument("bookmark_id_or_name")
 @LoginManager.requires_login("transfer")

--- a/src/globus_cli/commands/cli_profile_list.py
+++ b/src/globus_cli/commands/cli_profile_list.py
@@ -81,7 +81,7 @@ class ProfileIndicatorFormatter(formatters.FieldFormatter[bool]):
 @click.option("--all", is_flag=True, hidden=True)
 def cli_profile_list(*, all: bool) -> None:
     """
-    List all CLI profiles which have been used
+    List all CLI profiles which have been used.
 
     These are the values for GLOBUS_PROFILE which have been recorded, as well as
     GLOBUS_CLI_CLIENT_ID values which have been used.

--- a/src/globus_cli/commands/collection/__init__.py
+++ b/src/globus_cli/commands/collection/__init__.py
@@ -12,4 +12,4 @@ from globus_cli.parsing import group
     },
 )
 def collection_command() -> None:
-    """Manage your Collections"""
+    """Manage your Collections."""

--- a/src/globus_cli/commands/collection/create/__init__.py
+++ b/src/globus_cli/commands/collection/create/__init__.py
@@ -9,4 +9,4 @@ from globus_cli.parsing import group
     },
 )
 def collection_create() -> None:
-    """Create a new Collection"""
+    """Create a new Collection."""

--- a/src/globus_cli/commands/collection/create/guest.py
+++ b/src/globus_cli/commands/collection/create/guest.py
@@ -22,7 +22,7 @@ from globus_cli.services.gcs import CustomGCSClient
 from globus_cli.termio import display
 
 
-@command("guest", short_help="Create a GCSv5 Guest Collection")
+@command("guest", short_help="Create a GCSv5 Guest Collection.")
 @click.argument("MAPPED_COLLECTION_ID", type=click.UUID)
 @click.argument("COLLECTION_BASE_PATH", type=str)
 @click.option(

--- a/src/globus_cli/commands/collection/create/mapped.py
+++ b/src/globus_cli/commands/collection/create/mapped.py
@@ -43,7 +43,7 @@ def _posix_staging_policy_options_present(params: dict[str, t.Any]) -> bool:
     )
 
 
-@command("create", short_help="Create a new Mapped Collection")
+@command("create", short_help="Create a new Mapped Collection.")
 @endpoint_id_arg
 @endpointish_params.create(name="collection")
 @identity_id_option

--- a/src/globus_cli/commands/collection/delete.py
+++ b/src/globus_cli/commands/collection/delete.py
@@ -5,7 +5,7 @@ from globus_cli.parsing import collection_id_arg, command
 from globus_cli.termio import display
 
 
-@command("delete", short_help="Delete an existing Collection")
+@command("delete", short_help="Delete an existing Collection.")
 @collection_id_arg
 @LoginManager.requires_login("transfer")
 def collection_delete(login_manager: LoginManager, *, collection_id: uuid.UUID) -> None:

--- a/src/globus_cli/commands/collection/list.py
+++ b/src/globus_cli/commands/collection/list.py
@@ -32,7 +32,7 @@ class ChoiceSlugified(click.Choice):
         return value.replace("-", "_")
 
 
-@command("list", short_help="List all Collections on an Endpoint")
+@command("list", short_help="List all Collections on an Endpoint.")
 @endpoint_id_arg
 @click.option(
     "--filter",
@@ -108,7 +108,7 @@ def collection_list(
     limit: int,
 ) -> None:
     """
-    List the Collections on a given Globus Connect Server v5 Endpoint
+    List the Collections on a given Globus Connect Server v5 Endpoint.
     """
     gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
     auth_client = login_manager.get_auth_client()

--- a/src/globus_cli/commands/collection/show.py
+++ b/src/globus_cli/commands/collection/show.py
@@ -27,7 +27,7 @@ PRIVATE_FIELDS: list[Field] = [
 ]
 
 
-@command("show", short_help="Show a Collection definition")
+@command("show", short_help="Show a Collection definition.")
 @collection_id_arg
 @click.option(
     "--include-private-policies",
@@ -44,9 +44,7 @@ def collection_show(
     include_private_policies: bool,
     collection_id: uuid.UUID,
 ) -> None:
-    """
-    Display a Mapped or Guest Collection
-    """
+    """Display a Mapped or Guest Collection."""
     gcs_client = login_manager.get_gcs_client(collection_id=collection_id)
 
     query_params = {}

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -30,7 +30,7 @@ class _FullDataField(Field):
         return super().get_value(data.full_data)
 
 
-@command("update", short_help="Update a Collection definition")
+@command("update", short_help="Update a Collection definition.")
 @collection_id_arg
 @endpointish_params.update(name="collection")
 @click.option(
@@ -139,7 +139,7 @@ def collection_update(
     sharing_users_deny: list[str] | None,
 ) -> None:
     """
-    Update a Mapped or Guest Collection
+    Update a Mapped or Guest Collection.
     """
     if isinstance(sharing_restrict_paths, ParsedJSONData) and not isinstance(
         sharing_restrict_paths.data, dict

--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -21,7 +21,7 @@ from globus_cli.termio import Field, display, err_is_terminal, term_is_interacti
 
 @command(
     "delete",
-    short_help="Submit a delete task (asynchronous)",
+    short_help="Submit a delete task (asynchronous).",
     adoc_examples="""Delete a single file.
 
 [source,bash]

--- a/src/globus_cli/commands/endpoint/__init__.py
+++ b/src/globus_cli/commands/endpoint/__init__.py
@@ -26,4 +26,4 @@ from globus_cli.parsing import group
     },
 )
 def endpoint_command() -> None:
-    """Manage Globus endpoint definitions"""
+    """Manage Globus endpoint definitions."""

--- a/src/globus_cli/commands/endpoint/activate.py
+++ b/src/globus_cli/commands/endpoint/activate.py
@@ -81,8 +81,8 @@ def endpoint_activate(
     force: bool,
 ) -> None:
     """
-    Activate an endpoint using Autoactivation, Myproxy, Delegate Proxy,
-    or Web activation.
+    Activate an endpoint.
+
     Note that --web and --myproxy activation are mutually
     exclusive options.
 

--- a/src/globus_cli/commands/endpoint/delete.py
+++ b/src/globus_cli/commands/endpoint/delete.py
@@ -8,7 +8,7 @@ from globus_cli.termio import display
 
 @command(
     "delete",
-    short_help="Delete an endpoint",
+    short_help="Delete an endpoint.",
     adoc_examples="""[source,bash]
 ----
 $ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb

--- a/src/globus_cli/commands/endpoint/local_id.py
+++ b/src/globus_cli/commands/endpoint/local_id.py
@@ -6,7 +6,7 @@ from globus_cli.parsing import command, one_use_option
 
 @command(
     "local-id",
-    short_help="Display UUID of locally installed endpoint",
+    short_help="Display UUID of locally installed endpoint.",
     disable_options=["format", "map_http_status"],
     adoc_examples="""Do a Globus ls command on the current local endpoint.
 

--- a/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
+++ b/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
@@ -7,7 +7,7 @@ from globus_cli.termio import display
 
 @command(
     "my-shared-endpoint-list",
-    short_help="List all shared endpoints on an endpoint by the current user",
+    short_help="List all shared endpoints on an endpoint by the current user.",
     adoc_examples="""[source,bash]
 ----
 $ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb

--- a/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
+++ b/src/globus_cli/commands/endpoint/my_shared_endpoint_list.py
@@ -7,7 +7,7 @@ from globus_cli.termio import display
 
 @command(
     "my-shared-endpoint-list",
-    short_help="List all shared endpoints on an endpoint by the current user.",
+    short_help="List the current user's shared endpoints.",
     adoc_examples="""[source,bash]
 ----
 $ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb

--- a/src/globus_cli/commands/endpoint/permission/__init__.py
+++ b/src/globus_cli/commands/endpoint/permission/__init__.py
@@ -12,4 +12,4 @@ from globus_cli.parsing import group
     },
 )
 def permission_command() -> None:
-    """Manage endpoint permissions (Access Control Lists)"""
+    """Manage endpoint permissions (Access Control Lists)."""

--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -12,7 +12,7 @@ from globus_cli.termio import Field, display
 
 @command(
     "create",
-    short_help="Create an access control rule",
+    short_help="Create an access control rule.",
     adoc_examples="""Give anyone read access to a directory.
 
 [source,bash]

--- a/src/globus_cli/commands/endpoint/permission/delete.py
+++ b/src/globus_cli/commands/endpoint/permission/delete.py
@@ -9,7 +9,7 @@ from globus_cli.termio import display
 
 @command(
     "delete",
-    short_help="Delete an access control rule",
+    short_help="Delete an access control rule.",
     adoc_examples="""[source,bash]
 ----
 $ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb

--- a/src/globus_cli/commands/endpoint/permission/list.py
+++ b/src/globus_cli/commands/endpoint/permission/list.py
@@ -11,7 +11,7 @@ from ._common import AclPrincipalFormatter
 
 @command(
     "list",
-    short_help="List access control rules",
+    short_help="List access control rules.",
     adoc_examples="""[source,bash]
 ----
 $ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb

--- a/src/globus_cli/commands/endpoint/permission/show.py
+++ b/src/globus_cli/commands/endpoint/permission/show.py
@@ -13,7 +13,7 @@ from ._common import AclPrincipalFormatter
 
 @command(
     "show",
-    short_help="Display an access control rule",
+    short_help="Display an access control rule.",
     adoc_examples="""[source,bash]
 ----
 $ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb

--- a/src/globus_cli/commands/endpoint/permission/update.py
+++ b/src/globus_cli/commands/endpoint/permission/update.py
@@ -10,7 +10,7 @@ from globus_cli.termio import display
 
 @command(
     "update",
-    short_help="Update an access control rule",
+    short_help="Update an access control rule.",
     adoc_examples="""Change existing access control rule to read only:
 
 [source,bash]

--- a/src/globus_cli/commands/endpoint/role/__init__.py
+++ b/src/globus_cli/commands/endpoint/role/__init__.py
@@ -11,4 +11,4 @@ from globus_cli.parsing import group
     },
 )
 def role_command() -> None:
-    """Manage endpoint roles"""
+    """Manage endpoint roles."""

--- a/src/globus_cli/commands/endpoint/role/create.py
+++ b/src/globus_cli/commands/endpoint/role/create.py
@@ -12,7 +12,7 @@ from globus_cli.termio import display
 
 @command(
     "create",
-    short_help="Add a role to an endpoint",
+    short_help="Add a role to an endpoint.",
     adoc_output=(
         "Textual output is a simple success message in the absence of errors, "
         "containing the ID of the created role."

--- a/src/globus_cli/commands/endpoint/role/delete.py
+++ b/src/globus_cli/commands/endpoint/role/delete.py
@@ -9,7 +9,7 @@ from ._common import role_id_arg
 
 @command(
     "delete",
-    short_help="Remove a role from an endpoint",
+    short_help="Remove a role from an endpoint.",
     adoc_output="Textual output is a simple success message in the absence of errors.",
     adoc_examples="""Delete role '0f007eec-1aeb-11e7-aec4-3c970e0c9cc4' on endpoint
 'aa752cea-8222-5bc8-acd9-555b090c0ccb':

--- a/src/globus_cli/commands/endpoint/role/list.py
+++ b/src/globus_cli/commands/endpoint/role/list.py
@@ -9,7 +9,7 @@ from ._common import RolePrincipalFormatter
 
 @command(
     "list",
-    short_help="List roles on an endpoint",
+    short_help="List roles on an endpoint.",
     adoc_output="""Textual output has the following fields:
 
 - 'Principal Type'

--- a/src/globus_cli/commands/endpoint/role/show.py
+++ b/src/globus_cli/commands/endpoint/role/show.py
@@ -11,7 +11,7 @@ from ._common import RolePrincipalFormatter, role_id_arg
 
 @command(
     "show",
-    short_help="Show full info for a role on an endpoint",
+    short_help="Show full info for a role on an endpoint.",
     adoc_output="""Textual output has the following fields:
 
 - 'Principal Type'

--- a/src/globus_cli/commands/endpoint/search.py
+++ b/src/globus_cli/commands/endpoint/search.py
@@ -13,7 +13,7 @@ from globus_cli.utils import PagingWrapper
 
 @command(
     "search",
-    short_help="Find and discover endpoints",
+    short_help="Find and discover endpoints.",
     adoc_synopsis="""
 `globus endpoint search [OPTIONS] FILTER_FULLTEXT`
 

--- a/src/globus_cli/commands/endpoint/server/__init__.py
+++ b/src/globus_cli/commands/endpoint/server/__init__.py
@@ -5,7 +5,7 @@ from globus_cli.parsing import group
     "server",
     deprecated=True,
     hidden=True,
-    short_help="Manage servers for a Globus endpoint",
+    short_help="Manage servers for a Globus endpoint.",
     lazy_subcommands={
         "add": (".add", "server_add"),
         "delete": (".delete", "server_delete"),

--- a/src/globus_cli/commands/endpoint/server/add.py
+++ b/src/globus_cli/commands/endpoint/server/add.py
@@ -13,7 +13,7 @@ from ._common import server_add_opts
 @command(
     "add",
     deprecated=True,
-    short_help="Add a server to an endpoint",
+    short_help="Add a server to an endpoint.",
     adoc_examples="""Add a server with a url of gridftp.example.org to an endpoint
 
 [source,bash]

--- a/src/globus_cli/commands/endpoint/server/delete.py
+++ b/src/globus_cli/commands/endpoint/server/delete.py
@@ -60,7 +60,7 @@ def _detect_mode(server: str) -> t.Literal["id", "uri", "hostname", "hostname_po
 @command(
     "delete",
     deprecated=True,
-    short_help="Delete a server belonging to an endpoint",
+    short_help="Delete a server belonging to an endpoint.",
     adoc_examples="""[source,bash]
 ----
 $ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb

--- a/src/globus_cli/commands/endpoint/server/list.py
+++ b/src/globus_cli/commands/endpoint/server/list.py
@@ -22,7 +22,7 @@ class ServerURIFormatter(formatters.StrFormatter):
 @command(
     "list",
     deprecated=True,
-    short_help="List all servers for an endpoint",
+    short_help="List all servers for an endpoint.",
     adoc_examples="""[source,bash]
 ----
 $ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb

--- a/src/globus_cli/commands/endpoint/server/show.py
+++ b/src/globus_cli/commands/endpoint/server/show.py
@@ -55,7 +55,7 @@ class PortRangeFormatter(
 @command(
     "show",
     deprecated=True,
-    short_help="Show an endpoint server",
+    short_help="Show an endpoint server.",
     adoc_examples="""[source,bash]
 ----
 $ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb

--- a/src/globus_cli/commands/endpoint/server/update.py
+++ b/src/globus_cli/commands/endpoint/server/update.py
@@ -13,7 +13,7 @@ from ._common import server_id_arg, server_update_opts
 @command(
     "update",
     deprecated=True,
-    short_help="Update an endpoint server",
+    short_help="Update an endpoint server.",
     adoc_examples="""Change an existing server's scheme to use ftp:
 
 [source,bash]

--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -31,7 +31,7 @@ class SubscriptionIdType(click.ParamType):
 @command(
     "set-subscription-id",
     deprecated=True,
-    short_help="Set an endpoint's subscription",
+    short_help="Set an endpoint's subscription.",
 )
 @endpoint_id_arg
 @click.argument("SUBSCRIPTION_ID", type=SubscriptionIdType())

--- a/src/globus_cli/commands/endpoint/show.py
+++ b/src/globus_cli/commands/endpoint/show.py
@@ -46,7 +46,7 @@ def endpoint_show(
     endpoint_id: uuid.UUID,
     skip_endpoint_type_check: bool,
 ) -> None:
-    """Display a detailed endpoint definition"""
+    """Display a detailed endpoint definition."""
     transfer_client = login_manager.get_transfer_client()
     if not skip_endpoint_type_check:
         Endpointish(

--- a/src/globus_cli/commands/endpoint/storage_gateway/__init__.py
+++ b/src/globus_cli/commands/endpoint/storage_gateway/__init__.py
@@ -8,4 +8,4 @@ from globus_cli.parsing import group
     },
 )
 def storage_gateway_command() -> None:
-    """Manage Storage Gateways on a GCS Endpoint"""
+    """Manage Storage Gateways on a GCS Endpoint."""

--- a/src/globus_cli/commands/endpoint/storage_gateway/list.py
+++ b/src/globus_cli/commands/endpoint/storage_gateway/list.py
@@ -12,7 +12,7 @@ STANDARD_FIELDS = [
 ]
 
 
-@command("list", short_help="List the Storage Gateways on an Endpoint")
+@command("list", short_help="List the Storage Gateways on an Endpoint.")
 @endpoint_id_arg
 @LoginManager.requires_login("auth", "transfer")
 def storage_gateway_list(
@@ -21,7 +21,7 @@ def storage_gateway_list(
     endpoint_id: uuid.UUID,
 ) -> None:
     """
-    List the Storage Gateways on a given Globus Connect Server v5 Endpoint
+    List the Storage Gateways on a given Globus Connect Server v5 Endpoint.
     """
     gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
     res = gcs_client.get_storage_gateway_list()

--- a/src/globus_cli/commands/endpoint/update.py
+++ b/src/globus_cli/commands/endpoint/update.py
@@ -64,7 +64,7 @@ def endpoint_update(
     user_message: str | None | ExplicitNullType,
     user_message_link: str | None | ExplicitNullType,
 ) -> None:
-    """Update attributes of an endpoint"""
+    """Update attributes of an endpoint."""
     from globus_cli.services.transfer import assemble_generic_doc
 
     transfer_client = login_manager.get_transfer_client()

--- a/src/globus_cli/commands/endpoint/user_credential/__init__.py
+++ b/src/globus_cli/commands/endpoint/user_credential/__init__.py
@@ -12,4 +12,4 @@ from globus_cli.parsing import group
     },
 )
 def user_credential_command() -> None:
-    """Manage User Credentials on a GCS Endpoint"""
+    """Manage User Credentials on a GCS Endpoint."""

--- a/src/globus_cli/commands/endpoint/user_credential/create/__init__.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/__init__.py
@@ -10,4 +10,4 @@ from globus_cli.parsing import group
     },
 )
 def user_credential_create() -> None:
-    """Create a User Credential on an Endpoint"""
+    """Create a User Credential on an Endpoint."""

--- a/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
@@ -12,7 +12,7 @@ from globus_cli.parsing import (
 from globus_cli.termio import display
 
 
-@command("from-json", short_help="Create a User Credential from a JSON document")
+@command("from-json")
 @endpoint_id_arg
 @click.argument("user_credential_json", type=JSONStringOrFile())
 @LoginManager.requires_login("auth", "transfer")
@@ -23,7 +23,7 @@ def from_json(
     user_credential_json: ParsedJSONData,
 ) -> None:
     """
-    Create a User Credential on an endpoint from a JSON document
+    Create a User Credential on an endpoint from a JSON document.
     """
     if not isinstance(user_credential_json.data, dict):
         raise click.UsageError("User Credential JSON must be a JSON object")

--- a/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/from_json.py
@@ -12,7 +12,10 @@ from globus_cli.parsing import (
 from globus_cli.termio import display
 
 
-@command("from-json")
+@command(
+    "from-json",
+    short_help="Create a User Credential from a JSON document.",
+)
 @endpoint_id_arg
 @click.argument("user_credential_json", type=JSONStringOrFile())
 @LoginManager.requires_login("auth", "transfer")

--- a/src/globus_cli/commands/endpoint/user_credential/create/posix.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/posix.py
@@ -11,7 +11,7 @@ from globus_cli.termio import display
 from .._common import user_credential_create_and_update_params
 
 
-@command("posix", short_help="Create a User Credential for a POSIX storage gateway")
+@command("posix")
 @endpoint_id_arg
 @user_credential_create_and_update_params(create=True)
 @LoginManager.requires_login("auth", "transfer")
@@ -25,7 +25,7 @@ def posix(
     display_name: str | None,
 ) -> None:
     """
-    Create a User Credential for a POSIX storage gateway
+    Create a User Credential for a POSIX storage gateway.
     """
     gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
     auth_client = login_manager.get_auth_client()

--- a/src/globus_cli/commands/endpoint/user_credential/create/s3.py
+++ b/src/globus_cli/commands/endpoint/user_credential/create/s3.py
@@ -12,7 +12,7 @@ from globus_cli.termio import display
 from .._common import user_credential_create_and_update_params
 
 
-@command("s3", short_help="Create a User Credential for an S3 Storage Gateway")
+@command("s3")
 @endpoint_id_arg
 @user_credential_create_and_update_params(create=True)
 @click.argument("s3_key_id")
@@ -30,7 +30,7 @@ def s3(
     display_name: str | None,
 ) -> None:
     """
-    Create a User Credential for an S3 Storage Gateway
+    Create a User Credential for an S3 Storage Gateway.
     """
     gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
     auth_client = login_manager.get_auth_client()

--- a/src/globus_cli/commands/endpoint/user_credential/delete.py
+++ b/src/globus_cli/commands/endpoint/user_credential/delete.py
@@ -7,7 +7,7 @@ from globus_cli.termio import display
 from ._common import user_credential_id_arg
 
 
-@command("delete", short_help="Delete a specific User Credential on an Endpoint")
+@command("delete", short_help="Delete a specific User Credential on an Endpoint.")
 @endpoint_id_arg
 @user_credential_id_arg()
 @LoginManager.requires_login("auth", "transfer")
@@ -18,7 +18,7 @@ def user_credential_delete(
     user_credential_id: uuid.UUID,
 ) -> None:
     """
-    Delete a specific User Credential on a given Globus Connect Server v5 Endpoint
+    Delete a specific User Credential on a given Globus Connect Server v5 Endpoint.
     """
     gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
 

--- a/src/globus_cli/commands/endpoint/user_credential/list.py
+++ b/src/globus_cli/commands/endpoint/user_credential/list.py
@@ -9,7 +9,7 @@ from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import Field, display, formatters
 
 
-@command("list", short_help="List all User Credentials on an Endpoint")
+@command("list", short_help="List all User Credentials on an Endpoint.")
 @endpoint_id_arg
 @click.option(
     "--storage-gateway",
@@ -28,7 +28,7 @@ def user_credential_list(
     storage_gateway: uuid.UUID | None,
 ) -> None:
     """
-    List all of your User Credentials on a Globus Connect Server v5 Endpoint
+    List all of your User Credentials on a Globus Connect Server v5 Endpoint.
     """
     gcs_client = login_manager.get_gcs_client(endpoint_id=endpoint_id)
     auth_client = login_manager.get_auth_client()

--- a/src/globus_cli/commands/endpoint/user_credential/show.py
+++ b/src/globus_cli/commands/endpoint/user_credential/show.py
@@ -7,7 +7,7 @@ from globus_cli.termio import Field, display, formatters
 from ._common import user_credential_id_arg
 
 
-@command("show", short_help="Show a specific User Credential on an Endpoint")
+@command("show", short_help="Show a specific User Credential on an Endpoint.")
 @endpoint_id_arg
 @user_credential_id_arg()
 @LoginManager.requires_login("auth", "transfer")
@@ -18,7 +18,7 @@ def user_credential_show(
     user_credential_id: uuid.UUID,
 ) -> None:
     """
-    Show a specific User Credential on a given Globus Connect Server v5 Endpoint
+    Show a specific User Credential on a given Globus Connect Server v5 Endpoint.
     """
     from globus_cli.services.gcs import ConnectorIdFormatter
 

--- a/src/globus_cli/commands/endpoint/user_credential/update/__init__.py
+++ b/src/globus_cli/commands/endpoint/user_credential/update/__init__.py
@@ -9,4 +9,4 @@ from globus_cli.parsing import group
     hidden=True,
 )
 def user_credential_update() -> None:
-    """Update a User Credential on an Endpoint"""
+    """Update a User Credential on an Endpoint."""

--- a/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
@@ -14,7 +14,7 @@ from globus_cli.termio import display
 from .._common import user_credential_id_arg
 
 
-@command("from-json", short_help="Update a User Credential with a JSON document")
+@command("from-json")
 @endpoint_id_arg
 @user_credential_id_arg()
 @click.argument("user_credential_json", type=JSONStringOrFile())
@@ -27,7 +27,7 @@ def from_json(
     user_credential_json: ParsedJSONData,
 ) -> None:
     """
-    Update a User Credential on an endpoint with a JSON document
+    Update a User Credential on an endpoint with a JSON document.
     """
     if not isinstance(user_credential_json.data, dict):
         raise click.UsageError("User Credential JSON must be a JSON object")

--- a/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
+++ b/src/globus_cli/commands/endpoint/user_credential/update/from_json.py
@@ -14,7 +14,7 @@ from globus_cli.termio import display
 from .._common import user_credential_id_arg
 
 
-@command("from-json")
+@command("from-json", short_help="Update a User Credential with a JSON document.")
 @endpoint_id_arg
 @user_credential_id_arg()
 @click.argument("user_credential_json", type=JSONStringOrFile())

--- a/src/globus_cli/commands/flows/__init__.py
+++ b/src/globus_cli/commands/flows/__init__.py
@@ -16,4 +16,4 @@ from globus_cli.parsing import group
     },
 )
 def flows_command() -> None:
-    """Interact with the Globus Flows service"""
+    """Interact with the Globus Flows service."""

--- a/src/globus_cli/commands/flows/create.py
+++ b/src/globus_cli/commands/flows/create.py
@@ -21,7 +21,7 @@ from globus_cli.types import JsonValue
 ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 
 
-@command("create", short_help="Create a flow")
+@command("create", short_help="Create a flow.")
 @click.argument(
     "title",
     type=str,

--- a/src/globus_cli/commands/flows/delete.py
+++ b/src/globus_cli/commands/flows/delete.py
@@ -7,12 +7,12 @@ from globus_cli.parsing import command, flow_id_arg
 from globus_cli.termio import Field, display, formatters
 
 
-@command("delete", short_help="Delete a flow")
+@command("delete")
 @flow_id_arg
 @LoginManager.requires_login("flows")
 def delete_command(login_manager: LoginManager, *, flow_id: uuid.UUID) -> None:
     """
-    Delete a flow
+    Delete a flow.
     """
     flows_client = login_manager.get_flows_client()
 

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -26,7 +26,7 @@ ORDER_BY_FIELDS = (
 )
 
 
-@command("list", short_help="List flows")
+@command("list")
 @click.option(
     "--filter-role",
     type=click.Choice(ROLE_TYPES),
@@ -92,7 +92,7 @@ def list_command(
     limit: int,
 ) -> None:
     """
-    List flows
+    List flows.
     """
     flows_client = login_manager.get_flows_client()
     paginator = Paginator.wrap(flows_client.list_flows)

--- a/src/globus_cli/commands/flows/run/__init__.py
+++ b/src/globus_cli/commands/flows/run/__init__.py
@@ -15,4 +15,4 @@ from globus_cli.parsing import group
     },
 )
 def run_command() -> None:
-    """Interact with a run in the Globus Flows service"""
+    """Interact with a run in the Globus Flows service."""

--- a/src/globus_cli/commands/flows/run/cancel.py
+++ b/src/globus_cli/commands/flows/run/cancel.py
@@ -7,12 +7,12 @@ from globus_cli.parsing import command, run_id_arg
 from globus_cli.termio import Field, display, formatters
 
 
-@command("cancel", short_help="Cancel a run")
+@command("cancel")
 @run_id_arg
 @LoginManager.requires_login("flows")
 def cancel_command(login_manager: LoginManager, *, run_id: uuid.UUID) -> None:
     """
-    Cancel a run
+    Cancel a run.
     """
 
     flows_client = login_manager.get_flows_client()

--- a/src/globus_cli/commands/flows/run/delete.py
+++ b/src/globus_cli/commands/flows/run/delete.py
@@ -7,12 +7,12 @@ from globus_cli.parsing import command, run_id_arg
 from globus_cli.termio import Field, display, formatters
 
 
-@command("delete", short_help="Delete a run")
+@command("delete")
 @run_id_arg
 @LoginManager.requires_login("flows")
 def delete_command(login_manager: LoginManager, *, run_id: uuid.UUID) -> None:
     """
-    Delete a run
+    Delete a run.
     """
 
     flows_client = login_manager.get_flows_client()

--- a/src/globus_cli/commands/flows/run/list.py
+++ b/src/globus_cli/commands/flows/run/list.py
@@ -35,7 +35,7 @@ def list_command(
     login_manager: LoginManager, *, limit: int, filter_flow_id: tuple[uuid.UUID, ...]
 ) -> None:
     """
-    List runs
+    List runs.
 
     Enumerates runs visible to the current user, potentially filtered by the ID of
     the flow which was used to start the run.

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -37,7 +37,7 @@ def resume_command(
     login_manager: LoginManager, *, run_id: uuid.UUID, skip_inactive_reason_check: bool
 ) -> None:
     """
-    Resume a run
+    Resume a run.
     """
     flows_client = login_manager.get_flows_client()
     run_doc = flows_client.get_run(run_id)

--- a/src/globus_cli/commands/flows/run/show.py
+++ b/src/globus_cli/commands/flows/run/show.py
@@ -9,7 +9,7 @@ from globus_cli.parsing import command, run_id_arg
 from globus_cli.termio import Field, display, formatters
 
 
-@command("show", short_help="Show a run")
+@command("show")
 @run_id_arg
 @click.option(
     "--include-flow-description",
@@ -21,7 +21,7 @@ def show_command(
     login_manager: LoginManager, *, run_id: uuid.UUID, include_flow_description: bool
 ) -> None:
     """
-    Show a run
+    Show a run.
     """
 
     flows_client = login_manager.get_flows_client()

--- a/src/globus_cli/commands/flows/run/show_definition.py
+++ b/src/globus_cli/commands/flows/run/show_definition.py
@@ -7,7 +7,7 @@ from globus_cli.parsing import command, run_id_arg
 from globus_cli.termio import display
 
 
-@command("show-definition", short_help="Show a run's flow definition and input schema")
+@command("show-definition", short_help="Show a run's flow definition and input schema.")
 @run_id_arg
 @LoginManager.requires_login("flows")
 def show_definition_command(login_manager: LoginManager, *, run_id: uuid.UUID) -> None:

--- a/src/globus_cli/commands/flows/run/show_logs.py
+++ b/src/globus_cli/commands/flows/run/show_logs.py
@@ -42,7 +42,7 @@ def show_logs_command(
     limit: int,
 ) -> None:
     """
-    List run logs entries
+    List run logs entries.
 
     Enumerates the run log entries for a given run.
     """

--- a/src/globus_cli/commands/flows/run/update.py
+++ b/src/globus_cli/commands/flows/run/update.py
@@ -9,7 +9,7 @@ from globus_cli.parsing import CommaDelimitedList, command, run_id_arg
 from globus_cli.termio import Field, display, formatters
 
 
-@command("update", short_help="Update a run")
+@command("update")
 @run_id_arg
 @click.option(
     "--label",

--- a/src/globus_cli/commands/flows/show.py
+++ b/src/globus_cli/commands/flows/show.py
@@ -12,7 +12,7 @@ from globus_cli.termio import Field, display, formatters
 @LoginManager.requires_login("flows")
 def show_command(login_manager: LoginManager, *, flow_id: uuid.UUID) -> None:
     """
-    Show a flow
+    Show a flow.
     """
     flows_client = login_manager.get_flows_client()
     auth_client = login_manager.get_auth_client()

--- a/src/globus_cli/commands/flows/start.py
+++ b/src/globus_cli/commands/flows/start.py
@@ -12,7 +12,7 @@ from globus_cli.types import JsonValue
 ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 
 
-@command("start", short_help="Start a flow")
+@command("start", short_help="Start a flow.")
 @flow_id_arg
 @click.option(
     "--input",

--- a/src/globus_cli/commands/flows/update.py
+++ b/src/globus_cli/commands/flows/update.py
@@ -26,7 +26,7 @@ from globus_cli.types import JsonValue
 ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
 
 
-@command("update", short_help="Update a flow")
+@command("update", short_help="Update a flow.")
 @flow_id_arg
 @click.option("--title", type=str, help="The name of the flow.")
 @click.option(

--- a/src/globus_cli/commands/flows/validate.py
+++ b/src/globus_cli/commands/flows/validate.py
@@ -9,7 +9,7 @@ from globus_cli.parsing import JSONStringOrFile, ParsedJSONData, command
 from globus_cli.termio import Field, display
 
 
-@command("validate", short_help="Validate a flow definition")
+@command("validate", short_help="Validate a flow definition.")
 @click.argument(
     "definition",
     type=JSONStringOrFile(),

--- a/src/globus_cli/commands/gcp/__init__.py
+++ b/src/globus_cli/commands/gcp/__init__.py
@@ -10,4 +10,4 @@ from globus_cli.parsing import group
     },
 )
 def gcp_command() -> None:
-    """Manage Globus Connect Personal endpoints"""
+    """Manage Globus Connect Personal endpoints."""

--- a/src/globus_cli/commands/gcp/create/__init__.py
+++ b/src/globus_cli/commands/gcp/create/__init__.py
@@ -9,4 +9,4 @@ from globus_cli.parsing import group
     },
 )
 def create_command() -> None:
-    """Create Globus Connect Personal collections"""
+    """Create Globus Connect Personal collections."""

--- a/src/globus_cli/commands/gcp/create/guest.py
+++ b/src/globus_cli/commands/gcp/create/guest.py
@@ -12,7 +12,7 @@ from globus_cli.termio import Field, display
 from ._common import deprecated_verify_option
 
 
-@command("guest", short_help="Create a new Guest Collection on GCP")
+@command("guest", short_help="Create a new Guest Collection on GCP.")
 @endpointish_params.create(
     name="collection",
     keyword_style="string",

--- a/src/globus_cli/commands/gcp/create/mapped.py
+++ b/src/globus_cli/commands/gcp/create/mapped.py
@@ -10,7 +10,7 @@ from globus_cli.termio import Field, display
 from ._common import deprecated_verify_option
 
 
-@command("mapped", short_help="Create a new GCP Mapped Collection")
+@command("mapped", short_help="Create a new GCP Mapped Collection.")
 @endpointish_params.create(name="collection", keyword_style="string")
 @click.option(
     "--subscription-id",

--- a/src/globus_cli/commands/gcp/set_subscription_id.py
+++ b/src/globus_cli/commands/gcp/set_subscription_id.py
@@ -35,7 +35,7 @@ class GCPSubscriptionIdType(click.ParamType):
             self.fail(msg, param, ctx)
 
 
-@command("set-subscription-id", short_help="Update a GCP endpoint's subscription")
+@command("set-subscription-id", short_help="Update a GCP endpoint's subscription.")
 @endpoint_id_arg
 @click.argument("SUBSCRIPTION_ID", type=GCPSubscriptionIdType())
 @LoginManager.requires_login("transfer")

--- a/src/globus_cli/commands/gcp/update/__init__.py
+++ b/src/globus_cli/commands/gcp/update/__init__.py
@@ -9,4 +9,4 @@ from globus_cli.parsing import group
     },
 )
 def update_command() -> None:
-    """Update Globus Connect Personal collections"""
+    """Update Globus Connect Personal collections."""

--- a/src/globus_cli/commands/gcp/update/guest.py
+++ b/src/globus_cli/commands/gcp/update/guest.py
@@ -8,7 +8,7 @@ from globus_cli.parsing import collection_id_arg, command, endpointish_params
 from globus_cli.termio import display
 
 
-@command("guest", short_help="Update a Guest Collection on GCP")
+@command("guest", short_help="Update a Guest Collection on GCP.")
 @collection_id_arg
 @endpointish_params.update(
     name="collection",
@@ -33,7 +33,7 @@ def guest_command(
     verify: dict[str, bool],
 ) -> None:
     """
-    Update a Guest Collection on a Globus Connect Personal Mapped Collection
+    Update a Guest Collection on a Globus Connect Personal Mapped Collection.
     """
     from globus_cli.services.transfer import assemble_generic_doc
 

--- a/src/globus_cli/commands/gcp/update/mapped.py
+++ b/src/globus_cli/commands/gcp/update/mapped.py
@@ -10,7 +10,7 @@ from globus_cli.parsing import collection_id_arg, command, endpointish_params
 from globus_cli.termio import display
 
 
-@command("mapped", short_help="Update a GCP Mapped Collection")
+@command("mapped", short_help="Update a GCP Mapped Collection.")
 @collection_id_arg
 @endpointish_params.update(name="collection", keyword_style="string")
 @click.option(

--- a/src/globus_cli/commands/gcs/__init__.py
+++ b/src/globus_cli/commands/gcs/__init__.py
@@ -13,4 +13,4 @@ from globus_cli.parsing import group
     },
 )
 def gcs_command() -> None:
-    """Manage Globus Connect Server (GCS) resources"""
+    """Manage Globus Connect Server (GCS) resources."""

--- a/src/globus_cli/commands/gcs/endpoint/__init__.py
+++ b/src/globus_cli/commands/gcs/endpoint/__init__.py
@@ -11,4 +11,4 @@ from globus_cli.parsing import group
     },
 )
 def endpoint_command() -> None:
-    """Manage Globus Connect Server (GCS) endpoints"""
+    """Manage Globus Connect Server (GCS) endpoints."""

--- a/src/globus_cli/commands/gcs/endpoint/role/__init__.py
+++ b/src/globus_cli/commands/gcs/endpoint/role/__init__.py
@@ -11,4 +11,4 @@ from globus_cli.parsing import group
     },
 )
 def role_command() -> None:
-    """Manage Globus Connect Server (GCS) roles"""
+    """Manage Globus Connect Server (GCS) roles."""

--- a/src/globus_cli/commands/get_identities.py
+++ b/src/globus_cli/commands/get_identities.py
@@ -11,7 +11,7 @@ from globus_cli.termio import Field, display, is_verbose
 
 @command(
     "get-identities",
-    short_help="Lookup Globus Auth Identities",
+    short_help="Lookup Globus Auth Identities.",
     adoc_examples="""Resolve a user ID (outputs the user's username)
 
 [source,bash]
@@ -77,12 +77,12 @@ def get_identities_command(
 
     def _custom_text_format(identities: list[dict[str, t.Any]]) -> None:
         """
-        Non-verbose text output is customized
+        Non-verbose text output is customized.
         """
 
         def resolve_identity(value: dict[str, t.Any]) -> str:
             """
-            helper to deal with variable inputs and uncertain response order
+            Helper to deal with variable inputs and uncertain response order.
             """
             for identity in identities:
                 if identity["id"] == value:

--- a/src/globus_cli/commands/group/__init__.py
+++ b/src/globus_cli/commands/group/__init__.py
@@ -22,4 +22,4 @@ from globus_cli.parsing import group
     },
 )
 def group_command() -> None:
-    """Manage Globus Groups"""
+    """Manage Globus Groups."""

--- a/src/globus_cli/commands/group/create.py
+++ b/src/globus_cli/commands/group/create.py
@@ -28,7 +28,7 @@ def group_create(
     description: str | None,
     parent_id: uuid.UUID | None,
 ) -> None:
-    """Create a new group"""
+    """Create a new group."""
     groups_client = login_manager.get_groups_client()
 
     response = groups_client.create_group(

--- a/src/globus_cli/commands/group/delete.py
+++ b/src/globus_cli/commands/group/delete.py
@@ -15,7 +15,7 @@ def group_delete(
     *,
     group_id: uuid.UUID,
 ) -> None:
-    """Delete a group"""
+    """Delete a group."""
     groups_client = login_manager.get_groups_client()
 
     response = groups_client.delete_group(group_id)

--- a/src/globus_cli/commands/group/get_by_subscription.py
+++ b/src/globus_cli/commands/group/get_by_subscription.py
@@ -24,7 +24,7 @@ def group_get_by_subscription(
     """
     Show the group which provides a specific subscription.
 
-    If the group is not visible to the current user, only the Group ID will be shown.
+    If the group is not visible to the current user, only the group ID will be shown.
     """
     groups_client = login_manager.get_groups_client()
 

--- a/src/globus_cli/commands/group/get_by_subscription.py
+++ b/src/globus_cli/commands/group/get_by_subscription.py
@@ -13,14 +13,18 @@ from ._common import GROUP_FIELDS_W_SUBSCRIPTION, SUBSCRIPTION_FIELDS
 
 
 @click.argument("subscription_id", type=click.UUID)
-@command("get-by-subscription")
+@command(
+    "get-by-subscription",
+    short_help="Show the group for a specific subscription.",
+)
 @LoginManager.requires_login("groups")
 def group_get_by_subscription(
     login_manager: LoginManager, *, subscription_id: uuid.UUID
 ) -> None:
-    """Show the Group which provides a specific Subscription.
+    """
+    Show the group which provides a specific subscription.
 
-    If the Group is not visible to the current user, only the Group ID will be shown.
+    If the group is not visible to the current user, only the Group ID will be shown.
     """
     groups_client = login_manager.get_groups_client()
 

--- a/src/globus_cli/commands/group/get_by_subscription.py
+++ b/src/globus_cli/commands/group/get_by_subscription.py
@@ -61,7 +61,7 @@ def group_get_by_subscription(
 def try_resolve_group(
     groups_client: globus_sdk.GroupsClient, group_id: str
 ) -> globus_sdk.GlobusHTTPResponse | None:
-    """Attempt to get a group"""
+    """Attempt to get a group."""
     try:
         return groups_client.get_group(group_id, include="my_memberships")
     except globus_sdk.GlobusAPIError as e:

--- a/src/globus_cli/commands/group/invite/__init__.py
+++ b/src/globus_cli/commands/group/invite/__init__.py
@@ -9,4 +9,4 @@ from globus_cli.parsing import group
     },
 )
 def group_invite() -> None:
-    """Manage invitations to a Globus Group"""
+    """Manage invitations to a Globus Group."""

--- a/src/globus_cli/commands/group/invite/accept.py
+++ b/src/globus_cli/commands/group/invite/accept.py
@@ -12,7 +12,7 @@ from .._common import group_id_arg
 from ._common import build_invite_actions, get_invite_formatter
 
 
-@command("accept", short_help="Accept an invitation")
+@command("accept", short_help="Accept an invitation.")
 @group_id_arg
 @click.option(
     "--identity",

--- a/src/globus_cli/commands/group/invite/decline.py
+++ b/src/globus_cli/commands/group/invite/decline.py
@@ -12,7 +12,7 @@ from .._common import group_id_arg
 from ._common import build_invite_actions, get_invite_formatter
 
 
-@command("decline", short_help="Decline an invitation")
+@command("decline", short_help="Decline an invitation.")
 @group_id_arg
 @click.option(
     "--identity",

--- a/src/globus_cli/commands/group/join.py
+++ b/src/globus_cli/commands/group/join.py
@@ -17,7 +17,7 @@ JOIN_USER_FIELDS = [
 ]
 
 
-@command("join", short_help="Join a group")
+@command("join", short_help="Join a group.")
 @group_id_arg
 @click.option(
     "--identity",

--- a/src/globus_cli/commands/group/leave.py
+++ b/src/globus_cli/commands/group/leave.py
@@ -33,7 +33,7 @@ def group_leave_formatter(data: globus_sdk.GlobusHTTPResponse) -> None:
             click.echo(f"  {v}")
 
 
-@command("leave", short_help="Leave a group")
+@command("leave", short_help="Leave a group.")
 @group_id_arg
 @click.option(
     "--identity",

--- a/src/globus_cli/commands/group/list.py
+++ b/src/globus_cli/commands/group/list.py
@@ -5,10 +5,10 @@ from globus_cli.termio import Field, display, formatters
 from ._common import SESSION_ENFORCEMENT_FIELD
 
 
-@command("list", short_help="List groups you belong to")
+@command("list", short_help="List groups you belong to.")
 @LoginManager.requires_login("groups")
 def group_list(login_manager: LoginManager) -> None:
-    """List all groups for the current user"""
+    """List all groups for the current user."""
     groups_client = login_manager.get_groups_client()
 
     groups = groups_client.get_my_groups()

--- a/src/globus_cli/commands/group/member/__init__.py
+++ b/src/globus_cli/commands/group/member/__init__.py
@@ -13,4 +13,4 @@ from globus_cli.parsing import group
     },
 )
 def group_member() -> None:
-    """Manage members in a Globus Group"""
+    """Manage members in a Globus Group."""

--- a/src/globus_cli/commands/group/member/add.py
+++ b/src/globus_cli/commands/group/member/add.py
@@ -16,7 +16,7 @@ ADD_USER_FIELDS = [
 ]
 
 
-@command("add", short_help="Add a member to a group")
+@command("add", short_help="Add a member to a group.")
 @group_id_arg
 @click.argument("user", type=IdentityType())
 @click.option(

--- a/src/globus_cli/commands/group/member/approve.py
+++ b/src/globus_cli/commands/group/member/approve.py
@@ -15,7 +15,7 @@ APPROVED_USER_FIELDS = [
 ]
 
 
-@command("approve", short_help="Approve a member to join a group")
+@command("approve", short_help="Approve a member to join a group.")
 @group_id_arg
 @click.argument("user", type=IdentityType())
 @LoginManager.requires_login("groups")

--- a/src/globus_cli/commands/group/member/invite.py
+++ b/src/globus_cli/commands/group/member/invite.py
@@ -16,7 +16,7 @@ INVITED_USER_FIELDS = [
 ]
 
 
-@command("invite", short_help="Invite a user to a group")
+@command("invite", short_help="Invite a user to a group.")
 @group_id_arg
 @click.argument("user", type=IdentityType())
 @click.option(

--- a/src/globus_cli/commands/group/member/list.py
+++ b/src/globus_cli/commands/group/member/list.py
@@ -32,7 +32,7 @@ def member_list(
     group_id: uuid.UUID,
     fields: list[str] | None,
 ) -> None:
-    """List group members"""
+    """List group members."""
     groups_client = login_manager.get_groups_client()
 
     group = groups_client.get_group(group_id, include="memberships")

--- a/src/globus_cli/commands/group/member/reject.py
+++ b/src/globus_cli/commands/group/member/reject.py
@@ -15,7 +15,7 @@ REJECTED_USER_FIELDS = [
 ]
 
 
-@command("reject", short_help="Reject a member from a group")
+@command("reject", short_help="Reject a member from a group.")
 @group_id_arg
 @click.argument("user", type=IdentityType())
 @LoginManager.requires_login("groups")

--- a/src/globus_cli/commands/group/member/remove.py
+++ b/src/globus_cli/commands/group/member/remove.py
@@ -15,7 +15,7 @@ REMOVED_USER_FIELDS = [
 ]
 
 
-@command("remove", short_help="Remove a member from a group")
+@command("remove", short_help="Remove a member from a group.")
 @group_id_arg
 @click.argument("user", type=IdentityType())
 @LoginManager.requires_login("groups")

--- a/src/globus_cli/commands/group/set_policies.py
+++ b/src/globus_cli/commands/group/set_policies.py
@@ -70,7 +70,7 @@ def group_set_policies(
     join_requests: bool | None,
     signup_fields: list[str] | None,
 ) -> None:
-    """Update an existing group's policies"""
+    """Update an existing group's policies."""
     groups_client = login_manager.get_groups_client()
 
     # get the current state of the group's policies

--- a/src/globus_cli/commands/group/show.py
+++ b/src/globus_cli/commands/group/show.py
@@ -11,7 +11,7 @@ from ._common import GROUP_FIELDS, GROUP_FIELDS_W_SUBSCRIPTION, group_id_arg
 @command("show")
 @LoginManager.requires_login("groups")
 def group_show(login_manager: LoginManager, *, group_id: uuid.UUID) -> None:
-    """Show a group definition"""
+    """Show a group definition."""
     groups_client = login_manager.get_groups_client()
 
     group = groups_client.get_group(group_id, include="my_memberships")

--- a/src/globus_cli/commands/list_commands.py
+++ b/src/globus_cli/commands/list_commands.py
@@ -32,7 +32,7 @@ def _print_tree(
 
 @command(
     "list-commands",
-    short_help="List all CLI Commands",
+    short_help="List all CLI Commands.",
     help=(
         "List all Globus CLI Commands with short help output. "
         "For full command help, run the command with the "

--- a/src/globus_cli/commands/login.py
+++ b/src/globus_cli/commands/login.py
@@ -96,7 +96,7 @@ class GCSEndpointType(click.ParamType):
 
 @command(
     "login",
-    short_help="Log into Globus to get credentials for the Globus CLI",
+    short_help="Log into Globus to get credentials for the Globus CLI.",
     disable_options=["format", "map_http_status"],
 )
 @no_local_server_option

--- a/src/globus_cli/commands/logout.py
+++ b/src/globus_cli/commands/logout.py
@@ -41,7 +41,7 @@ flow.
 
 @command(
     "logout",
-    short_help="Logout of the Globus CLI",
+    short_help="Logout of the Globus CLI.",
     disable_options=["format", "map_http_status"],
 )
 @click.confirmation_option(

--- a/src/globus_cli/commands/ls.py
+++ b/src/globus_cli/commands/ls.py
@@ -39,7 +39,7 @@ class PathItemFormatter(formatters.StrFormatter):
 
 @command(
     "ls",
-    short_help="List endpoint directory contents",
+    short_help="List endpoint directory contents.",
     adoc_examples=r"""List files and dirs in your default directory on an endpoint
 
 [source,bash]

--- a/src/globus_cli/commands/mkdir.py
+++ b/src/globus_cli/commands/mkdir.py
@@ -11,7 +11,7 @@ from globus_cli.termio import display
 
 @command(
     "mkdir",
-    short_help="Create a directory on an endpoint",
+    short_help="Create a directory on an endpoint.",
     adoc_examples="""Create a directory under your home directory:
 
 [source,bash]

--- a/src/globus_cli/commands/rename.py
+++ b/src/globus_cli/commands/rename.py
@@ -11,7 +11,7 @@ from globus_cli.termio import display
 
 @command(
     "rename",
-    short_help="Rename a file or directory on an endpoint",
+    short_help="Rename a file or directory on an endpoint.",
     adoc_examples="""Rename a directory:
 
 [source,bash]

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -21,7 +21,7 @@ from ._common import transfer_task_wait_with_io
 
 @command(
     "rm",
-    short_help="Delete a single path; wait for it to complete",
+    short_help="Delete a single path; wait for it to complete.",
     adoc_examples="""Delete a single file.
 
 [source,bash]

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -67,7 +67,7 @@ def rm_command(
     timeout_exit_code: int,
 ) -> None:
     """
-    Submit a Delete Task to delete a single path, and then block and wait for it to
+    Submit a 'delete task' to delete a single path, and then block and wait for it to
     complete.
 
     Output is similar to *globus task wait*, and it is safe to *globus task wait*

--- a/src/globus_cli/commands/search/__init__.py
+++ b/src/globus_cli/commands/search/__init__.py
@@ -13,4 +13,4 @@ from globus_cli.parsing import group
     },
 )
 def search_command() -> None:
-    """Use Globus Search to store and query for data"""
+    """Use Globus Search to store and query for data."""

--- a/src/globus_cli/commands/search/delete_by_query.py
+++ b/src/globus_cli/commands/search/delete_by_query.py
@@ -17,7 +17,7 @@ from globus_cli.termio import Field, display, formatters
 from ._common import index_id_arg
 
 
-@command("delete-by-query", short_help="Perform a delete-by-query")
+@command("delete-by-query", short_help="Perform a delete-by-query.")
 @click.option("-q", help="The query-string to use to search the index.")
 @click.option(
     "--query-document",

--- a/src/globus_cli/commands/search/delete_by_query.py
+++ b/src/globus_cli/commands/search/delete_by_query.py
@@ -41,7 +41,7 @@ def delete_by_query_command(
     advanced: bool,
 ) -> None:
     """
-    Perform a Delete-By-Query on a Globus Search Index using either a simple query
+    Perform a Delete-By-Query on a Globus Search index using either a simple query
     string or a complex query document. The operation will be submitted as a task and
     can be monitored via the task_id returned.
 

--- a/src/globus_cli/commands/search/index/__init__.py
+++ b/src/globus_cli/commands/search/index/__init__.py
@@ -12,4 +12,4 @@ from globus_cli.parsing import group
     },
 )
 def index_command() -> None:
-    """View and manage indices"""
+    """View and manage indices."""

--- a/src/globus_cli/commands/search/index/create.py
+++ b/src/globus_cli/commands/search/index/create.py
@@ -14,7 +14,7 @@ from .._common import INDEX_FIELDS
 def create_command(
     login_manager: LoginManager, *, display_name: str, description: str
 ) -> None:
-    """Create a new Index"""
+    """Create a new Index."""
     search_client = login_manager.get_search_client()
     display(
         search_client.create_index(display_name=display_name, description=description),

--- a/src/globus_cli/commands/search/index/create.py
+++ b/src/globus_cli/commands/search/index/create.py
@@ -14,7 +14,7 @@ from .._common import INDEX_FIELDS
 def create_command(
     login_manager: LoginManager, *, display_name: str, description: str
 ) -> None:
-    """Create a new Index."""
+    """Create a new index."""
     search_client = login_manager.get_search_client()
     display(
         search_client.create_index(display_name=display_name, description=description),

--- a/src/globus_cli/commands/search/index/delete.py
+++ b/src/globus_cli/commands/search/index/delete.py
@@ -9,7 +9,7 @@ from globus_cli.termio import display
 @LoginManager.requires_login("search")
 @click.argument("INDEX_ID")
 def delete_command(login_manager: LoginManager, *, index_id: str) -> None:
-    """Delete a Search Index."""
+    """Delete a Search index."""
     search_client = login_manager.get_search_client()
     display(
         search_client.delete_index(index_id),

--- a/src/globus_cli/commands/search/index/delete.py
+++ b/src/globus_cli/commands/search/index/delete.py
@@ -9,7 +9,7 @@ from globus_cli.termio import display
 @LoginManager.requires_login("search")
 @click.argument("INDEX_ID")
 def delete_command(login_manager: LoginManager, *, index_id: str) -> None:
-    """Delete a Search Index"""
+    """Delete a Search Index."""
     search_client = login_manager.get_search_client()
     display(
         search_client.delete_index(index_id),

--- a/src/globus_cli/commands/search/index/list.py
+++ b/src/globus_cli/commands/search/index/list.py
@@ -12,7 +12,7 @@ INDEX_LIST_FIELDS = INDEX_FIELDS + [
 @command("list")
 @LoginManager.requires_login("search")
 def list_command(login_manager: LoginManager) -> None:
-    """List indices where you have some permissions"""
+    """List indices where you have some permissions."""
     search_client = login_manager.get_search_client()
     display(
         search_client.get("/v1/index_list"),

--- a/src/globus_cli/commands/search/index/role/__init__.py
+++ b/src/globus_cli/commands/search/index/role/__init__.py
@@ -10,4 +10,4 @@ from globus_cli.parsing import group
     },
 )
 def role_command() -> None:
-    """View and manage index roles"""
+    """View and manage index roles."""

--- a/src/globus_cli/commands/search/index/role/create.py
+++ b/src/globus_cli/commands/search/index/role/create.py
@@ -38,7 +38,7 @@ def create_command(
     principal_type: t.Literal["identity", "group"] | None,
 ) -> None:
     """
-    Create a role (requires admin or owner)
+    Create a role (requires admin or owner).
 
     PRINCIPAL is expected to be an identity or group ID, a principal URN, or a username.
 

--- a/src/globus_cli/commands/search/index/role/delete.py
+++ b/src/globus_cli/commands/search/index/role/delete.py
@@ -19,7 +19,7 @@ def delete_command(
     index_id: uuid.UUID,
     role_id: str,
 ) -> None:
-    """Delete a role (requires admin or owner)"""
+    """Delete a role (requires admin or owner)."""
     search_client = login_manager.get_search_client()
     display(
         search_client.delete_role(index_id, role_id),

--- a/src/globus_cli/commands/search/index/role/list.py
+++ b/src/globus_cli/commands/search/index/role/list.py
@@ -11,7 +11,7 @@ from ..._common import index_id_arg, resolved_principals_field
 @index_id_arg
 @LoginManager.requires_login("auth", "search")
 def list_command(login_manager: LoginManager, *, index_id: uuid.UUID) -> None:
-    """List roles on an index (requires admin)"""
+    """List roles on an index (requires admin)."""
     search_client = login_manager.get_search_client()
     auth_client = login_manager.get_auth_client()
 

--- a/src/globus_cli/commands/search/index/show.py
+++ b/src/globus_cli/commands/search/index/show.py
@@ -11,7 +11,7 @@ from .._common import INDEX_FIELDS, index_id_arg
 @index_id_arg
 @LoginManager.requires_login("search")
 def show_command(login_manager: LoginManager, *, index_id: uuid.UUID) -> None:
-    """Display information about an index"""
+    """Display information about an index."""
     search_client = login_manager.get_search_client()
     display(
         search_client.get_index(index_id), text_mode=display.RECORD, fields=INDEX_FIELDS

--- a/src/globus_cli/commands/search/ingest.py
+++ b/src/globus_cli/commands/search/ingest.py
@@ -9,7 +9,7 @@ from globus_cli.termio import Field, display
 from ._common import index_id_arg
 
 
-@command("ingest", short_help="Ingest a document into Globus Search")
+@command("ingest", short_help="Ingest a document into Globus Search.")
 @index_id_arg
 @click.argument("DOCUMENT", type=JSONStringOrFile())
 @LoginManager.requires_login("search")

--- a/src/globus_cli/commands/search/ingest.py
+++ b/src/globus_cli/commands/search/ingest.py
@@ -17,7 +17,7 @@ def ingest_command(
     login_manager: LoginManager, *, index_id: uuid.UUID, document: ParsedJSONData
 ) -> None:
     """
-    Submit a Globus Search 'GIngest' document, to be indexed in a Globus Search Index.
+    Submit a Globus Search 'GIngest' document, to be indexed in a Globus Search index.
     You must have 'owner', 'admin', or 'writer' permissions on that index.
 
     The document can be provided either as a filename, or via stdin. To use stdin, pass
@@ -29,8 +29,8 @@ def ingest_command(
     The document can be a complete GIngest document, a GMetaList, or a GMetaEntry.
     The datatype is taken from the `@datatype` field, with a default of `GIngest`.
 
-    On success, the response will contain a Task ID, which can be used to monitor the
-    Ingest Task.
+    On success, the response will contain a task ID, which can be used to monitor the
+    ingest task.
     """
     search_client = login_manager.get_search_client()
     if not isinstance(document.data, dict):

--- a/src/globus_cli/commands/search/query.py
+++ b/src/globus_cli/commands/search/query.py
@@ -26,7 +26,7 @@ def _print_subjects(data: dict[str, JsonValue]) -> None:
         click.echo(item["subject"])
 
 
-@command("query", short_help="Perform a search")
+@command("query", short_help="Perform a search.")
 @click.option("-q", help="The query-string to use to search the index.")
 @click.option(
     "--query-document",

--- a/src/globus_cli/commands/search/query.py
+++ b/src/globus_cli/commands/search/query.py
@@ -73,7 +73,7 @@ def query_command(
     filter_principal_sets: list[str] | None,
 ) -> None:
     """
-    Query a Globus Search Index by ID using either a simple query string, or a complex
+    Query a Globus Search index by ID using either a simple query string, or a complex
     query document. At least one of `-q` or `--query-document` must be provided.
 
     If a query document and command-line options are provided, the options used will

--- a/src/globus_cli/commands/search/subject/__init__.py
+++ b/src/globus_cli/commands/search/subject/__init__.py
@@ -3,11 +3,11 @@ from globus_cli.parsing import group
 
 @group(
     "subject",
-    short_help="Manage data by subject",
+    short_help="Manage data by subject.",
     lazy_subcommands={
         "delete": (".delete", "delete_command"),
         "show": (".show", "show_command"),
     },
 )
 def subject_command() -> None:
-    """View and manage individual documents in an index by subject"""
+    """View and manage individual documents in an index by subject."""

--- a/src/globus_cli/commands/search/subject/delete.py
+++ b/src/globus_cli/commands/search/subject/delete.py
@@ -19,7 +19,8 @@ def delete_command(
     index_id: uuid.UUID,
     subject: str,
 ) -> None:
-    """Delete a subject (requires writer, admin, or owner)
+    """
+    Delete a subject (requires writer, admin, or owner).
 
     Delete a submit a delete_by_subject task on an index. This requires writer or
     stronger privileges on the index.

--- a/src/globus_cli/commands/search/subject/show.py
+++ b/src/globus_cli/commands/search/subject/show.py
@@ -26,7 +26,8 @@ def _print_subject(subject_doc: "globus_sdk.GlobusHTTPResponse") -> None:
 def show_command(
     login_manager: LoginManager, *, index_id: uuid.UUID, subject: str
 ) -> None:
-    """Show the data for a given subject in an index
+    """
+    Show the data for a given subject in an index.
 
     This is subject the visible_to access control list on the entries for that subject.
     If there are one or more entries visible to the current user, they will be

--- a/src/globus_cli/commands/search/task/__init__.py
+++ b/src/globus_cli/commands/search/task/__init__.py
@@ -9,4 +9,4 @@ from globus_cli.parsing import group
     },
 )
 def task_command() -> None:
-    """View Task documents."""
+    """View task documents."""

--- a/src/globus_cli/commands/search/task/__init__.py
+++ b/src/globus_cli/commands/search/task/__init__.py
@@ -9,4 +9,4 @@ from globus_cli.parsing import group
     },
 )
 def task_command() -> None:
-    """View Task documents"""
+    """View Task documents."""

--- a/src/globus_cli/commands/search/task/list.py
+++ b/src/globus_cli/commands/search/task/list.py
@@ -18,7 +18,7 @@ TASK_FIELDS = [
 @index_id_arg
 @LoginManager.requires_login("search")
 def list_command(login_manager: LoginManager, *, index_id: uuid.UUID) -> None:
-    """List the 1000 most recent Tasks for an index."""
+    """List the 1000 most recent tasks for an index."""
     search_client = login_manager.get_search_client()
     display(
         search_client.get_task_list(index_id),

--- a/src/globus_cli/commands/search/task/list.py
+++ b/src/globus_cli/commands/search/task/list.py
@@ -14,7 +14,7 @@ TASK_FIELDS = [
 ]
 
 
-@command("list", short_help="List recent Tasks for an index.")
+@command("list", short_help="List recent tasks for an index.")
 @index_id_arg
 @LoginManager.requires_login("search")
 def list_command(login_manager: LoginManager, *, index_id: uuid.UUID) -> None:

--- a/src/globus_cli/commands/search/task/list.py
+++ b/src/globus_cli/commands/search/task/list.py
@@ -14,11 +14,11 @@ TASK_FIELDS = [
 ]
 
 
-@command("list", short_help="List recent Tasks for an index")
+@command("list", short_help="List recent Tasks for an index.")
 @index_id_arg
 @LoginManager.requires_login("search")
 def list_command(login_manager: LoginManager, *, index_id: uuid.UUID) -> None:
-    """List the 1000 most recent Tasks for an index"""
+    """List the 1000 most recent Tasks for an index."""
     search_client = login_manager.get_search_client()
     display(
         search_client.get_task_list(index_id),

--- a/src/globus_cli/commands/search/task/show.py
+++ b/src/globus_cli/commands/search/task/show.py
@@ -23,7 +23,7 @@ TASK_FIELDS = [
 @task_id_arg
 @LoginManager.requires_login("search")
 def show_command(login_manager: LoginManager, *, task_id: uuid.UUID) -> None:
-    """Display a Task"""
+    """Display a Task."""
     search_client = login_manager.get_search_client()
     display(
         search_client.get_task(task_id), fields=TASK_FIELDS, text_mode=display.RECORD

--- a/src/globus_cli/commands/search/task/show.py
+++ b/src/globus_cli/commands/search/task/show.py
@@ -23,7 +23,7 @@ TASK_FIELDS = [
 @task_id_arg
 @LoginManager.requires_login("search")
 def show_command(login_manager: LoginManager, *, task_id: uuid.UUID) -> None:
-    """Display a Task."""
+    """Display a task."""
     search_client = login_manager.get_search_client()
     display(
         search_client.get_task(task_id), fields=TASK_FIELDS, text_mode=display.RECORD

--- a/src/globus_cli/commands/session/__init__.py
+++ b/src/globus_cli/commands/session/__init__.py
@@ -10,4 +10,4 @@ from globus_cli.parsing import group
     },
 )
 def session_command() -> None:
-    """Manage your CLI auth session"""
+    """Manage your CLI auth session."""

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -10,7 +10,7 @@ from globus_cli.parsing import command, no_local_server_option
 
 @command(
     "consent",
-    short_help="Update your session with specific consents",
+    short_help="Update your session with specific consents.",
     disable_options=["format", "map_http_status"],
 )
 @no_local_server_option

--- a/src/globus_cli/commands/session/show.py
+++ b/src/globus_cli/commands/session/show.py
@@ -24,7 +24,7 @@ SESSION_FIELDS = [
 
 @command(
     "show",
-    short_help="Show your current CLI auth session",
+    short_help="Show your current CLI auth session.",
     adoc_output="""Note: this output will not show your primary identity if it is not
 in session. For information on your identity set use 'globus whoami'.
 

--- a/src/globus_cli/commands/session/update.py
+++ b/src/globus_cli/commands/session/update.py
@@ -17,7 +17,7 @@ from globus_cli.parsing import (
 def _update_session_params_all_case(
     identity_set: list[dict[str, t.Any]], session_params: dict[str, t.Any]
 ) -> None:
-    """if --all use every identity id in the user's identity set"""
+    """If --all use every identity id in the user's identity set."""
     identity_ids = [x["sub"] for x in identity_set]
     # set session params once we have all identity ids
     session_params["session_required_identities"] = ",".join(identity_ids)
@@ -78,7 +78,7 @@ def _update_session_params_identities_case(
 
 @command(
     "update",
-    short_help="Update your CLI auth session",
+    short_help="Update your CLI auth session.",
     disable_options=["format", "map_http_status"],
 )
 @no_local_server_option

--- a/src/globus_cli/commands/stat.py
+++ b/src/globus_cli/commands/stat.py
@@ -22,7 +22,7 @@ STAT_FIELDS = [
 
 @command(
     "stat",
-    short_help="Get the status of a path",
+    short_help="Get the status of a path.",
     adoc_examples=r"""Get the status of a path on a collection.
 
 [source,bash]

--- a/src/globus_cli/commands/task/__init__.py
+++ b/src/globus_cli/commands/task/__init__.py
@@ -15,4 +15,4 @@ from globus_cli.parsing import group
     },
 )
 def task_command() -> None:
-    """Manage asynchronous tasks"""
+    """Manage asynchronous tasks."""

--- a/src/globus_cli/commands/task/cancel.py
+++ b/src/globus_cli/commands/task/cancel.py
@@ -15,7 +15,7 @@ from ._common import task_id_arg
 
 @command(
     "cancel",
-    short_help="Cancel a task",
+    short_help="Cancel a task.",
     adoc_synopsis="""
 `globus task cancel [OPTIONS] TASK_ID`
 

--- a/src/globus_cli/commands/task/event_list.py
+++ b/src/globus_cli/commands/task/event_list.py
@@ -42,7 +42,7 @@ class SquashedJsonFormatter(formatters.FieldFormatter[t.Tuple[t.Any, bool]]):
 
 @command(
     "event-list",
-    short_help="List events for a given task",
+    short_help="List events for a given task.",
     adoc_synopsis="""
 `globus task event-list [OPTIONS] TASK_ID`
 

--- a/src/globus_cli/commands/task/generate_submission_id.py
+++ b/src/globus_cli/commands/task/generate_submission_id.py
@@ -5,7 +5,7 @@ from globus_cli.termio import display
 
 @command(
     "generate-submission-id",
-    short_help="Get a task submission ID",
+    short_help="Get a task submission ID.",
     adoc_output=(
         "When text output is requested, the generated 'UUID' is the only output."
     ),

--- a/src/globus_cli/commands/task/generate_submission_id.py
+++ b/src/globus_cli/commands/task/generate_submission_id.py
@@ -28,7 +28,7 @@ def generate_submission_id(login_manager: LoginManager) -> None:
     submissions.
 
     \b
-    Important Note: Submission IDs are not the same as Task IDs.
+    Important Note: submission IDs are not the same as task IDs.
     """
     transfer_client = login_manager.get_transfer_client()
 

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -38,7 +38,7 @@ def _process_filterval(
 
 @command(
     "list",
-    short_help="List your tasks",
+    short_help="List your tasks.",
     adoc_output="""When text output is requested, the following fields are used:
 
 - 'Task ID'

--- a/src/globus_cli/commands/task/pause_info.py
+++ b/src/globus_cli/commands/task/pause_info.py
@@ -56,7 +56,7 @@ PAUSE_RULE_DISPLAY_FIELDS = [
 
 @command(
     "pause-info",
-    short_help="Show why an in-progress task is currently paused",
+    short_help="Show why an in-progress task is currently paused.",
     adoc_output="""
 When text output is requested, output is broken apart into explicit pause rules
 applied to the specific task (explicit pauses), and "effective pause rules"

--- a/src/globus_cli/commands/task/show.py
+++ b/src/globus_cli/commands/task/show.py
@@ -103,7 +103,7 @@ def print_task_detail(client: globus_sdk.TransferClient, task_id: uuid.UUID) -> 
 
 @command(
     "show",
-    short_help="Show detailed information about a task",
+    short_help="Show detailed information about a task.",
     adoc_output="""
 When text output is requested, output varies slightly between 'TRANSFER' and
 'DELETE' tasks, and between active and completed tasks.

--- a/src/globus_cli/commands/task/update.py
+++ b/src/globus_cli/commands/task/update.py
@@ -13,7 +13,7 @@ from ._common import task_id_arg
 
 @command(
     "update",
-    short_help="Update a task",
+    short_help="Update a task.",
     adoc_output=(
         "When text output is requested, the output will be a simple success "
         "message (or an error)."

--- a/src/globus_cli/commands/task/update.py
+++ b/src/globus_cli/commands/task/update.py
@@ -41,7 +41,7 @@ def update_task(
     """
     Update label and/or deadline on an active task.
 
-    If a Task has completed, these attributes may no longer be updated.
+    If a task has completed, these attributes may no longer be updated.
     """
     from globus_cli.services.transfer import assemble_generic_doc
 

--- a/src/globus_cli/commands/task/wait.py
+++ b/src/globus_cli/commands/task/wait.py
@@ -11,7 +11,7 @@ from ._common import task_id_arg
 
 @command(
     "wait",
-    short_help="Wait for a task to complete",
+    short_help="Wait for a task to complete.",
     adoc_output="""
 When text output is requested, no output is written to standard out. All output
 is written to standard error.

--- a/src/globus_cli/commands/timer/__init__.py
+++ b/src/globus_cli/commands/timer/__init__.py
@@ -13,4 +13,4 @@ from globus_cli.parsing import group
     },
 )
 def timer_command() -> None:
-    """Schedule and manage timers in Globus Timers"""
+    """Schedule and manage timers in Globus Timers."""

--- a/src/globus_cli/commands/timer/create/__init__.py
+++ b/src/globus_cli/commands/timer/create/__init__.py
@@ -3,7 +3,7 @@ from globus_cli.parsing import group
 
 @group(
     "create",
-    short_help="Create a timer",
+    short_help="Create a timer.",
     lazy_subcommands={"transfer": (".transfer", "transfer_command")},
 )
 def create_command() -> None:

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -65,7 +65,7 @@ def resolve_optional_local_time(
     return start_with_tz
 
 
-@command("transfer", short_help="Create a recurring transfer timer")
+@command("transfer", short_help="Create a recurring transfer timer.")
 @click.argument(
     "source", metavar="SOURCE_ENDPOINT_ID[:SOURCE_PATH]", type=ENDPOINT_PLUS_OPTPATH
 )

--- a/src/globus_cli/commands/timer/delete.py
+++ b/src/globus_cli/commands/timer/delete.py
@@ -9,7 +9,7 @@ from globus_cli.termio import display
 from ._common import DELETED_TIMER_FORMAT_FIELDS
 
 
-@command("delete", short_help="Delete a timer")
+@command("delete", short_help="Delete a timer.")
 @click.argument("TIMER_ID", type=click.UUID)
 @LoginManager.requires_login("timer")
 def delete_command(login_manager: LoginManager, *, timer_id: uuid.UUID) -> None:

--- a/src/globus_cli/commands/timer/list.py
+++ b/src/globus_cli/commands/timer/list.py
@@ -5,7 +5,7 @@ from globus_cli.termio import display
 from ._common import TIMER_FORMAT_FIELDS
 
 
-@command("list", short_help="List your timers")
+@command("list", short_help="List your timers.")
 @LoginManager.requires_login("timer")
 def list_command(login_manager: LoginManager) -> None:
     """

--- a/src/globus_cli/commands/timer/pause.py
+++ b/src/globus_cli/commands/timer/pause.py
@@ -7,7 +7,7 @@ from globus_cli.parsing import command
 from globus_cli.termio import display
 
 
-@command("pause", short_help="Pause a timer")
+@command("pause", short_help="Pause a timer.")
 @click.argument("TIMER_ID", type=click.UUID)
 @LoginManager.requires_login("timer")
 def pause_command(login_manager: LoginManager, *, timer_id: uuid.UUID) -> None:

--- a/src/globus_cli/commands/timer/resume.py
+++ b/src/globus_cli/commands/timer/resume.py
@@ -21,7 +21,7 @@ if t.TYPE_CHECKING:
     )
 
 
-@command("resume", short_help="Resume a timer")
+@command("resume", short_help="Resume a timer.")
 @click.argument("TIMER_ID", type=click.UUID)
 @click.option(
     "--skip-inactive-reason-check",

--- a/src/globus_cli/commands/timer/show.py
+++ b/src/globus_cli/commands/timer/show.py
@@ -9,7 +9,7 @@ from globus_cli.termio import display
 from ._common import TIMER_FORMAT_FIELDS
 
 
-@command("show", short_help="Display a timer")
+@command("show", short_help="Display a timer.")
 @click.argument("TIMER_ID", type=click.UUID)
 @LoginManager.requires_login("timer")
 def show_command(login_manager: LoginManager, *, timer_id: uuid.UUID) -> None:

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -32,7 +32,7 @@ from globus_cli.termio import Field, display
         "include": "filter_rules",
         "exclude": "filter_rules",
     },
-    short_help="Submit a transfer task (asynchronous)",
+    short_help="Submit a transfer task (asynchronous).",
     adoc_examples="""Transfer a single file:
 
 [source,bash]

--- a/src/globus_cli/commands/update.py
+++ b/src/globus_cli/commands/update.py
@@ -67,7 +67,7 @@ def _check_pip_installed() -> bool:
 @command(
     "update",
     disable_options=["format", "map_http_status"],
-    short_help="Update the Globus CLI to its latest version",
+    short_help="Update the Globus CLI to its latest version.",
 )
 @click.option("--force", is_flag=True, hidden=True)
 @click.option("--yes", is_flag=True, help='Automatically say "yes" to all prompts')

--- a/src/globus_cli/commands/version.py
+++ b/src/globus_cli/commands/version.py
@@ -74,7 +74,7 @@ def _get_post_message(current: Version, latest: Version) -> str:
 @command(
     "version",
     disable_options=["format", "map_http_status"],
-    short_help="Show the version and exit",
+    short_help="Show the version and exit.",
 )
 def version_command() -> None:
     """

--- a/src/globus_cli/commands/whoami.py
+++ b/src/globus_cli/commands/whoami.py
@@ -9,7 +9,7 @@ from globus_cli.termio import Field, display, is_verbose, print_command_hint
 @command(
     "whoami",
     disable_options=["map_http_status"],
-    short_help="Show the currently logged-in identity",
+    short_help="Show the currently logged-in identity.",
     adoc_output="""\
 Note: this output is not affected by sessions in any way. For information
 on which of your identities are in session use *globus session show*

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -133,7 +133,7 @@ def handle_internal_auth_requirements(
 )
 def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
     """
-    Expects an exception with a valid authorization_paramaters info field
+    Expects an exception with a valid authorization_paramaters info field.
     """
     message = exception.info.authorization_parameters.session_message
     if message:
@@ -155,7 +155,7 @@ def session_hook(exception: globus_sdk.GlobusAPIError) -> None:
 )
 def consent_required_hook(exception: globus_sdk.GlobusAPIError) -> int | None:
     """
-    Expects an exception with a required_scopes field in its raw_json
+    Expects an exception with a required_scopes field in its raw_json.
     """
     if not exception.info.consent_required.required_scopes:
         click.secho(

--- a/src/globus_cli/login_manager/tokenstore.py
+++ b/src/globus_cli/login_manager/tokenstore.py
@@ -36,7 +36,7 @@ def _template_client_id() -> str:
 
 def internal_native_client() -> globus_sdk.NativeAppAuthClient:
     """
-    This is the client that represents the CLI itself (prior to templating)
+    This is the client that represents the CLI itself (prior to templating).
     """
     template_id = _template_client_id()
     return globus_sdk.NativeAppAuthClient(

--- a/src/globus_cli/parsing/param_types/endpoint_plus_path.py
+++ b/src/globus_cli/parsing/param_types/endpoint_plus_path.py
@@ -37,7 +37,7 @@ class EndpointPlusPath(click.ParamType):
     @property
     def metavar(self) -> str:
         """
-        Metavar as a property, so that we can make it different if `path_required`
+        Metavar as a property, so that we can make it different if `path_required`.
         """
         if self.path_required:
             return "ENDPOINT_ID:PATH"

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -79,7 +79,7 @@ def task_notify_option(f: C) -> C:
 
 def task_submission_options(f: C) -> C:
     """
-    Options shared by both transfer and delete task submission
+    Options shared by both transfer and delete task submission.
     """
 
     def format_deadline_callback(
@@ -126,7 +126,7 @@ def delete_and_rm_options(
     default_enable_globs: bool = False,
 ) -> t.Callable[[C], C]:
     """
-    Options which apply both to `globus delete` and `globus rm`
+    Options which apply both to `globus delete` and `globus rm`.
     """
 
     def decorator(f: C) -> C:
@@ -367,7 +367,7 @@ def no_local_server_option(f: C) -> C:
 
 def local_user_option(f: C) -> C:
     """
-    Option for setting the mapped local user used across multiple Transfer commands
+    Option for setting the mapped local user used across multiple Transfer commands.
     """
     return click.option(
         "--local-user",

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -205,7 +205,7 @@ def synchronous_task_wait_options(f: C) -> C:
         type=int,
         metavar="N",
         help=(
-            "Wait N seconds. If the Task does not terminate by "
+            "Wait N seconds. If the task does not terminate by "
             "then, or terminates with an unsuccessful status, "
             "exit with status 1"
         ),
@@ -216,7 +216,7 @@ def synchronous_task_wait_options(f: C) -> C:
         type=int,
         show_default=True,
         callback=polling_interval_callback,
-        help="Number of seconds between Task status checks.",
+        help="Number of seconds between task status checks.",
     )(f)
     f = click.option(
         "--heartbeat",

--- a/tests/functional/endpoint/test_endpoint_show.py
+++ b/tests/functional/endpoint/test_endpoint_show.py
@@ -4,7 +4,6 @@ from globus_sdk._testing import load_response_set
 
 @pytest.mark.parametrize("ep_type", ["personal", "share", "server"])
 def test_show_works(run_line, ep_type):
-    """make sure it doesn't blow up"""
     meta = load_response_set("cli.endpoint_operations").metadata
     if ep_type == "personal":
         epid = meta["gcp_endpoint_id"]

--- a/tests/functional/exception_handling/test_json_output.py
+++ b/tests/functional/exception_handling/test_json_output.py
@@ -6,7 +6,7 @@ from globus_sdk._testing import RegisteredResponse
 
 def test_base_json_hook(run_line):
     """
-    confirms that the base json hook captures the error JSON and prints it verbatim
+    Confirms that the base json hook captures the error JSON and prints it verbatim.
     """
     response = RegisteredResponse(
         service="transfer",
@@ -21,7 +21,7 @@ def test_base_json_hook(run_line):
 @pytest.mark.parametrize("output_format", ("json", "text"))
 def test_base_json_hook_when_no_body_is_present(run_line, output_format):
     """
-    confirms that the base json hook captures the error JSON and prints it verbatim
+    Confirms that the base json hook captures the error JSON and prints it verbatim.
     """
     RegisteredResponse(
         service="transfer",

--- a/tests/functional/groups/test_group_create.py
+++ b/tests/functional/groups/test_group_create.py
@@ -8,7 +8,7 @@ from globus_sdk._testing import get_last_request, load_response_set
 @pytest.mark.parametrize("parent_group_id", (None, str(uuid.UUID(int=0))))
 def test_group_create(run_line, parent_group_id):
     """
-    Basic success test for globus group create
+    Basic success test for globus group create.
     """
     meta = load_response_set("cli.groups").metadata
 

--- a/tests/functional/groups/test_group_delete.py
+++ b/tests/functional/groups/test_group_delete.py
@@ -3,7 +3,7 @@ from globus_sdk._testing import load_response_set
 
 def test_group_delete(run_line):
     """
-    Basic success test for globus group delete
+    Basic success test for globus group delete.
     """
     meta = load_response_set("cli.groups").metadata
 

--- a/tests/functional/groups/test_group_list.py
+++ b/tests/functional/groups/test_group_list.py
@@ -3,7 +3,7 @@ from globus_sdk._testing import load_response_set
 
 def test_group_list(run_line):
     """
-    Runs globus group list and validates results
+    Runs globus group list and validates results.
     """
     meta = load_response_set("cli.groups").metadata
 

--- a/tests/functional/groups/test_group_show.py
+++ b/tests/functional/groups/test_group_show.py
@@ -3,7 +3,7 @@ from globus_sdk._testing import load_response_set
 
 def test_group_show(run_line):
     """
-    Basic success test for globus group show
+    Basic success test for globus group show.
     """
     meta = load_response_set("cli.groups").metadata
 

--- a/tests/functional/search/test_delete_by_query.py
+++ b/tests/functional/search/test_delete_by_query.py
@@ -31,7 +31,7 @@ def _register_dbq_responses():
 @pytest.mark.parametrize("advanced_mode", [True, False])
 def test_dbq_query_string(run_line, advanced_mode):
     """
-    Runs 'globus search query -q ...' and validates results
+    Runs 'globus search query -q ...' and validates results.
     """
     meta = load_response("delete_by_query").metadata
     index_id = meta["index_id"]
@@ -58,7 +58,7 @@ def test_dbq_query_string(run_line, advanced_mode):
 
 def test_dbq_query_document(run_line, tmp_path):
     """
-    Runs 'globus search query --query-document ...' and validates results
+    Runs 'globus search query --query-document ...' and validates results.
     """
     meta = load_response("delete_by_query").metadata
     index_id = meta["index_id"]
@@ -80,7 +80,7 @@ def test_dbq_query_document(run_line, tmp_path):
 
 def test_dbq_query_string_and_document_mutex(run_line, tmp_path):
     """
-    Check that `-q` and `--query-document` cannot be used together
+    Check that `-q` and `--query-document` cannot be used together.
     """
     meta = load_response("delete_by_query").metadata
     index_id = meta["index_id"]
@@ -125,7 +125,7 @@ def test_dbq_rejects_non_object_document(run_line, tmp_path):
 
 def test_query_required(run_line):
     """
-    Check that at least one of `-q` or `--query-document` must be provided
+    Check that at least one of `-q` or `--query-document` must be provided.
     """
     meta = load_response("delete_by_query").metadata
     index_id = meta["index_id"]

--- a/tests/functional/search/test_query.py
+++ b/tests/functional/search/test_query.py
@@ -20,7 +20,7 @@ from globus_sdk._testing import load_response_set
 )
 def test_query_string(run_line, addargs, expect_params):
     """
-    Runs 'globus search query -q ...' and validates results
+    Runs 'globus search query -q ...' and validates results.
     """
     meta = load_response_set("cli.search").metadata
     index_id = meta["index_id"]
@@ -54,7 +54,7 @@ def test_query_string(run_line, addargs, expect_params):
 )
 def test_query_document(run_line, tmp_path, addargs, expect_params):
     """
-    Runs 'globus search query --query-document ...' and validates results
+    Runs 'globus search query --query-document ...' and validates results.
     """
     meta = load_response_set("cli.search").metadata
     index_id = meta["index_id"]
@@ -80,7 +80,7 @@ def test_query_document(run_line, tmp_path, addargs, expect_params):
 
 def test_query_string_and_document_mutex(run_line, tmp_path):
     """
-    Check that `-q` and `--query-document` cannot be used together
+    Check that `-q` and `--query-document` cannot be used together.
     """
     meta = load_response_set("cli.search").metadata
     index_id = meta["index_id"]
@@ -105,7 +105,7 @@ def test_query_string_and_document_mutex(run_line, tmp_path):
 
 def test_query_required(run_line):
     """
-    Check that at least one of `-q` or `--query-document` must be provided
+    Check that at least one of `-q` or `--query-document` must be provided.
     """
     meta = load_response_set("cli.search").metadata
     index_id = meta["index_id"]

--- a/tests/functional/task/test_task_submit.py
+++ b/tests/functional/task/test_task_submit.py
@@ -54,7 +54,7 @@ def test_filter_rules(run_line, go_ep1_id, go_ep2_id):
 
 def test_exclude_recursive(run_line, go_ep1_id, go_ep2_id):
     """
-    Confirms using --exclude on non recursive transfers raises errors
+    Confirms using --exclude on non recursive transfers raises errors.
     """
     # would be better if this could fail before we make any api calls, but
     # we want to build the transfer_data object before we parse batch input
@@ -125,7 +125,7 @@ def test_transfer_local_user_opts(run_line, go_ep1_id, go_ep2_id):
 
 def test_delete_local_user(run_line, go_ep1_id):
     """
-    confirms --local-user is present in delete dry-run output
+    Confirms --local-user is present in delete dry-run output.
     """
     load_response_set("cli.get_submission_id")
 
@@ -139,7 +139,7 @@ def test_delete_local_user(run_line, go_ep1_id):
 
 def test_rm_local_user(run_line, go_ep1_id):
     """
-    confirms --local-user is present in rm dry-run output
+    Confirms --local-user is present in rm dry-run output.
     """
     load_response_set("cli.get_submission_id")
 

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -7,10 +7,6 @@ from globus_sdk._testing import RegisteredResponse, load_response, load_response
 
 
 def test_parsing(run_line):
-    """
-    Runs --help and confirms the option is parsed
-    """
-    # globus --help
     result = run_line("globus --help")
     assert "-h, --help" in result.output
     assert "Show this message and exit." in result.output
@@ -18,7 +14,7 @@ def test_parsing(run_line):
 
 def test_command(run_line):
     """
-    Runs list-commands and confirms the command is run
+    Runs list-commands and confirms the command is run.
     """
     result = run_line("globus list-commands")
     assert "=== globus ===" in result.output
@@ -34,25 +30,16 @@ def test_command_parsing(run_line):
 
 
 def test_command_missing_args(run_line):
-    """
-    Runs get-identities without values, confirms exit_code 2
-    """
     result = run_line("globus get-identities", assert_exit_code=2)
     assert "Missing argument" in result.stderr
 
 
 def test_invalid_command(run_line):
-    """
-    Runs globus invalid-command, confirms Error
-    """
     result = run_line("globus invalid-command", assert_exit_code=2)
     assert "Error: No such command" in result.stderr
 
 
 def test_whoami(run_line):
-    """
-    Runs whoami to confirm test config successfully setup
-    """
     load_response_set("cli.foo_user_info")
     result = run_line("globus whoami")
     assert result.output == "foo@globusid.org\n"
@@ -60,7 +47,7 @@ def test_whoami(run_line):
 
 def test_json_raw_string_output(run_line):
     """
-    Get single-field jmespath output and make sure it's quoted
+    Get single-field jmespath output and make sure it's quoted.
     """
     load_response_set("cli.foo_user_info")
     result = run_line("globus whoami --jmespath name")
@@ -120,7 +107,7 @@ def test_transfer_call(run_line):
 @pytest.mark.parametrize("output_format", ["json", "text"])
 def test_transfer_batch_stdin_dryrun(run_line, go_ep1_id, go_ep2_id, output_format):
     """
-    Dry-runs a transfer in batchmode, confirms batchmode inputs received
+    Dry-runs a transfer in batchmode, confirms batchmode inputs received.
     """
     # put a submission ID and autoactivate response in place
     load_response_set("cli.get_submission_id")
@@ -169,7 +156,7 @@ def test_transfer_batch_file_dryrun(run_line, go_ep1_id, go_ep2_id, tmp_path):
 
 def test_delete_batchmode_dryrun(run_line, go_ep1_id):
     """
-    Dry-runs a delete in batchmode
+    Dry-runs a delete in batchmode.
     """
     # put a submission ID and autoactivate response in place
     load_response_set("cli.get_submission_id")

--- a/tests/functional/test_bookmark_commands.py
+++ b/tests/functional/test_bookmark_commands.py
@@ -5,7 +5,7 @@ from globus_sdk._testing import load_response_set
 
 def test_bookmark_create(run_line, go_ep1_id):
     """
-    Runs bookmark create, confirms simple things about text and json output
+    Runs bookmark create, confirms simple things about text and json output.
     """
     meta = load_response_set("cli.bookmark_operations").metadata
     bookmark_id = meta["bookmark_id"]

--- a/tests/functional/test_get_identities.py
+++ b/tests/functional/test_get_identities.py
@@ -5,7 +5,7 @@ from globus_sdk._testing import RegisteredResponse, load_response, load_response
 
 def test_default_one_id(run_line):
     """
-    Runs get-identities with one id, confirms correct username returned
+    Runs get-identities with one id, confirms correct username returned.
     """
     meta = load_response_set("cli.foo_user_info").metadata
     user_id = meta["user_id"]
@@ -16,7 +16,7 @@ def test_default_one_id(run_line):
 
 def test_default_one_username(run_line):
     """
-    Runs get-identities with one username, confirms correct id returned
+    Runs get-identities with one username, confirms correct id returned.
     """
     meta = load_response_set("cli.foo_user_info").metadata
     user_id = meta["user_id"]
@@ -27,7 +27,7 @@ def test_default_one_username(run_line):
 
 def test_default_nosuchidentity(run_line):
     """
-    Runs get-identities with one username, confirms correct id returned
+    Runs get-identities with one username, confirms correct id returned.
     """
     load_response(
         RegisteredResponse(
@@ -73,7 +73,7 @@ def test_default_multiple_inputs(run_line):
 
 def test_verbose(run_line):
     """
-    Runs get-identities with --verbose, confirms expected fields found
+    Runs get-identities with --verbose, confirms expected fields found.
     """
     meta = load_response_set("cli.foo_user_info").metadata
     user_id = meta["user_id"]
@@ -84,7 +84,7 @@ def test_verbose(run_line):
 
 def test_json(run_line):
     """
-    Runs get-identities with -F json confirms expected values
+    Runs get-identities with -F json confirms expected values.
     """
     meta = load_response_set("cli.foo_user_info").metadata
     user_id = meta["user_id"]

--- a/tests/functional/test_ls.py
+++ b/tests/functional/test_ls.py
@@ -23,7 +23,7 @@ def test_path(run_line, go_ep1_id):
 
 def test_recursive(run_line, go_ep1_id):
     """
-    Confirms --recursive ls on EP1:/share/ finds file1.txt
+    Confirms --recursive ls on EP1:/share/ finds file1.txt .
     """
     load_response_set("cli.transfer_activate_success")
     load_response_set("cli.ls_results")
@@ -35,7 +35,7 @@ def test_recursive(run_line, go_ep1_id):
 #   https://github.com/globus/globus-cli/issues/577
 def test_recursive_empty(run_line, go_ep1_id):
     """
-    empty recursive ls should have an empty result
+    Empty recursive ls should have an empty result.
     """
     load_response_set("cli.transfer_activate_success")
     load_response_set("cli.ls_results")
@@ -56,7 +56,7 @@ def test_depth(run_line, go_ep1_id):
 
 def test_recursive_json(run_line, go_ep1_id):
     """
-    Confirms -F json works with the RecursiveLsResponse
+    Confirms -F json works with the RecursiveLsResponse.
     """
     load_response_set("cli.transfer_activate_success")
     load_response_set("cli.ls_results")
@@ -67,7 +67,7 @@ def test_recursive_json(run_line, go_ep1_id):
 
 def test_local_user(run_line, go_ep1_id):
     """
-    Confirms --local-user is passed to query params
+    Confirms --local-user is passed to query params.
     """
     load_response_set("cli.transfer_activate_success")
     load_response_set("cli.ls_results")

--- a/tests/functional/test_mkdir.py
+++ b/tests/functional/test_mkdir.py
@@ -19,7 +19,7 @@ def test_simple_mkdir_success(run_line):
 
 def test_local_user(run_line):
     """
-    Confirms --local-user makes it to the request body
+    Confirms --local-user makes it to the request body.
     """
     load_response_set("cli.transfer_activate_success")
     meta = load_response(globus_sdk.TransferClient.operation_mkdir).metadata

--- a/tests/functional/test_rename.py
+++ b/tests/functional/test_rename.py
@@ -17,7 +17,7 @@ def test_simple_rename_success(run_line, go_ep1_id):
 
 def test_local_user(run_line, go_ep1_id):
     """
-    Confirms --local-user makes it to the request body
+    Confirms --local-user makes it to the request body.
     """
     load_response_set("cli.transfer_activate_success")
     load_response_set("cli.rename_result")

--- a/tests/functional/test_rm.py
+++ b/tests/functional/test_rm.py
@@ -42,7 +42,7 @@ def test_recursive(run_line, go_ep1_id):
 
 def test_no_file(run_line, go_ep1_id):
     """
-    Attempts to remove a non-existent file. Confirms exit code 1
+    Attempts to remove a non-existent file. Confirms exit code 1.
     """
     load_response_set("cli.transfer_activate_success")
     load_response_set("cli.get_submission_id")

--- a/tests/functional/test_stat.py
+++ b/tests/functional/test_stat.py
@@ -30,7 +30,7 @@ Group:         tutorial
 
 def test_stat_not_found(run_line):
     """
-    operation_stat returns a NotFound error, confirm non-error output
+    operation_stat returns a NotFound error, confirm non-error output.
     """
     meta = load_response(
         globus_sdk.TransferClient.operation_stat, case="not_found"
@@ -44,7 +44,7 @@ def test_stat_not_found(run_line):
 
 def test_stat_permission_denied(run_line):
     """
-    operation_stat hits a permission denied error, confirm error output
+    operation_stat hits a permission denied error, confirm error output.
     """
     meta = load_response(
         globus_sdk.TransferClient.operation_stat, case="permission_denied"

--- a/tests/functional/test_whoami.py
+++ b/tests/functional/test_whoami.py
@@ -16,7 +16,7 @@ def test_verbose(run_line):
 
 def test_linked_identities(run_line):
     """
-    Confirms --linked-identities sees foo2
+    Confirms --linked-identities sees foo2.
     """
     meta = load_response_set("cli.foo_user_info").metadata
     username = meta["username"]

--- a/tests/functional/timer/test_transfer_create.py
+++ b/tests/functional/timer/test_transfer_create.py
@@ -200,7 +200,7 @@ def test_create_timer_simple(run_line, ep_for_timer, extra_args):
 
 
 def test_create_endless_timer(run_line, ep_for_timer):
-    """Create a timer which has no end condition"""
+    """Create a timer which has no end condition."""
     create_route = f"{get_service_url('timer')}v2/timer"
     patched_response = requests.post(create_route).json()
     patched_response["timer"]["schedule"]["end"] = None

--- a/tests/unit/test_command_decorators.py
+++ b/tests/unit/test_command_decorators.py
@@ -36,7 +36,7 @@ def test_main_group_reraises_epipe_errors_without_invoking_custom_handler(runner
 def test_custom_command_missing_param_helptext(runner):
     @command()
     @click.option("--bar", help="BAR-STRING-HERE", required=True)
-    def foo(bar):
+    def foo(bar):  # noqa: CLI007
         click.echo(bar or "none")
 
     # call with `--help` to confirm help behavior
@@ -56,7 +56,7 @@ def test_custom_command_missing_param_helptext_suppressed_when_args_present(runn
     @command()
     @click.option("--bar", help="BAR-STRING-HERE", required=True)
     @click.option("--baz", help="BAZ-STRING-HERE", required=True)
-    def foo(bar, baz):
+    def foo(bar, baz):  # noqa: CLI007
         click.echo(bar or "none")
         click.echo(baz or "none")
 

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -251,7 +251,7 @@ def test_login_manager_respects_context_error_message(patched_tokenstorage):
 
 
 def test_client_login_two_requirements(client_login):
-    @LoginManager.requires_login("transfer", "auth")
+    @LoginManager.requires_login("auth", "transfer")
     def dummy_command(login_manager):
         transfer_client = login_manager.get_transfer_client()
         auth_client = login_manager.get_auth_client()


### PR DESCRIPTION
## What

Expand the CLI's flake8 plugin (`globus-cli-flake8`) with the following new rules aimed at command helptext:

- CLI003 single-line function docstring did not end in '.'
- CLI004 short_help string did not end in '.'
- CLI005 command function short_help too long
- CLI006 command function implicit short_help does not end in '.'
- CLI007 command function missing expected docstring

## Why

We regularly note inconsistent styling across CLI command help as an area for improvement.
These inconsistencies are usually trivial to resolve but hard to handle systematically.
`<insert long and boring discussion of why linters and style guides are useful here/>`

These new lint rules are specifically aimed at `short_help`, not the full `help` text attached to each command.
`short_help` is used to render lists of subcommands.

The goal here is to begin enforcing consistent styles.

### Example improvement

We consider the following example output substandard:
```
$ globus toon
Usage: globus toon [OPTIONS] COMMAND [ARGS]...

  Frob the snorks! Demuddle the smurfs!

Commands:
  gargamel  Demuddle gargamel.
  smurf     Demuddle the smurf of your choice, allowing for...
  occy      Frob occy
  snork     Frob the snork of your choice.
```

The preamble is fine, but the style of the command short_help for each subcommand is not consistent.
`globus toon gargamel` and `globus toon snork` are correct.
Each is a short phrase ending in a period.
`globus toon smurf` is too long, and truncates.
`globus toon occy` is missing the trailing period.

Better command listing would be:
```
Commands:
  gargamel  Demuddle gargamel.
  smurf     Demuddle the smurf of your choice.
  occy      Frob occy.
  snork     Frob the snork of your choice.
```

The rules obviously can't enforce this exact text, but they will guide us towards it.

### Why Not Exclude `tests/`, utilities, etc

At first glance, some of the changes here seem entirely unnecessary.
For example, docstrings in helper modules have been updated, even though these have nothing to do with helptext.

A balance needs to be struck between complexity for the flake8 plugin and its ability to filter out "irrelevant" content.
Even simple rules -- e.g., "don't descend into functions named `test_*`" -- increase implementation complexity and in many cases may prove to be error prone.

Because the plugin is not a major area of focus for our team, I decided to keep the implementation as simple as possible.
Suffering through a very small number of false-positives is a tradeoff we're making here because the cost of obeying these lint rules is very low.

## Review Notes

In order to keep `flake8` passing, we must apply these changes in the same PR which updates the plugin.
This is a very large number of simple, rote changes, which were mostly applied with editor macros.
My intent is to squash-merge the result, so we don't need to worry about the exact commit history.

The history here, in this PR, demonstrates part of how this change was executed.
CLI003 and CLI004 are added at the start of the process, and refined when CLI005, CLI006, and CLI007 were added later.
Chunks of the src/ and tests/ trees were modified on an ongoing basis, largely by means of piped `flake8` output.
e.g., `flake8 src/globus_cli/commands/bookmark/ | cut -d':' -f1 | uniq | xargs -o vim`
This should help give us confidence in the process used, that no extraneous changes were introduced.

### Notable exception: group help

After working up this PR (and opening it initially), I found that one of the targets for it failed.
[aea93d5](https://github.com/globus/globus-cli/pull/1009/commits/aea93d529d3ecb61480ab17ca06ffc370b72d576) fixes the command, which passes linting but demonstrates the ellipsis behavior which we're trying to avoid.

What happens in this case is that the short_help is 58 chars long (below the 60 limit used here), but the command name is long. Because the gap this reveals is caused not only by the associated command-name but also from _sibling command names_, I have decided not to try to address it here.

This counterexample undercuts some of the value of this new linting, but there are still many demonstrated cases in which it _does_ help us fix our helptext.