### PR TITLE
Tighten mypy to disallow-any-generics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,7 @@ entry_title_template = '{{ version }} ({{ date.strftime("%Y-%m-%d") }})'
 # `strict=true` in effect
 warn_unused_configs = true
 
-# TODO: enable disallow_any_generics (currently fails)
-# disallow_any_generics = true
+disallow_any_generics = true
 disallow_subclassing_any = true
 
 # do not disallow_untyped_calls, as we have untyped defs of our own
@@ -107,6 +106,13 @@ extra_checks = true
 
 # additional settings (not part of strict=true)
 warn_unreachable = true
+
+[[tool.mypy.overrides]]
+disallow_any_generics = false
+module = [
+    "globus_cli.exception_handling.registry",
+    "globus_cli.exception_handling.hooks",
+]
 
 [[tool.mypy.overrides]]
 disallow_untyped_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ warn_unreachable = true
 disallow_any_generics = false
 module = [
     "globus_cli.exception_handling.registry",
-    "globus_cli.exception_handling.hooks",
 ]
 
 [[tool.mypy.overrides]]

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -13,9 +13,9 @@ from globus_cli.login_manager import LoginManager, is_client_login
 from globus_cli.login_manager.scopes import CLI_SCOPE_REQUIREMENTS
 from globus_cli.parsing import command, endpoint_id_arg, group, mutex_option_group
 from globus_cli.termio import display
-from globus_cli.types import ServiceNameLiteral
+from globus_cli.types import AnyCommand, ServiceNameLiteral
 
-C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 class QueryParamType(click.ParamType):

--- a/src/globus_cli/commands/endpoint/_common.py
+++ b/src/globus_cli/commands/endpoint/_common.py
@@ -6,8 +6,9 @@ import click
 
 from globus_cli.constants import EXPLICIT_NULL
 from globus_cli.endpointish import EntityType
+from globus_cli.types import AnyCommand
 
-C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 def validate_endpoint_create_and_update_params(

--- a/src/globus_cli/commands/endpoint/_common.py
+++ b/src/globus_cli/commands/endpoint/_common.py
@@ -12,7 +12,7 @@ C = t.TypeVar("C", bound=AnyCommand)
 
 
 def validate_endpoint_create_and_update_params(
-    entity_type: EntityType, managed: bool, params: dict
+    entity_type: EntityType, managed: bool, params: dict[str, t.Any]
 ) -> None:
     """
     Given an endpoint type and option values

--- a/src/globus_cli/commands/endpoint/role/_common.py
+++ b/src/globus_cli/commands/endpoint/role/_common.py
@@ -3,8 +3,9 @@ import typing as t
 import click
 
 from globus_cli.termio import formatters
+from globus_cli.types import AnyCommand
 
-C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 class RolePrincipalFormatter(formatters.auth.PrincipalDictFormatter):

--- a/src/globus_cli/commands/endpoint/user_credential/_common.py
+++ b/src/globus_cli/commands/endpoint/user_credential/_common.py
@@ -2,7 +2,9 @@ import typing as t
 
 import click
 
-C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
+from globus_cli.types import AnyCommand
+
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 def user_credential_id_arg(

--- a/src/globus_cli/commands/gcp/create/_common.py
+++ b/src/globus_cli/commands/gcp/create/_common.py
@@ -7,8 +7,9 @@ import click
 from globus_cli import utils
 from globus_cli.parsing import MutexInfo, mutex_option_group
 from globus_cli.termio import print_command_hint
+from globus_cli.types import AnyCommand
 
-F = t.TypeVar("F", bound=t.Union[click.BaseCommand, t.Callable])
+F = t.TypeVar("F", bound=AnyCommand)
 
 
 def deprecated_verify_option(f: F) -> F:

--- a/src/globus_cli/commands/gcs/endpoint/update.py
+++ b/src/globus_cli/commands/gcs/endpoint/update.py
@@ -13,6 +13,9 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import CommaDelimitedList, command, endpoint_id_arg
 from globus_cli.parsing.param_types.nullable import IntOrNull
 from globus_cli.termio import display
+from globus_cli.types import AnyCallable
+
+F = t.TypeVar("F", bound=AnyCallable)
 
 
 class SubscriptionIdType(click.ParamType):
@@ -38,7 +41,7 @@ class SubscriptionIdType(click.ParamType):
             self.fail(f"{value} is not a valid Subscription ID", param, ctx)
 
 
-def network_use_constraints(func: t.Callable) -> t.Callable:
+def network_use_constraints(func: F) -> F:
     """
     Enforces that custom network use related parameters are present when network use is
     set to custom.
@@ -64,7 +67,7 @@ def network_use_constraints(func: t.Callable) -> t.Callable:
                 )
         return func(*args, **kwargs)
 
-    return wrapped
+    return wrapped  # type: ignore[return-value]
 
 
 @command("update")

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -5,8 +5,9 @@ import typing as t
 import click
 
 from globus_cli.termio import Field, formatters
+from globus_cli.types import AnyCommand
 
-C = t.TypeVar("C", bound=t.Union[click.Command, t.Callable])
+C = t.TypeVar("C", bound=AnyCommand)
 
 # cannot do this because it causes immediate imports and ruins the lazy import
 # performance gain

--- a/src/globus_cli/commands/search/_common.py
+++ b/src/globus_cli/commands/search/_common.py
@@ -6,8 +6,9 @@ import click
 import globus_sdk
 
 from globus_cli.termio import Field, formatters
+from globus_cli.types import AnyCommand
 
-C = t.TypeVar("C", bound=t.Callable)
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 def index_id_arg(f: C) -> C:

--- a/src/globus_cli/commands/task/_common.py
+++ b/src/globus_cli/commands/task/_common.py
@@ -4,7 +4,9 @@ import typing as t
 
 import click
 
-C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
+from globus_cli.types import AnyCommand
+
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 def task_id_arg(*, required: bool = True) -> t.Callable[[C], C]:

--- a/src/globus_cli/endpointish/entity_type.py
+++ b/src/globus_cli/endpointish/entity_type.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from enum import Enum
 
+from globus_cli.types import JsonValue
+
 
 class EntityType(Enum):
     # endpoint / collection types, strings match entity_type value in
@@ -46,7 +48,7 @@ class EntityType(Enum):
         }.get(entitytype, "UNRECOGNIZED")
 
     @classmethod
-    def determine_entity_type(cls, ep_doc: dict) -> EntityType:
+    def determine_entity_type(cls, ep_doc: dict[str, JsonValue]) -> EntityType:
         try:
             return cls(ep_doc.get("entity_type"))
         except ValueError:

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -19,7 +19,7 @@ from .tokenstore import (
 def do_link_auth_flow(
     scopes: str | t.Sequence[str | MutableScope],
     *,
-    session_params: dict[str, t.Any] | None = None,
+    session_params: dict[str, str] | None = None,
 ) -> bool:
     """
     Prompts the user with a link to authenticate with globus auth
@@ -60,7 +60,7 @@ def do_link_auth_flow(
 def do_local_server_auth_flow(
     scopes: str | t.Sequence[str | MutableScope],
     *,
-    session_params: dict[str, t.Any] | None = None,
+    session_params: dict[str, str] | None = None,
 ) -> bool:
     """
     Starts a local http server, opens a browser to have the user authenticate,

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -194,7 +194,7 @@ class LoginManager:
         no_local_server: bool = False,
         local_server_message: str | None = None,
         epilog: str | None = None,
-        session_params: dict | None = None,
+        session_params: dict[str, str] | None = None,
         scopes: list[str | MutableScope] | None = None,
     ) -> None:
         if is_client_login():

--- a/src/globus_cli/parsing/command_state.py
+++ b/src/globus_cli/parsing/command_state.py
@@ -6,6 +6,7 @@ import typing as t
 import click
 
 from globus_cli import _warnings
+from globus_cli.types import AnyCommand
 
 # Format Enum for output formatting
 # could use a namedtuple, but that's overkill
@@ -13,7 +14,7 @@ JSON_FORMAT = "json"
 TEXT_FORMAT = "text"
 UNIX_FORMAT = "unix"
 
-F = t.TypeVar("F", bound=t.Union[t.Callable, click.Command])
+F = t.TypeVar("F", bound=AnyCommand)
 
 
 def _setup_logging(level: str = "DEBUG") -> None:

--- a/src/globus_cli/parsing/mutex_group.py
+++ b/src/globus_cli/parsing/mutex_group.py
@@ -5,9 +5,11 @@ import typing as t
 
 import click
 
+from globus_cli.types import AnyCommand
+
 from ..utils import format_list_of_words
 
-C = t.TypeVar("C", bound=t.Callable)
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 class MutexInfo:
@@ -76,6 +78,6 @@ def mutex_option_group(*options: str | MutexInfo) -> t.Callable[[C], C]:
                 raise click.UsageError(f"{option_str} are mutually exclusive")
             return func(*args, **kwargs)
 
-        return t.cast(C, wrapped)
+        return wrapped  # type: ignore[return-value]
 
     return decorator

--- a/src/globus_cli/parsing/param_classes.py
+++ b/src/globus_cli/parsing/param_classes.py
@@ -4,7 +4,9 @@ import typing as t
 
 import click
 
-C = t.TypeVar("C", bound=t.Union[click.BaseCommand, t.Callable])
+from globus_cli.types import AnyCommand
+
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 class OneUseOption(click.Option):

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -16,8 +16,9 @@ from globus_cli.parsing.command_state import (
     verbose_option,
 )
 from globus_cli.parsing.param_types import NotificationParamType
+from globus_cli.types import AnyCommand
 
-C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 def common_options(*, disable_options: list[str] | None = None) -> t.Callable[[C], C]:
@@ -285,7 +286,7 @@ def security_principal_opts(
 
             return f(*args, **kwargs)
 
-        return t.cast(C, wrapper)
+        return wrapper  # type: ignore[return-value]
 
     def decorate(f: C) -> C:
         # order matters here -- the preprocessor must run after option

--- a/src/globus_cli/parsing/shared_options/endpointish.py
+++ b/src/globus_cli/parsing/shared_options/endpointish.py
@@ -12,8 +12,9 @@ from globus_cli.parsing.param_types import (
     StringOrNull,
     UrlOrNull,
 )
+from globus_cli.types import AnyCommand
 
-C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 _GCSONLY = "(Globus Connect Server only)"

--- a/src/globus_cli/parsing/shared_options/transfer_task_options.py
+++ b/src/globus_cli/parsing/shared_options/transfer_task_options.py
@@ -5,7 +5,9 @@ import typing as t
 
 import click
 
-C = t.TypeVar("C", bound=t.Union[t.Callable, click.Command])
+from globus_cli.types import AnyCommand
+
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 def sync_level_option(*, aliases: tuple[str, ...] = ()) -> t.Callable[[C], C]:

--- a/src/globus_cli/services/transfer/data.py
+++ b/src/globus_cli/services/transfer/data.py
@@ -7,6 +7,7 @@ import globus_sdk
 
 from globus_cli.constants import ExplicitNullType
 from globus_cli.parsing import TaskPath, mutex_option_group
+from globus_cli.types import JsonValue
 from globus_cli.utils import shlex_process_stream
 
 
@@ -44,8 +45,10 @@ def add_batch_to_transfer_data(
     shlex_process_stream(process_batch_line, batch, "--batch")
 
 
-def display_name_or_cname(ep_doc: dict | globus_sdk.GlobusHTTPResponse) -> str:
-    return t.cast(str, ep_doc["display_name"] or ep_doc["canonical_name"])
+def display_name_or_cname(
+    ep_doc: dict[str, JsonValue] | globus_sdk.GlobusHTTPResponse
+) -> str:
+    return str(ep_doc["display_name"] or ep_doc["canonical_name"])
 
 
 def iterable_response_to_dict(iterator: t.Iterable[t.Any]) -> dict[str, list[t.Any]]:

--- a/src/globus_cli/termio/field.py
+++ b/src/globus_cli/termio/field.py
@@ -21,7 +21,7 @@ class Field:
         key: str,
         *,
         wrap_enabled: bool = False,
-        formatter: formatters.FieldFormatter = formatters.Str,
+        formatter: formatters.FieldFormatter[t.Any] = formatters.Str,
     ):
         self.name = name
         self.key = key

--- a/src/globus_cli/termio/formatters/compound.py
+++ b/src/globus_cli/termio/formatters/compound.py
@@ -27,11 +27,11 @@ class ArrayFormatter(FieldFormatter[t.List[str]]):
         *,
         delimiter: str = ",",
         sort: bool = False,
-        element_formatter: FieldFormatter | None = None,
+        element_formatter: FieldFormatter[t.Any] | None = None,
     ) -> None:
         self.delimiter = delimiter
         self.sort = sort
-        self.element_formatter: FieldFormatter = (
+        self.element_formatter: FieldFormatter[t.Any] = (
             element_formatter if element_formatter is not None else StrFormatter()
         )
 

--- a/src/globus_cli/termio/formatters/compound.py
+++ b/src/globus_cli/termio/formatters/compound.py
@@ -3,21 +3,21 @@ from __future__ import annotations
 import json
 import typing as t
 
+from globus_cli.types import JsonValue
+
 from .base import FieldFormatter
 from .primitive import StrFormatter
 
-JSON = t.Union[None, bool, dict, float, int, list, str]
 
-
-class SortedJsonFormatter(FieldFormatter[JSON]):
+class SortedJsonFormatter(FieldFormatter[JsonValue]):
     parse_null_values = True
 
-    def parse(self, value: t.Any) -> JSON:
+    def parse(self, value: t.Any) -> JsonValue:
         if value is None or isinstance(value, (bool, dict, float, int, list, str)):
-            return t.cast(JSON, value)
-        raise ValueError("bad JSON value")
+            return value
+        raise ValueError("bad JsonValue value")
 
-    def render(self, value: JSON) -> str:
+    def render(self, value: JsonValue) -> str:
         return json.dumps(value, sort_keys=True)
 
 

--- a/src/globus_cli/types.py
+++ b/src/globus_cli/types.py
@@ -21,12 +21,16 @@ if t.TYPE_CHECKING:
     import globus_sdk
 
 
+AnyCallable: TypeAlias = t.Callable[..., t.Any]
+AnyCommand: TypeAlias = t.Union[click.Command, AnyCallable]
+
+
 ClickContextTree: TypeAlias = t.Tuple[
     click.Context, t.List[click.Context], t.List["ClickContextTree"]
 ]
 
 
-DATA_CONTAINER_T = t.Union[
+DATA_CONTAINER_T: TypeAlias = t.Union[
     t.Mapping[str, t.Any],
     "globus_sdk.GlobusHTTPResponse",
 ]

--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -5,6 +5,8 @@ import uuid
 
 import click
 
+from globus_cli.types import AnyCallable
+
 if t.TYPE_CHECKING:
     from globus_cli.services.auth import CustomAuthClient
 
@@ -15,7 +17,7 @@ if t.TYPE_CHECKING:
         GlobusAuthRequirementsError,
     )
 
-F = t.TypeVar("F", bound=t.Callable)
+F = t.TypeVar("F", bound=AnyCallable)
 
 
 def str2bool(v: str) -> bool | None:
@@ -63,7 +65,7 @@ def get_current_option_help(
     return [o.get_error_hint(ctx) for o in opts]
 
 
-def supported_parameters(c: t.Callable) -> list[str]:
+def supported_parameters(c: AnyCallable) -> list[str]:
     import inspect
 
     sig = inspect.signature(c)


### PR DESCRIPTION
This sets `disallow-any-generics = true`, which forbids the use of implicit `Any` in a generic when a type parameter is not provided.
There is one troublesome module, related to exception hooks, where this rule is still disabled for now.

The pass over the codebase done here was also used as an opportunity for some minor related refinements, e.g. switching `cast` usages to `type-ignore` comments.

- mypy: disallow-any-generics
- Introduce AnyCallable,AnyCommand aliases
- Fix declarations of FieldFormatter[Any]
- Fix usages of bare `dict` generic type
- Fix any-generics in exception hooks
