### PR TITLE
Set mypy strict=true

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,31 +78,7 @@ output_file = "changelog.adoc"
 entry_title_template = '{{ version }} ({{ date.strftime("%Y-%m-%d") }})'
 
 [tool.mypy]
-# the desired config here is
-#   strict=true
-# however, strict=true does not play well with overrides (used below)
-# therefore, we explicitly declare a number of options which approach
-# `strict=true` in effect
-warn_unused_configs = true
-
-disallow_any_generics = true
-disallow_subclassing_any = true
-
-# do not disallow_untyped_calls, as we have untyped defs of our own
-# this rule causes too much chaos at present
-#
-# disallow_untyped_calls = true
-
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-disallow_untyped_decorators = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_return_any = true
-no_implicit_reexport = true
-strict_equality = true
-extra_checks = true
+strict = true
 
 # additional settings (not part of strict=true)
 warn_unreachable = true
@@ -114,6 +90,7 @@ module = [
 ]
 
 [[tool.mypy.overrides]]
+disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 module = [

--- a/src/globus_cli/termio/printer.py
+++ b/src/globus_cli/termio/printer.py
@@ -83,7 +83,7 @@ def print_json_response(
 def print_unix_response(res: JsonValue | globus_sdk.GlobusHTTPResponse) -> None:
     res = _jmespath_preprocess(res)
     try:
-        unix_display(res)
+        unix_display(res)  # type: ignore[no-untyped-call]
     # Attr errors indicate that we got data which cannot be unix formatted
     # likely a scalar + non-scalar in an array, though there may be other cases
     # print good error and exit(2) (Count this as UsageError!)


### PR DESCRIPTION
We have finally achieved a state where the CLI code is fully typed
enough that enabling strict mode is feasible.
All of the options redundant with `strict=true` have been removed from
config.

Two adjustments are needed to finish this body of work:
- disallow_untyped_calls is set for "untyped modules" in overrides
- a single untyped call into one of those modules is type-ignored
