### PR TITLE
Fix type-annotations in excepthook registry module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,12 +84,6 @@ strict = true
 warn_unreachable = true
 
 [[tool.mypy.overrides]]
-disallow_any_generics = false
-module = [
-    "globus_cli.exception_handling.registry",
-]
-
-[[tool.mypy.overrides]]
 disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false

--- a/src/globus_cli/exception_handling/__init__.py
+++ b/src/globus_cli/exception_handling/__init__.py
@@ -22,12 +22,12 @@ from globus_cli.parsing.command_state import CommandState
 from .hooks import register_all_hooks
 from .registry import find_handler
 
+E = t.TypeVar("E", bound=Exception)
+
 register_all_hooks()
 
 
-def custom_except_hook(
-    exc_info: tuple[type[Exception], Exception, types.TracebackType]
-) -> t.NoReturn:
+def custom_except_hook(exc_info: tuple[type[E], E, types.TracebackType]) -> t.NoReturn:
     """
     A custom excepthook to present python errors produced by the CLI.
     We don't want to show end users big scary stacktraces if they aren't python
@@ -45,7 +45,7 @@ def custom_except_hook(
     # we're not in debug mode, do custom handling
 
     # look for a relevant registered handler
-    handler = find_handler(exception)
+    handler: t.Callable[[E], t.NoReturn] | None = find_handler(exception)
     if handler:
         handler(exception)
 

--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -218,7 +218,7 @@ class TopLevelGroup(GlobusCommandGroup):
             raise
         except Exception:
             # mypy thinks that exc_info could be (None, None, None), but... nope. False.
-            custom_except_hook(sys.exc_info())  # type: ignore[arg-type]
+            custom_except_hook(sys.exc_info())  # type: ignore[arg-type,type-var]
 
 
 def main_group(**kwargs: t.Any) -> t.Callable[[C], TopLevelGroup]:


### PR DESCRIPTION
This module was listed with an override for `disallow_any_generics=false` due to the complexities around the generic type aliases it defines.

In short, the problem this module faces is that it converts between various types while preserving a type var (the type of exception being handled). However, attempting to explicitly *declare* that type var leads to mypy flagging runtime-safe usages which aren't provably type-safe.

To resolve these issues, a few steps are taken:

1.  Tuples of hook functions with their relevant tests in the registry are replaced by a small dataclass

    Where we once had `(handleErrorX, errorIsOfTypeX)`, we now have `_RegisteredHook[X]`. This keeps the harmonious types declared in a way which type-checkers will find more palatable.

2.  Overloads are declared for an internal helper which resolves class names to classes. Because the type of this function cannotbe deduced correctly by a type checker, several overloads are declared which "explain the type".

3.  Drop support for a `condition` (test) function from the non-SDK error handler decorator. This is additional complexity, requiring overloads or similar "explanation" to make type-checking pass. But it is never actually used, and can therefore be safely dropped.
