### PR TITLE
Convert to ConnectorTable for resolution

### DIFF
--- a/changelog.d/20240729_134844_sirosen_use_sdk_connector_table.md
+++ b/changelog.d/20240729_134844_sirosen_use_sdk_connector_table.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Connector ID to name rendering has been fixed for the Dropbox and HPSS
+  storage connectors

--- a/changelog.d/20240729_134844_sirosen_use_sdk_connector_table.md
+++ b/changelog.d/20240729_134844_sirosen_use_sdk_connector_table.md
@@ -1,4 +1,4 @@
 ### Bugfixes
 
-* Connector ID to name rendering has been fixed for the Dropbox and HPSS
-  storage connectors
+* Fix rendering of connector names by connector ID for the Dropbox and HPSS
+  storage connectors.

--- a/src/globus_cli/services/gcs.py
+++ b/src/globus_cli/services/gcs.py
@@ -7,81 +7,15 @@ import globus_sdk
 from globus_cli.endpointish import Endpointish
 from globus_cli.termio import formatters
 
-CONNECTOR_INFO: list[dict[str, str]] = [
-    {
-        "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
-        "name": "POSIX",
-    },
-    {
-        "connector_id": "7e3f3f5e-350c-4717-891a-2f451c24b0d4",
-        "name": "BlackPearl",
-    },
-    {
-        "connector_id": "7c100eae-40fe-11e9-95a3-9cb6d0d9fd63",
-        "name": "Box",
-    },
-    {
-        "connector_id": "1b6374b0-f6a4-4cf7-a26f-f262d9c6ca72",
-        "name": "Ceph",
-    },
-    {
-        "connector_id": "28ef55da-1f97-11eb-bdfd-12704e0d6a4d",
-        "name": "OneDrive",
-    },
-    {
-        "connector_id": "976cf0cf-78c3-4aab-82d2-7c16adbcc281",
-        "name": "Google Drive",
-    },
-    {
-        "connector_id": "56366b96-ac98-11e9-abac-9cb6d0d9fd63",
-        "name": "Google Cloud Storage",
-    },
-    {
-        "connector_id": "7251f6c8-93c9-11eb-95ba-12704e0d6a4d",
-        "name": "ActiveScale",
-    },
-    {
-        "connector_id": "7643e831-5f6c-4b47-a07f-8ee90f401d23",
-        "name": "S3",
-    },
-    {
-        "connector_id": "052be037-7dda-4d20-b163-3077314dc3e6",
-        "name": "POSIX Staging",
-    },
-    {
-        "connector_id": "e47b6920-ff57-11ea-8aaa-000c297ab3c2",
-        "name": "iRODS",
-    },
-]
-
-
-def connector_display_name_to_id(connector_name: str) -> str | None:
-    conn_id = None
-    for data in CONNECTOR_INFO:
-        if data["name"] == connector_name:
-            conn_id = data["connector_id"]
-            break
-    return conn_id
-
-
-def connector_id_to_display_name(connector_id: str) -> str:
-    display_name = None
-    for data in CONNECTOR_INFO:
-        if data["connector_id"] == connector_id:
-            display_name = data["name"]
-            break
-
-    if not display_name:
-        display_name = f"UNKNOWN ({connector_id})"
-
-    return display_name
-
 
 class ConnectorIdFormatter(formatters.StrFormatter):
     def parse(self, value: t.Any) -> str:
         if not isinstance(value, str):
             raise ValueError("bad connector ID")
-        return connector_id_to_display_name(value)
+        connector = globus_sdk.ConnectorTable.lookup(value)
+        if not connector:
+            return f"UNKNOWN ({value})"
+        return connector.name
 
 
 class CustomGCSClient(globus_sdk.GCSClient):

--- a/tests/unit/formatters/test_connector_formatter.py
+++ b/tests/unit/formatters/test_connector_formatter.py
@@ -2,10 +2,7 @@ import uuid
 
 import pytest
 
-from globus_cli.services.gcs import (
-    connector_display_name_to_id,
-    connector_id_to_display_name,
-)
+from globus_cli.services.gcs import ConnectorIdFormatter
 
 
 @pytest.mark.parametrize(
@@ -24,16 +21,10 @@ from globus_cli.services.gcs import (
         ("e47b6920-ff57-11ea-8aaa-000c297ab3c2", "iRODS"),
     ],
 )
-def test_connector_id_name_methods_are_inverses(connector_id, connector_name):
-    assert connector_display_name_to_id(connector_name) == connector_id
-    assert connector_id_to_display_name(connector_id) == connector_name
+def test_connector_id_to_name_formatting(connector_id, connector_name):
+    assert ConnectorIdFormatter().format(connector_id) == connector_name
 
 
 def test_name_of_unknown_connector_id():
     fake_id = str(uuid.UUID(int=0))
-    assert connector_id_to_display_name(fake_id) == f"UNKNOWN ({fake_id})"
-
-
-def test_id_of_unknown_connector_name():
-    fake_name = "foo-invalid"
-    assert connector_display_name_to_id(fake_name) is None
+    assert ConnectorIdFormatter().format(fake_id) == f"UNKNOWN ({fake_id})"


### PR DESCRIPTION
Rather than keeping a CLI-specific dict of IDs and names, use the
ConnectorTable object provided by the SDK to resolve IDs to names.

This changeset also eliminates a never-used method for converting
names to IDs, which is functionality provided by the ConnectorTable if
we should need it.

In addition to test refactoring, the relevant test module is renamed.

The changelog notes this as a rendering fix, since Dropbox and HPSS
were previously missing from the data but are included in the
ConnectorTable. So, effectively two entries have been "added" to this
formatter.
