### PR TITLE
Added --delete flag to timer create transfer

### DIFF
--- a/changelog.d/20240801_163618_derek_timer_transfer_delete.md
+++ b/changelog.d/20240801_163618_derek_timer_transfer_delete.md
@@ -1,0 +1,9 @@
+
+### Enhancements
+
+* Added a `--delete` flag to `globus timer create transfer` to mirror
+  `globus transfer --delete` functionality.
+
+  This option will delete files, directories, and symlinks on the destination endpoint
+  which don’t exist on the source endpoint or are a different type. Only applies for
+  recursive directory transfers.

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -55,16 +55,6 @@ e.g. '1h30m', '500s', '10d'
 """
 
 
-def resolve_optional_local_time(
-    start: datetime.datetime | None,
-) -> datetime.datetime | globus_sdk.utils.MissingType:
-    if start is None:
-        return globus_sdk.MISSING
-    # set the timezone to local system time if the timezone input is not aware
-    start_with_tz = start.astimezone() if start.tzinfo is None else start
-    return start_with_tz
-
-
 @command("transfer", short_help="Create a recurring transfer timer.")
 @click.argument(
     "source", metavar="SOURCE_ENDPOINT_ID[:SOURCE_PATH]", type=ENDPOINT_PLUS_OPTPATH
@@ -108,6 +98,15 @@ def resolve_optional_local_time(
     help="Stop running the transfer after this number of runs have happened.",
 )
 @mutex_option_group("--stop-after-date", "--stop-after-runs")
+@click.option(
+    "--delete",
+    is_flag=True,
+    default=False,
+    help=(
+        "Delete extraneous files in the destination directory. "
+        "Only applies to recursive directory transfers."
+    ),
+)
 @LoginManager.requires_login("auth", "timer", "transfer")
 def transfer_command(
     login_manager: LoginManager,
@@ -122,6 +121,7 @@ def transfer_command(
     label: str | None,
     stop_after_date: datetime.datetime | None,
     stop_after_runs: int | None,
+    delete: bool,
     sync_level: t.Literal["exists", "size", "mtime", "checksum"] | None,
     encrypt_data: bool,
     verify_checksum: bool,
@@ -174,13 +174,18 @@ def transfer_command(
     source_endpoint, cmd_source_path = source
     dest_endpoint, cmd_dest_path = destination
 
-    # avoid 'mutex_option_group', emit a custom error message
-    if recursive is not None and batch:
-        option_name = "--recursive" if recursive else "--no-recursive"
-        raise click.UsageError(
-            f"You cannot use {option_name} in addition to --batch. "
-            f"Instead, use {option_name} on lines of --batch input which need it."
-        )
+    if recursive is not None:
+        if batch:
+            # avoid 'mutex_option_group', emit a custom error message
+            option_name = "--recursive" if recursive else "--no-recursive"
+            raise click.UsageError(
+                f"You cannot use {option_name} in addition to --batch. "
+                f"Instead, use {option_name} on lines of --batch input which need it."
+            )
+
+        if delete and not recursive:
+            msg = "The --delete option cannot be specified with --no-recursion."
+            raise click.UsageError(msg)
     if (cmd_source_path is None or cmd_dest_path is None) and (not batch):
         raise click.UsageError(
             "transfer requires either SOURCE_PATH and DEST_PATH or --batch"
@@ -273,6 +278,7 @@ def transfer_command(
         encrypt_data=encrypt_data,
         skip_source_errors=skip_source_errors,
         fail_on_quota_errors=fail_on_quota_errors,
+        delete_destination_extra=delete,
         # mypy can't understand kwargs expansion very well
         **notify,  # type: ignore[arg-type]
     )
@@ -294,6 +300,16 @@ def transfer_command(
     body = globus_sdk.TransferTimer(name=name, schedule=schedule, body=transfer_data)
     response = timer_client.create_timer(body)
     display(response["timer"], text_mode=display.RECORD, fields=FORMAT_FIELDS)
+
+
+def resolve_optional_local_time(
+    start: datetime.datetime | None,
+) -> datetime.datetime | globus_sdk.utils.MissingType:
+    if start is None:
+        return globus_sdk.MISSING
+    # set the timezone to local system time if the timezone input is not aware
+    start_with_tz = start.astimezone() if start.tzinfo is None else start
+    return start_with_tz
 
 
 def _derive_needed_scopes(

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -103,8 +103,8 @@ e.g. '1h30m', '500s', '10d'
     is_flag=True,
     default=False,
     help=(
-        "Delete extraneous files in the destination directory. "
-        "Only applies to recursive directory transfers."
+        "Delete any files in the destination directory not contained in the source. "
+        'This results in "directory mirroring." Only valid on recursive transfers.'
     ),
 )
 @LoginManager.requires_login("auth", "timer", "transfer")

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -141,8 +141,8 @@ fi
     is_flag=True,
     default=False,
     help=(
-        "Delete extraneous files in the destination directory. "
-        "Only applies to recursive directory transfers."
+        "Delete any files in the destination directory not contained in the source. "
+        'This results in "directory mirroring." Only valid on recursive transfers.'
     ),
 )
 @click.option(

--- a/tests/functional/timer/test_transfer_create.py
+++ b/tests/functional/timer/test_transfer_create.py
@@ -498,3 +498,33 @@ def test_timer_creation_errors_on_data_access_with_client_creds(
 
     req = get_last_request()
     assert req.url.startswith("https://timer")
+
+
+@pytest.mark.parametrize(
+    "deletion_option,recursion_option,expected_error",
+    (
+        ("--delete", "--recursive", ""),
+        ("--delete", "", ""),
+        (
+            "--delete",
+            "--no-recursive",
+            "The --delete option cannot be specified with --no-recursion.",
+        ),
+    ),
+)
+def test_timer_creation_delete_flag_requires_recursion(
+    run_line,
+    client_login,
+    ep_for_timer,
+    deletion_option,
+    recursion_option,
+    expected_error,
+):
+    base_cmd = f"globus timer create transfer {ep_for_timer}:/foo/ {ep_for_timer}:/bar/"
+    options_list = ("--interval 60m", deletion_option, recursion_option)
+    options = " ".join(op for op in options_list if op is not None)
+
+    exit_code = 0 if not expected_error else 2
+    resp = run_line(f"{base_cmd} {options}", assert_exit_code=exit_code)
+
+    assert expected_error in resp.stderr


### PR DESCRIPTION
## What?
Added a `--delete` flag to `globus timer create transfer` to match the one in `globus transfer` ([docs](https://docs.globus.org/cli/reference/transfer/#options)).

### Note
This flag does not perform a "deletion" task but rather performs a "transfer" task with "delete_destination_extra" set to true.

From the [docs](https://docs.globus.org/api/transfer/task_submit/#transfer_specific_fields), this field requests that the task:
>Delete files, directories, and symlinks in the destination directory which don’t exist on the source directory or are a different type. Only applies for recursive directory transfers. Default: false.

I chose to use the flag name `--delete` instead of `--delete-destination-extra` to maintain consistency with the regular transfer cli command.

## Testing

Created a timer which ran once, performing a transfer that delete extra files on the destination. Observed timer run and transfer task success.

```zsh
globus timer create transfer --delete $MY_GCP:/~/gcp/subdir/ $MY_GCP:/~/gcp/subdir2/ --stop-after-runs=1
```
