### PR TITLE
Fix search index delete to use index_id_arg

### DIFF
--- a/changelog.d/20240815_115113_sirosen_fix_index_id_arg.md
+++ b/changelog.d/20240815_115113_sirosen_fix_index_id_arg.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* `globus search index delete` will now emit a usage error if the index ID is
+  malformed.

--- a/src/globus_cli/commands/search/index/delete.py
+++ b/src/globus_cli/commands/search/index/delete.py
@@ -1,14 +1,16 @@
-import click
+import uuid
 
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import display
 
+from .._common import index_id_arg
+
 
 @command("delete")
 @LoginManager.requires_login("search")
-@click.argument("INDEX_ID")
-def delete_command(login_manager: LoginManager, *, index_id: str) -> None:
+@index_id_arg
+def delete_command(login_manager: LoginManager, *, index_id: uuid.UUID) -> None:
     """Delete a Search index."""
     search_client = login_manager.get_search_client()
     display(

--- a/tests/functional/search/test_index.py
+++ b/tests/functional/search/test_index.py
@@ -52,3 +52,8 @@ def test_index_delete(run_line):
         f"globus search index delete {index_id}",
         search_stdout=f"Index {index_id} is now marked for deletion.",
     )
+
+
+def test_index_delete_rejects_empty_str(run_line):
+    result = run_line(["globus", "search", "index", "delete", ""], assert_exit_code=2)
+    assert "Invalid value for 'INDEX_ID'" in result.stderr


### PR DESCRIPTION
This was doing basic string-arg parsing, which allowed for (among
other things) the empty string. A regression test captures the bad
usage which uncovered this.
