### PR TITLE
Fix use of 'TimerScopes'

### DIFF
--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -17,7 +17,6 @@ from globus_sdk.scopes import (
     GroupsScopes,
     MutableScope,
     SearchScopes,
-    TimerScopes,
     TransferScopes,
 )
 
@@ -36,6 +35,12 @@ from .tokenstore import (
     token_storage_adapter,
 )
 from .utils import get_current_identity_id, is_remote_session
+
+# TODO: remove this after an SDK release provides TimersScopes
+try:
+    from globus_sdk.scopes import TimersScopes
+except ImportError:
+    from globus_sdk.scopes import TimerScopes as TimersScopes
 
 if t.TYPE_CHECKING:
     from ..services.auth import CustomAuthClient
@@ -371,7 +376,7 @@ class LoginManager:
         return globus_sdk.SearchClient(authorizer=authorizer, app_name=version.app_name)
 
     def get_timer_client(self) -> globus_sdk.TimerClient:
-        authorizer = self._get_client_authorizer(TimerScopes.resource_server)
+        authorizer = self._get_client_authorizer(TimersScopes.resource_server)
         return globus_sdk.TimerClient(authorizer=authorizer, app_name=version.app_name)
 
     def _get_gcs_info(

--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -38,7 +38,7 @@ from .utils import get_current_identity_id, is_remote_session
 
 # TODO: remove this after an SDK release provides TimersScopes
 try:
-    from globus_sdk.scopes import TimersScopes
+    from globus_sdk.scopes import TimersScopes  # type: ignore[attr-defined]
 except ImportError:
     from globus_sdk.scopes import TimerScopes as TimersScopes
 

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -14,7 +14,7 @@ from globus_sdk.scopes import (
 
 # TODO: remove this after an SDK release provides TimersScopes
 try:
-    from globus_sdk.scopes import TimersScopes
+    from globus_sdk.scopes import TimersScopes  # type: ignore[attr-defined]
 except ImportError:
     from globus_sdk.scopes import TimerScopes as TimersScopes
 
@@ -37,7 +37,7 @@ def compute_timer_scope(
     transfer_ap_scope = MutableScope(TRANSFER_AP_SCOPE_STR)
     transfer_ap_scope.add_dependency(transfer_scope)
 
-    timer_scope = TimersScopes.make_mutable("timer")
+    timer_scope: MutableScope = TimersScopes.make_mutable("timer")
     timer_scope.add_dependency(transfer_ap_scope)
     return timer_scope
 

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -9,9 +9,14 @@ from globus_sdk.scopes import (
     GroupsScopes,
     MutableScope,
     SearchScopes,
-    TimerScopes,
     TransferScopes,
 )
+
+# TODO: remove this after an SDK release provides TimersScopes
+try:
+    from globus_sdk.scopes import TimersScopes
+except ImportError:
+    from globus_sdk.scopes import TimerScopes as TimersScopes
 
 from globus_cli.types import ServiceNameLiteral
 
@@ -32,7 +37,7 @@ def compute_timer_scope(
     transfer_ap_scope = MutableScope(TRANSFER_AP_SCOPE_STR)
     transfer_ap_scope.add_dependency(transfer_scope)
 
-    timer_scope = TimerScopes.make_mutable("timer")
+    timer_scope = TimersScopes.make_mutable("timer")
     timer_scope.add_dependency(transfer_ap_scope)
     return timer_scope
 
@@ -88,7 +93,7 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
         }
         self["timer"] = {
             "min_contract_version": 1,
-            "resource_server": TimerScopes.resource_server,
+            "resource_server": TimersScopes.resource_server,
             "nice_server_name": "Globus Timers",
             "scopes": [
                 TIMER_SCOPE_WITH_DEPENDENCIES,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,17 @@ import pytest
 import responses
 from click.testing import CliRunner
 from globus_sdk._testing import register_response_set
-from globus_sdk.scopes import TimerScopes
 from globus_sdk.transport import RequestsTransport
 from ruamel.yaml import YAML
 
 import globus_cli
 from globus_cli.login_manager.tokenstore import build_storage_adapter
+
+# TODO: remove this after an SDK release provides TimersScopes
+try:
+    from globus_sdk.scopes import TimersScopes
+except ImportError:
+    from globus_sdk.scopes import TimerScopes as TimersScopes
 
 yaml = YAML()
 log = logging.getLogger(__name__)
@@ -109,8 +114,8 @@ def mock_login_token_response():
         "search.api.globus.org": _mock_token_response_data(
             "search.api.globus.org", "urn:globus:auth:scope:search.api.globus.org:all"
         ),
-        TimerScopes.resource_server: _mock_token_response_data(
-            TimerScopes.resource_server, TimerScopes.timer
+        TimersScopes.resource_server: _mock_token_response_data(
+            TimersScopes.resource_server, TimersScopes.timer
         ),
         "flows.globus.org": _mock_token_response_data(
             "flows.globus.org",


### PR DESCRIPTION
New SDK versions have renamed this to 'TimersScopes'. Attempting to
use the old name emits a deprecation warning and therefore fails the
testsuite. (When running against SDK 'main'.)

To handle this in advance of the next release, use simple
`try-except(ImportError)` handling.
