### PR TITLE
Fix an AsciiDoc rendering warning

### DIFF
--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -40,10 +40,11 @@ def set_endpoint_subscription_id(
     login_manager: LoginManager, *, endpoint_id: uuid.UUID, subscription_id: str
 ) -> None:
     """
-    For GCS endpoints, refer to ``globus gcs endpoint set-subscription-id``. For
-    GCP endpoints, refer to ``globus gcp set-subscription-id``.
-
-    -----------------------------
+    [NOTE]
+    ====
+    For GCS endpoints, refer to ``globus gcs endpoint set-subscription-id``.
+    For GCP endpoints, refer to ``globus gcp set-subscription-id``.
+    ====
 
     Set an endpoint's subscription ID.
 


### PR DESCRIPTION
Found while working on the docs site.

The horizontal rule causes this warning:

```
asciidoctor: WARNING: endpoint_set-subscription-id.adoc: line 17: unterminated listing block
```