### PR TITLE
Remove the redundant tox `skip_missing_interpreters` setting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
     cov-combine
     cov-report
     mypy
-skip_missing_interpreters = true
 minversion = 4.3.5
 
 [testenv]


### PR DESCRIPTION

This PR removes the redundant tox `skip_missing_interpreters` setting in `tox.ini`.
This codifies the recently-discovered fact that it's true by default.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>