### PR TITLE
Make the 'sdkmain' build pass again

### DIFF
--- a/src/globus_cli/commands/collection/create/guest.py
+++ b/src/globus_cli/commands/collection/create/guest.py
@@ -5,7 +5,6 @@ import uuid
 
 import click
 import globus_sdk
-import globus_sdk.experimental.auth_requirements_error
 
 from globus_cli.commands.collection._common import (
     LazyCurrentIdentity,

--- a/src/globus_cli/commands/flows/run/resume.py
+++ b/src/globus_cli/commands/flows/run/resume.py
@@ -110,9 +110,12 @@ def check_inactive_reason(
 def _get_inactive_reason(
     run_doc: dict[str, t.Any] | globus_sdk.GlobusHTTPResponse
 ) -> GlobusAuthRequirementsError | None:
-    from globus_sdk.experimental.auth_requirements_error import (
-        to_auth_requirements_error,
-    )
+    try:
+        from globus_sdk.gare import to_gare  # type: ignore[import-not-found]
+    except ImportError:
+        from globus_sdk.experimental.auth_requirements_error import (
+            to_auth_requirements_error as to_gare,
+        )
 
     if not run_doc.get("status") == "INACTIVE":
         return None
@@ -121,7 +124,7 @@ def _get_inactive_reason(
     if not isinstance(details, dict):
         return None
 
-    return to_auth_requirements_error(details)
+    return to_gare(details)  # type: ignore[no-any-return]
 
 
 def _has_required_consent(

--- a/src/globus_cli/commands/session/consent.py
+++ b/src/globus_cli/commands/session/consent.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import click
-from globus_sdk.scopes import MutableScope
+from globus_sdk.scopes import Scope
 
 from globus_cli import utils
 from globus_cli.login_manager import LoginManager, compute_timer_scope
@@ -36,7 +36,7 @@ def session_consent(
     This command is necessary when the CLI needs access to resources which require the
     user to explicitly consent to access.
     """
-    scope_list: list[str | MutableScope] = [
+    scope_list: list[str | Scope] = [
         utils.unquote_cmdprompt_single_quotes(s) for s in scopes
     ]
 

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -6,7 +6,7 @@ import uuid
 
 import click
 import globus_sdk
-from globus_sdk.scopes import GCSCollectionScopeBuilder, MutableScope
+from globus_sdk.scopes import GCSCollectionScopeBuilder, Scope
 
 from globus_cli.endpointish import Endpointish
 from globus_cli.login_manager import LoginManager, is_client_login
@@ -314,7 +314,7 @@ def resolve_optional_local_time(
 
 def _derive_needed_scopes(
     needs_data_access: list[str],
-) -> dict[str, MutableScope]:
+) -> dict[str, Scope]:
     # Render the fully nested scope strings for each target
     scopes_needed = {}
     for target in needs_data_access:
@@ -330,7 +330,7 @@ def _derive_needed_scopes(
 
 def _derive_missing_scopes(
     auth_client: CustomAuthClient,
-    scopes_needed: dict[str, MutableScope],
+    scopes_needed: dict[str, Scope],
 ) -> list[str]:
     # read the identity ID stored from the login flow
     user_identity_id = get_current_identity_id()
@@ -350,8 +350,8 @@ def _derive_missing_scopes(
 
 
 # shorthand helper for constructing a nested scope
-def _ez_make_nested_scope(*scope_strings: str) -> MutableScope:
-    current_node = MutableScope(scope_strings[-1])
+def _ez_make_nested_scope(*scope_strings: str) -> Scope:
+    current_node = Scope(scope_strings[-1])
     for current_scope in scope_strings[-2::-1]:
-        current_node = MutableScope(current_scope, dependencies=[current_node])
+        current_node = Scope(current_scope, dependencies=[current_node])
     return current_node

--- a/src/globus_cli/commands/timer/resume.py
+++ b/src/globus_cli/commands/timer/resume.py
@@ -103,9 +103,12 @@ def check_inactive_reason(
 def _get_inactive_reason(
     timer_doc: dict[str, t.Any] | globus_sdk.GlobusHTTPResponse
 ) -> GlobusAuthRequirementsError | None:
-    from globus_sdk.experimental.auth_requirements_error import (
-        to_auth_requirements_error,
-    )
+    try:
+        from globus_sdk.gare import to_gare  # type: ignore[import-not-found]
+    except ImportError:
+        from globus_sdk.experimental.auth_requirements_error import (
+            to_auth_requirements_error as to_gare,
+        )
 
     if timer_doc.get("status") != "inactive":
         return None
@@ -114,7 +117,7 @@ def _get_inactive_reason(
     if reason.get("cause") != "globus_auth_requirements":
         return None
 
-    return to_auth_requirements_error(reason.get("detail", {}))
+    return to_gare(reason.get("detail", {}))  # type: ignore[no-any-return]
 
 
 def _has_required_consent(

--- a/src/globus_cli/login_manager/auth_flows.py
+++ b/src/globus_cli/login_manager/auth_flows.py
@@ -6,7 +6,7 @@ import typing as t
 
 import click
 import globus_sdk
-from globus_sdk.scopes import MutableScope
+from globus_sdk.scopes import Scope
 
 from .tokenstore import (
     internal_auth_client,
@@ -17,7 +17,7 @@ from .tokenstore import (
 
 
 def do_link_auth_flow(
-    scopes: str | t.Sequence[str | MutableScope],
+    scopes: str | t.Sequence[str | Scope],
     *,
     session_params: dict[str, str] | None = None,
 ) -> bool:
@@ -58,7 +58,7 @@ def do_link_auth_flow(
 
 
 def do_local_server_auth_flow(
-    scopes: str | t.Sequence[str | MutableScope],
+    scopes: str | t.Sequence[str | Scope],
     *,
     session_params: dict[str, str] | None = None,
 ) -> bool:

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -7,7 +7,7 @@ from globus_sdk.scopes import (
     FlowsScopes,
     GCSCollectionScopeBuilder,
     GroupsScopes,
-    MutableScope,
+    Scope,
     SearchScopes,
     TimersScopes,
     TransferScopes,
@@ -22,17 +22,17 @@ TRANSFER_AP_SCOPE_STR: str = (
 
 def compute_timer_scope(
     *, data_access_collection_ids: t.Sequence[str] | None = None
-) -> MutableScope:
-    transfer_scope = TransferScopes.make_mutable("all")
+) -> Scope:
+    transfer_scope = Scope(TransferScopes.all)
     for cid in data_access_collection_ids or ():
         transfer_scope.add_dependency(
-            GCSCollectionScopeBuilder(cid).make_mutable("data_access", optional=True)
+            Scope(GCSCollectionScopeBuilder(cid).data_access, optional=True)
         )
 
-    transfer_ap_scope = MutableScope(TRANSFER_AP_SCOPE_STR)
+    transfer_ap_scope = Scope(TRANSFER_AP_SCOPE_STR)
     transfer_ap_scope.add_dependency(transfer_scope)
 
-    timer_scope: MutableScope = TimersScopes.make_mutable("timer")
+    timer_scope = Scope(TimersScopes.timer)
     timer_scope.add_dependency(transfer_ap_scope)
     return timer_scope
 
@@ -46,7 +46,7 @@ class _ServiceRequirement(t.TypedDict):
     min_contract_version: int
     resource_server: str
     nice_server_name: str
-    scopes: list[str | MutableScope]
+    scopes: list[str | Scope]
 
 
 class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):


### PR DESCRIPTION
Following moves and deprecations, there's a divergence between `main` and the last SDK release.
To address this:

- Update SDK Scope and Consent usages
- Update SDK GARE usages to be forwards-compatible
