### PR TITLE
globus group update --terms-and-conditions

### DIFF
--- a/changelog.d/20241015_133817_derek_groups_update_terms_and_conditions.md
+++ b/changelog.d/20241015_133817_derek_groups_update_terms_and_conditions.md
@@ -1,0 +1,4 @@
+
+### Enhancements
+
+* Added a `--terms-and-conditions` option to the `globus group update` command.

--- a/src/globus_cli/commands/group/_common.py
+++ b/src/globus_cli/commands/group/_common.py
@@ -64,6 +64,7 @@ _BASE_GROUP_RECORD_FIELDS = [
         "my_memberships[].role",
         formatter=formatters.SortedArray,
     ),
+    Field("Terms and Conditions", "terms_and_conditions", wrap_enabled=True),
 ]
 GROUP_FIELDS = [Field("Group ID", "id")] + _BASE_GROUP_RECORD_FIELDS
 GROUP_FIELDS_W_SUBSCRIPTION = (

--- a/src/globus_cli/commands/group/update.py
+++ b/src/globus_cli/commands/group/update.py
@@ -15,6 +15,9 @@ from ._common import group_id_arg
 @group_id_arg
 @click.option("--name", help="Name for the group")
 @click.option("--description", help="Description for the group")
+@click.option(
+    "--terms-and-conditions", help="Terms and conditions for group membership"
+)
 @LoginManager.requires_login("groups")
 def group_update(
     login_manager: LoginManager,
@@ -22,6 +25,7 @@ def group_update(
     group_id: uuid.UUID,
     name: str | None,
     description: str | None,
+    terms_and_conditions: str | None,
 ) -> None:
     """Update an existing group."""
     groups_client = login_manager.get_groups_client()
@@ -30,10 +34,14 @@ def group_update(
     group = groups_client.get_group(group_id)
 
     # assemble put data using existing values for any field not given
-    # note that the API does not accept the full group document, so we must
-    # specify name and description instead of just iterating kwargs
+    # note that the API only allows modification of certain fields
+    #   https://groups.api.globus.org/redoc#tag/groups/operation/update_group_v2_groups__group_id__put
     data = {}
-    for attrname, argval in (("name", name), ("description", description)):
+    for attrname, argval in (
+        ("name", name),
+        ("description", description),
+        ("terms_and_conditions", terms_and_conditions),
+    ):
         if argval is not None:
             data[attrname] = argval
         else:

--- a/tests/files/api_fixtures/groups.yaml
+++ b/tests/files/api_fixtures/groups.yaml
@@ -74,6 +74,7 @@ groups:
         "id": "8b7d57bc-1666-11ec-88b2-f50515619d57",
         "name": "Group 1",
         "description": "The first group.",
+        "terms_and_conditions": null,
         "group_type": "regular",
         "enforce_session": false,
         "my_memberships": [

--- a/tests/functional/groups/test_group_update.py
+++ b/tests/functional/groups/test_group_update.py
@@ -7,11 +7,26 @@ from globus_sdk._testing import get_last_request, load_response_set
 @pytest.mark.parametrize(
     "add_args, payload_contains",
     (
-        (["--name", "New Name"], {"name": "New Name"}),
-        (["--description", "New Description"], {"description": "New Description"}),
+        (("--name", "New Name"), {"name": "New Name"}),
+        (("--description", "New Description"), {"description": "New Description"}),
         (
-            ["--name", "New Name", "--description", "New Description"],
-            {"description": "New Description", "name": "New Name"},
+            ("--terms-and-conditions", "New Terms and Conditions"),
+            {"terms_and_conditions": "New Terms and Conditions"},
+        ),
+        (
+            (
+                "--name",
+                "New Name",
+                "--description",
+                "New Description",
+                "--terms-and-conditions",
+                "New Terms and Conditions",
+            ),
+            {
+                "description": "New Description",
+                "name": "New Name",
+                "terms_and_conditions": "New Terms and Conditions",
+            },
         ),
     ),
 )
@@ -28,7 +43,7 @@ def test_group_update(run_line, add_args, payload_contains):
     group1_description = meta["group1_description"]
 
     # update name
-    result = run_line(["globus", "group", "update", group1_id] + add_args)
+    result = run_line(("globus", "group", "update", group1_id) + add_args)
     assert "Group updated successfully" in result.output
 
     # confirm that 'name' and 'description' are both always sent,


### PR DESCRIPTION
## What?
* Added a `--terms-and-conditions` flag to the `globus group update` command.
* Added a `Terms and Conditions` field to the `globus group show` command.

## Why?
The field exists in the groups API but was never added to the CLI [here](https://groups.api.globus.org/redoc#tag/groups/operation/update_group_v2_groups__group_id__put).

(Customer question about it in email thread [here](https://groups.google.com/a/globus.org/g/discuss/c/EP5TC6zJ40o).)

## Testing
```
> globus group update f353afe3-35ca-11ed-a698-4ffe8363feee --terms-and-conditions ""
Group updated successfully

> globus group show f353afe3-35ca-11ed-a698-4ffe8363feee                            
Group ID:              f353afe3-35ca-11ed-a698-4ffe8363feee
Name:                  derek-test
Description:           Testing Globus Group Functionality
Type:                  regular
Visibility:            private
Membership Visibility: managers
Session Enforcement:   not strict
Join Requests Allowed: False
Signup Fields:         
Roles:                 admin
Terms and Conditions:  

> globus group update f353afe3-35ca-11ed-a698-4ffe8363feee --terms-and-conditions "You must be a good person"
Group updated successfully

> globus group show f353afe3-35ca-11ed-a698-4ffe8363feee                                                     
Group ID:              f353afe3-35ca-11ed-a698-4ffe8363feee
Name:                  derek-test
Description:           Testing Globus Group Functionality
Type:                  regular
Visibility:            private
Membership Visibility: managers
Session Enforcement:   not strict
Join Requests Allowed: False
Signup Fields:         
Roles:                 admin
Terms and Conditions:  You must be a good person
```
