### PR TITLE
Minor copyedits for consistent error and changelog styling

### DIFF
--- a/changelog.d/20241015_111820_max.tuecke_sc_35029_deprecate_delete_flag.md
+++ b/changelog.d/20241015_111820_max.tuecke_sc_35029_deprecate_delete_flag.md
@@ -1,5 +1,4 @@
-Added
-~~~~~
+### Added
 
-- Added new ``--delete-destination-extra`` flag to ``globus timer create transfer`` and ``globus transfer`` that mirrors the existing ``--delete`` flags' behaviors. (:pr:`1037`)
-- Added deprecation warning to the old ``--delete`` flag. (:pr:`1037`)
+* Added new `--delete-destination-extra` flag to `globus timer create transfer` and `globus transfer` that mirrors the existing `--delete` flags' behaviors.
+* Added deprecation warning to the old `--delete` flag.

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -189,7 +189,7 @@ def transfer_command(
     if delete:
         msg = (
             "`--delete` has been deprecated and will be removed in a future release. "
-            "Use --delete-destination-extra instead."
+            "Use `--delete-destination-extra` instead."
         )
         click.echo(click.style(msg, fg="yellow"), err=True)
 
@@ -198,23 +198,24 @@ def transfer_command(
             # avoid 'mutex_option_group', emit a custom error message
             option_name = "--recursive" if recursive else "--no-recursive"
             raise click.UsageError(
-                f"You cannot use {option_name} in addition to --batch. "
-                f"Instead, use {option_name} on lines of --batch input which need it."
+                f"You cannot use `{option_name}` in addition to `--batch`. "
+                f"Instead, use `{option_name}` on lines of `--batch` input which "
+                "need it."
             )
 
         if delete and not recursive:
             raise click.UsageError(
-                "The --delete option cannot be specified with --no-recursive."
+                "The `--delete` option cannot be specified with `--no-recursive`."
             )
         if delete_destination_extra and not recursive:
             raise click.UsageError(
-                "The --delete-destination-extra option cannot be specified with "
-                "--no-recursive."
+                "The `--delete-destination-extra` option cannot be specified with "
+                "`--no-recursive`."
             )
 
     if (cmd_source_path is None or cmd_dest_path is None) and (not batch):
         raise click.UsageError(
-            "transfer requires either SOURCE_PATH and DEST_PATH or --batch"
+            "Transfer requires either `SOURCE_PATH` and `DEST_PATH` or `--batch`"
         )
 
     # Interval must be null iff the timer is 'once', i.e. stop-after-runs == 1.
@@ -223,12 +224,12 @@ def transfer_command(
     start_ = resolve_optional_local_time(start)
     if stop_after_runs == 1:
         if interval is not None:
-            raise click.UsageError("'--interval' is invalid with `--stop-after-runs=1`")
+            raise click.UsageError("`--interval` is invalid with `--stop-after-runs=1`")
         schedule = globus_sdk.OnceTimerSchedule(datetime=start_)
     else:
         if interval is None:
             raise click.UsageError(
-                "'--interval' is required unless `--stop-after-runs=1`"
+                "`--interval` is required unless `--stop-after-runs=1`"
             )
 
         end: dict[str, t.Any] | globus_sdk.MissingType = globus_sdk.MISSING

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -203,14 +203,14 @@ def transfer_command(
             )
 
         if delete and not recursive:
-            msg = "The --delete option cannot be specified with --no-recursion."
-            raise click.UsageError(msg)
-        if delete_destination_extra and not recursive:
-            msg = (
-                "The --delete-destination-extra option cannot be specified with "
-                "--no-recursion."
+            raise click.UsageError(
+                "The --delete option cannot be specified with --no-recursive."
             )
-            raise click.UsageError(msg)
+        if delete_destination_extra and not recursive:
+            raise click.UsageError(
+                "The --delete-destination-extra option cannot be specified with "
+                "--no-recursive."
+            )
 
     if (cmd_source_path is None or cmd_dest_path is None) and (not batch):
         raise click.UsageError(

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -341,7 +341,7 @@ def transfer_command(
     if delete:
         msg = (
             "`--delete` has been deprecated and will be removed in a future release. "
-            "Use --delete-destination-extra instead."
+            "Use `--delete-destination-extra` instead."
         )
         click.echo(click.style(msg, fg="yellow"), err=True)
 
@@ -349,14 +349,15 @@ def transfer_command(
     if recursive is not None and batch:
         option_name = "--recursive" if recursive else "--no-recursive"
         raise click.UsageError(
-            f"You cannot use {option_name} in addition to --batch. "
-            f"Instead, use {option_name} on lines of --batch input which need it."
+            f"You cannot use `{option_name}` in addition to `--batch`. "
+            f"Instead, use `{option_name}` on lines of `--batch` input which need it."
         )
 
     if external_checksum and batch:
         raise click.UsageError(
-            "You cannot use --external-checksum in addition to --batch. "
-            "Instead, use --external-checksum on lines of --batch input which need it."
+            "You cannot use `--external-checksum` in addition to `--batch`. "
+            "Instead, use `--external-checksum` on lines of `--batch` input which "
+            "need it."
         )
 
     # the performance options (of which there are a few), have elements which should be
@@ -403,7 +404,7 @@ def transfer_command(
     else:
         if cmd_source_path is None or cmd_dest_path is None:
             raise click.UsageError(
-                "transfer requires either SOURCE_PATH and DEST_PATH or --batch"
+                "Transfer requires either `SOURCE_PATH` and `DEST_PATH` or `--batch`"
             )
         transfer_data.add_item(
             cmd_source_path,
@@ -422,7 +423,7 @@ def transfer_command(
 
     if filter_rules and not has_recursive_items:
         raise click.UsageError(
-            "--include and --exclude can only be used with --recursive transfers"
+            "`--include` and `--exclude` can only be used with `--recursive` transfers"
         )
 
     if dry_run:

--- a/tests/functional/task/test_task_submit.py
+++ b/tests/functional/task/test_task_submit.py
@@ -63,7 +63,7 @@ def test_exclude_recursive(run_line, go_ep1_id, go_ep2_id):
         assert_exit_code=2,
     )
     assert (
-        "--include and --exclude can only be used with --recursive transfers"
+        "`--include` and `--exclude` can only be used with `--recursive` transfers"
         in result.stderr
     )
 
@@ -76,7 +76,7 @@ def test_exclude_recursive_batch_stdin(run_line, go_ep1_id, go_ep2_id):
         assert_exit_code=2,
     )
     assert (
-        "--include and --exclude can only be used with --recursive transfers"
+        "`--include` and `--exclude` can only be used with `--recursive` transfers"
         in result.stderr
     )
 
@@ -99,7 +99,7 @@ def test_exclude_recursive_batch_file(run_line, go_ep1_id, go_ep2_id, tmp_path):
         assert_exit_code=2,
     )
     assert (
-        "--include and --exclude can only be used with --recursive transfers"
+        "`--include` and `--exclude` can only be used with `--recursive` transfers"
         in result.stderr
     )
 

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -217,7 +217,7 @@ def test_recursive_and_batch_exclusive(run_line, option):
         ],
         assert_exit_code=2,
     )
-    assert f"You cannot use {option} in addition to --batch" in result.stderr
+    assert f"You cannot use `{option}` in addition to `--batch`" in result.stderr
 
 
 def test_legacy_delete_and_delete_destination_are_mutex(run_line):
@@ -248,4 +248,4 @@ def test_legacy_delete_flag_deprecation_warning(run_line):
         ],
         assert_exit_code=2,
     )
-    assert "--delete` has been deprecated" in result.stderr
+    assert "`--delete` has been deprecated" in result.stderr

--- a/tests/functional/timer/test_transfer_create.py
+++ b/tests/functional/timer/test_transfer_create.py
@@ -250,7 +250,7 @@ def test_recursive_and_batch_exclusive(run_line, option):
         ],
         assert_exit_code=2,
     )
-    assert f"You cannot use {option} in addition to --batch" in result.stderr
+    assert f"You cannot use `{option}` in addition to `--batch`" in result.stderr
 
 
 def test_create_timer_requires_some_pathargs(run_line):
@@ -261,7 +261,8 @@ def test_create_timer_requires_some_pathargs(run_line):
         assert_exit_code=2,
     )
     assert (
-        "transfer requires either SOURCE_PATH and DEST_PATH or --batch" in result.stderr
+        "Transfer requires either `SOURCE_PATH` and `DEST_PATH` or `--batch`"
+        in result.stderr
     )
 
 
@@ -280,7 +281,7 @@ def test_interval_usually_required(run_line):
         ],
         assert_exit_code=2,
     )
-    assert "'--interval' is required unless `--stop-after-runs=1`" in result.stderr
+    assert "`--interval` is required unless `--stop-after-runs=1`" in result.stderr
 
 
 def test_stop_conditions_are_mutex(run_line):
@@ -335,7 +336,7 @@ def test_timer_creation_legacy_delete_flag_deprecation_warning(run_line):
         ],
         assert_exit_code=2,
     )
-    assert "--delete` has been deprecated" in result.stderr
+    assert "`--delete` has been deprecated" in result.stderr
 
 
 def test_timer_uses_once_schedule_if_stop_after_is_one(run_line, ep_for_timer):
@@ -528,8 +529,8 @@ def test_timer_creation_errors_on_data_access_with_client_creds(
             "--delete-destination-extra",
             "--no-recursive",
             (
-                "The --delete-destination-extra option cannot be specified with "
-                "--no-recursive."
+                "The `--delete-destination-extra` option cannot be specified with "
+                "`--no-recursive`."
             ),
         ),
         ("--delete", "--recursive", ""),
@@ -537,7 +538,7 @@ def test_timer_creation_errors_on_data_access_with_client_creds(
         (
             "--delete",
             "--no-recursive",
-            "The --delete option cannot be specified with --no-recursive.",
+            "The `--delete` option cannot be specified with `--no-recursive`.",
         ),
     ),
 )

--- a/tests/functional/timer/test_transfer_create.py
+++ b/tests/functional/timer/test_transfer_create.py
@@ -529,7 +529,7 @@ def test_timer_creation_errors_on_data_access_with_client_creds(
             "--no-recursive",
             (
                 "The --delete-destination-extra option cannot be specified with "
-                "--no-recursion."
+                "--no-recursive."
             ),
         ),
         ("--delete", "--recursive", ""),
@@ -537,7 +537,7 @@ def test_timer_creation_errors_on_data_access_with_client_creds(
         (
             "--delete",
             "--no-recursive",
-            "The --delete option cannot be specified with --no-recursion.",
+            "The --delete option cannot be specified with --no-recursive.",
         ),
     ),
 )


### PR DESCRIPTION
A medley of minor flaws relating, primarily, to backtick quoting.
Much of our internal CLI doc is destined to render on the docs site, and therefore needs to fit that context.

- Fix messages with `--no-recursive`
- More consistently use backticks in errors
- Minor changelog copyedit fixes

I noted some potential semantic issues with old `globus transfer` behavior, which I'd like to tackle in a separate PR.
