### PR TITLE
Fix transfer usage error for invalid use of --no-recursive flag

### DIFF
--- a/changelog.d/20241017_122919_max.tuecke_sc_35029_transfer_usage_error.md
+++ b/changelog.d/20241017_122919_max.tuecke_sc_35029_transfer_usage_error.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Fixed `globus transfer` usage error checks to reject `--no-recursive --delete-destination-extra` and `--no-recursive --delete`.
+    * Updated `globus timer create transfer` usage error checks to mirror the `globus transfer` logic.

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -193,26 +193,21 @@ def transfer_command(
         )
         click.echo(click.style(msg, fg="yellow"), err=True)
 
-    if recursive is not None:
-        if batch:
-            # avoid 'mutex_option_group', emit a custom error message
-            option_name = "--recursive" if recursive else "--no-recursive"
-            raise click.UsageError(
-                f"You cannot use `{option_name}` in addition to `--batch`. "
-                f"Instead, use `{option_name}` on lines of `--batch` input which "
-                "need it."
-            )
-
-        if delete and not recursive:
-            raise click.UsageError(
-                "The `--delete` option cannot be specified with `--no-recursive`."
-            )
-        if delete_destination_extra and not recursive:
-            raise click.UsageError(
-                "The `--delete-destination-extra` option cannot be specified with "
-                "`--no-recursive`."
-            )
-
+    # avoid 'mutex_option_group', emit a custom error message
+    if recursive is not None and batch:
+        option_name = "--recursive" if recursive else "--no-recursive"
+        raise click.UsageError(
+            f"You cannot use `{option_name}` in addition to `--batch`. "
+            f"Instead, use `{option_name}` on lines of `--batch` input which "
+            "need it."
+        )
+    if recursive is False and (delete_destination_extra or delete):
+        option_name = (
+            "--delete-destination-extra" if delete_destination_extra else "--delete"
+        )
+        raise click.UsageError(
+            f"The `{option_name}` option cannot be specified with `--no-recursive`."
+        )
     if (cmd_source_path is None or cmd_dest_path is None) and (not batch):
         raise click.UsageError(
             "Transfer requires either `SOURCE_PATH` and `DEST_PATH` or `--batch`"

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -198,8 +198,7 @@ def transfer_command(
         option_name = "--recursive" if recursive else "--no-recursive"
         raise click.UsageError(
             f"You cannot use `{option_name}` in addition to `--batch`. "
-            f"Instead, use `{option_name}` on lines of `--batch` input which "
-            "need it."
+            f"Instead, use `{option_name}` on lines of `--batch` input which need it."
         )
     if recursive is False and (delete_destination_extra or delete):
         option_name = (

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -352,7 +352,13 @@ def transfer_command(
             f"You cannot use `{option_name}` in addition to `--batch`. "
             f"Instead, use `{option_name}` on lines of `--batch` input which need it."
         )
-
+    if recursive is False and (delete_destination_extra or delete):
+        option_name = (
+            "--delete-destination-extra" if delete_destination_extra else "--delete"
+        )
+        raise click.UsageError(
+            f"The `{option_name}` option cannot be specified with `--no-recursive`."
+        )
     if external_checksum and batch:
         raise click.UsageError(
             "You cannot use `--external-checksum` in addition to `--batch`. "

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -220,6 +220,49 @@ def test_recursive_and_batch_exclusive(run_line, option):
     assert f"You cannot use `{option}` in addition to `--batch`" in result.stderr
 
 
+@pytest.mark.parametrize(
+    "deletion_option,recursion_option,expected_error",
+    (
+        ("--delete-destination-extra", "--recursive", ""),
+        ("--delete-destination-extra", "", ""),
+        (
+            "--delete-destination-extra",
+            "--no-recursive",
+            (
+                "The `--delete-destination-extra` option cannot be specified with "
+                "`--no-recursive`."
+            ),
+        ),
+        ("--delete", "--recursive", ""),
+        ("--delete", "", ""),
+        (
+            "--delete",
+            "--no-recursive",
+            "The `--delete` option cannot be specified with `--no-recursive`.",
+        ),
+    ),
+)
+def test_no_recursive_and_delete_exclusive(
+    run_line,
+    deletion_option,
+    recursion_option,
+    expected_error,
+):
+    load_response("transfer.get_submission_id")
+    load_response("transfer.submit_transfer")
+    ep_meta = load_response("transfer.get_endpoint").metadata
+    ep_id = ep_meta["endpoint_id"]
+
+    base_cmd = f"globus transfer {ep_id}:/foo/ {ep_id}:/bar/"
+    options_list = (deletion_option, recursion_option)
+    options = " ".join(op for op in options_list if op is not None)
+
+    exit_code = 0 if not expected_error else 2
+    result = run_line(f"{base_cmd} {options}", assert_exit_code=exit_code)
+
+    assert expected_error in result.stderr
+
+
 def test_legacy_delete_and_delete_destination_are_mutex(run_line):
     ep_id = str(uuid.UUID(int=1))
     result = run_line(

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -254,8 +254,7 @@ def test_no_recursive_and_delete_exclusive(
     ep_id = ep_meta["endpoint_id"]
 
     base_cmd = f"globus transfer {ep_id}:/foo/ {ep_id}:/bar/"
-    options_list = (deletion_option, recursion_option)
-    options = " ".join(op for op in options_list if op is not None)
+    options = f"{deletion_option} {recursion_option}"
 
     exit_code = 0 if not expected_error else 2
     result = run_line(f"{base_cmd} {options}", assert_exit_code=exit_code)


### PR DESCRIPTION
While working on [this story](https://app.shortcut.com/globus/story/35029/globus-cli-replace-delete-with-delete-destination-extra-in-transfer-commands), I came across a small bug with `globus transfer`, where it was not raising a `UsageError` for some invalid flag combinations. See the story comments for more details.

### Changes
- Fixed `globus transfer` to raise a `UsageError` for the invalid flag combinations: `--no-recursive --delete-destination-extra` and `--no-recursive --delete.
- Changed `globus timer create transfer` usage error checks to mirror the `globus transfer` logic.

### Testing
- Added test for `globus transfer` checking that `--no-recursive --delete-destination-extra` and `--no-recursive --delete` flag combinations raise a `UsageError`. 