### PR TITLE
Configure mypy to cache to sqlite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ entry_title_template = '{{ version }} ({{ date.strftime("%Y-%m-%d") }})'
 
 [tool.mypy]
 strict = true
+sqlite_cache = true
 
 # additional settings (not part of strict=true)
 warn_unreachable = true


### PR DESCRIPTION

This PR introduces the following changes:

*   Configure mypy to use sqlite as its backend cache.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>