### PR TITLE
Remove old Automate Transfer AP scope from timers scope dependencies

### DIFF
--- a/changelog.d/20241105_161119_max.tuecke_sc_35400_timers_scope_update.md
+++ b/changelog.d/20241105_161119_max.tuecke_sc_35400_timers_scope_update.md
@@ -1,4 +1,4 @@
 ### Bugfixes
 
 * Removed the old Automate Transfer AP scope from timers scope dependencies.
-* Updated timers scope requirements min_contract_version from 1 to 2.
+* Updated CURRENT_SCOPE_CONTRACT_VERSION and timers min_contract_version from 1 to 2.

--- a/changelog.d/20241105_161119_max.tuecke_sc_35400_timers_scope_update.md
+++ b/changelog.d/20241105_161119_max.tuecke_sc_35400_timers_scope_update.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Removed the old Automate Transfer AP scope from timers scope dependencies.
+* Updated timers scope requirements min_contract_version from 1 to 2.

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -342,7 +342,6 @@ def _derive_needed_scopes(
         target_scope = GCSCollectionScopeBuilder(target).data_access
         scopes_needed[target] = _ez_make_nested_scope(
             globus_sdk.TimerClient.scopes.timer,
-            "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer",
             globus_sdk.TransferClient.scopes.all,
             target_scope,
         )

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -15,10 +15,6 @@ from globus_sdk.scopes import (
 
 from globus_cli.types import ServiceNameLiteral
 
-TRANSFER_AP_SCOPE_STR: str = (
-    "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer"
-)
-
 
 def compute_timer_scope(
     *, data_access_collection_ids: t.Sequence[str] | None = None
@@ -29,11 +25,8 @@ def compute_timer_scope(
             Scope(GCSCollectionScopeBuilder(cid).data_access, optional=True)
         )
 
-    transfer_ap_scope = Scope(TRANSFER_AP_SCOPE_STR)
-    transfer_ap_scope.add_dependency(transfer_scope)
-
     timer_scope = Scope(TimersScopes.timer)
-    timer_scope.add_dependency(transfer_ap_scope)
+    timer_scope.add_dependency(transfer_scope)
     return timer_scope
 
 
@@ -87,7 +80,7 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
             ],
         }
         self["timer"] = {
-            "min_contract_version": 1,
+            "min_contract_version": 2,
             "resource_server": TimersScopes.resource_server,
             "nice_server_name": "Globus Timers",
             "scopes": [
@@ -125,4 +118,4 @@ CLI_SCOPE_REQUIREMENTS = _CLIScopeRequirements()
 # version we were at when we got a token
 # it should be the max of the version numbers required by the various different
 # services
-CURRENT_SCOPE_CONTRACT_VERSION: t.Final[int] = 1
+CURRENT_SCOPE_CONTRACT_VERSION: t.Final[int] = 2

--- a/tests/functional/timer/test_transfer_create.py
+++ b/tests/functional/timer/test_transfer_create.py
@@ -61,20 +61,10 @@ def setup_timer_consent_tree_response(identity_id, *data_access_collection_ids):
                         **_dummy_consent_fields,
                     },
                     {
-                        "scope_name": (
-                            "https://auth.globus.org/scopes/"
-                            "actions.globus.org/transfer/transfer"
-                        ),
+                        "scope_name": globus_sdk.TransferClient.scopes.all,
                         "scope": str(uuid.uuid1()),
                         "dependency_path": [100, 101],
                         "id": 101,
-                        **_dummy_consent_fields,
-                    },
-                    {
-                        "scope_name": globus_sdk.TransferClient.scopes.all,
-                        "scope": str(uuid.uuid1()),
-                        "dependency_path": [100, 101, 102],
-                        "id": 102,
                         **_dummy_consent_fields,
                     },
                 ]
@@ -82,7 +72,7 @@ def setup_timer_consent_tree_response(identity_id, *data_access_collection_ids):
                     {
                         "scope_name": GCSCollectionScopeBuilder(name).data_access,
                         "scope": str(uuid.uuid1()),
-                        "dependency_path": [100, 101, 102, 1000 + idx],
+                        "dependency_path": [100, 101, 1000 + idx],
                         "id": 1000 + idx,
                         **_dummy_consent_fields,
                     }

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -101,7 +101,6 @@ def urlfmt_scope(rs: str, name: str) -> str:
 
 
 BASE_TIMER_SCOPE = urlfmt_scope("524230d7-ea86-4a52-8312-86065a9e0417", "timer")
-TRANSFER_AP_SCOPE = urlfmt_scope("actions.globus.org", "transfer/transfer")
 
 
 def test_requires_login_success(patch_scope_requirements, patched_tokenstorage):
@@ -297,7 +296,7 @@ def test_compute_timer_scope_no_data_access():
 
     computed = str(compute_timer_scope())
     assert computed.startswith(BASE_TIMER_SCOPE)
-    assert computed == f"{BASE_TIMER_SCOPE}[{TRANSFER_AP_SCOPE}[{transfer_scope}]]"
+    assert computed == f"{BASE_TIMER_SCOPE}[{transfer_scope}]"
 
 
 def test_compute_timer_scope_one_data_access():
@@ -307,10 +306,7 @@ def test_compute_timer_scope_one_data_access():
     computed = str(compute_timer_scope(data_access_collection_ids=["foo"]))
     assert computed.startswith(BASE_TIMER_SCOPE)
     assert foo_scope in computed
-    assert (
-        computed
-        == f"{BASE_TIMER_SCOPE}[{TRANSFER_AP_SCOPE}[{transfer_scope}[*{foo_scope}]]]"
-    )
+    assert computed == f"{BASE_TIMER_SCOPE}[{transfer_scope}[*{foo_scope}]]"
 
 
 def test_compute_timer_scope_multiple_data_access():
@@ -326,8 +322,8 @@ def test_compute_timer_scope_multiple_data_access():
     assert foo_scope in computed
     assert bar_scope in computed
     assert baz_scope in computed
-    start_part = f"{BASE_TIMER_SCOPE}[{TRANSFER_AP_SCOPE}[{transfer_scope}["
-    end_part = "]]]"
+    start_part = f"{BASE_TIMER_SCOPE}[{transfer_scope}["
+    end_part = "]]"
     assert computed == f"{start_part}*{foo_scope} *{bar_scope} *{baz_scope}{end_part}"
 
 


### PR DESCRIPTION
[sc-35400](https://app.shortcut.com/globus/story/35400/cli-globus-cli-scopes-for-timers-still-treat-the-automate-transfer-ap-as-the-target-for-data-access-construction)

### Bugfixes
* Removed the old Automate Transfer AP scope from timers scope dependencies.
* Updated `CURRENT_SCOPE_CONTRACT_VERSION` and timers `min_contract_version` from 1 to 2.

### Testing
* Updated existing tests with the new scope dependencies.
* Manual testing done:
  * With the existing timers tokens present, was able to create a new timer w/ data_access
  * With the existing timers tokens present, was able to create a new timer w/ no data_access
  * With no tokens present, was able to create a new timer w/ data_access
  * With the new timers tokens present, was able to revert and create a new timer w/ data_access (simulating a CLI downgrade)
