### PR TITLE
Updated contributing doc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -19,10 +19,21 @@ Developer Setup
 
 These steps should help you setup a development environment for the Globus CLI.
 
-  1. Clone repo:
-     `git clone git@github.com:globus/globus-cli.git && cd globus-cli`
-  2. Create a virtualenv for development. `make localdev`.
-  3. Activate the resulting virtualenv with `source .venv/bin/activate`
+  1. Create a fork of the globus/globus-cli repository.
+
+     Follow https://github.com/globus/globus-cli/fork in a browser.
+
+  2. Clone your forked repository & navigate to it.
+
+     git clone <fork-repo-url> && cd globus-cli
+
+  3. Install dependencies in a local virtualenv for development.
+
+     make install
+
+  4. Activate the resulting virtualenv.
+
+     source .venv/bin/activate
 
 You should now have, in your virtualenv, the `globus-cli` installed, pointed at
 your local copy of the repo. `globus` will invoke code directly out of the

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ CLI_VERSION=$(shell grep '^__version__' src/globus_cli/version.py | cut -d '"' -
 	.venv/bin/pip install -e '.[development]'
 	.venv/bin/pip install -e '.[test]'
 
-.PHONY: localdev
+.PHONY: localdev install
 localdev: .venv
+install: .venv
 
 
 .PHONY: lint test reference

--- a/changelog.d/20241107_174803_derek_improve_contributing_doc.md
+++ b/changelog.d/20241107_174803_derek_improve_contributing_doc.md
@@ -1,0 +1,4 @@
+
+### Enhancements
+
+* Add a "fork" step to the contributing documentation.


### PR DESCRIPTION
* Added a step to the CONTRIBUTING documentation instructing users to first make a fork prior to cloning.
* Added a `make install` command identical to `make localdev` to mirror our other projects.