### PR TITLE
add size and checksum fields to task show --successful-transfers

### DIFF
--- a/changelog.d/20241108_100250_derek_sc_27244_checksum_and_size_successful_transfer_fields.md
+++ b/changelog.d/20241108_100250_derek_sc_27244_checksum_and_size_successful_transfer_fields.md
@@ -1,4 +1,4 @@
 
 ### Enhancements
 
-* Added `Size`, `Checksum`, and `Checksum Algorithm` to `globus task show` output.
+* Added `Size`, `Checksum`, and `Checksum Algorithm` to `globus task show --successful-transfers` output.

--- a/changelog.d/20241108_100250_derek_sc_27244_checksum_and_size_successful_transfer_fields.md
+++ b/changelog.d/20241108_100250_derek_sc_27244_checksum_and_size_successful_transfer_fields.md
@@ -1,0 +1,4 @@
+
+### Enhancements
+
+* Added `Size`, `Checksum`, and `Checksum Algorithm` to `globus task show` output.

--- a/src/globus_cli/commands/task/show.py
+++ b/src/globus_cli/commands/task/show.py
@@ -53,6 +53,9 @@ TRANSFER_FIELDS = [
 SUCCESSFULL_TRANSFER_FIELDS = [
     Field("Source Path", "source_path"),
     Field("Destination Path", "destination_path"),
+    Field("Size", "size"),
+    Field("Checksum Algorithm", "checksum_algorithm"),
+    Field("Checksum", "checksum"),
 ]
 
 SKIPPED_PATHS_FIELDS = [


### PR DESCRIPTION
Add the following fields to the tabular output of

globus task show --successful-transfers

* size
* checksum_algorithm
* checksum

If there is more that needs to be done from a testing or documentation standpoint, please let me know as this is my first foray into the CLI development way of doing things. :-)

refs sc-27244