### PR TITLE
Release v3.32.0

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -2,6 +2,22 @@
 
 // scriv-insert-here
 
+== 3.32.0 (2024-11-08)
+
+Bugfixes:
+
+* Remove the legacy Automate Transfer AP scope from Timers' scope dependencies.
+* Update `CURRENT_SCOPE_CONTRACT_VERSION` and Timers' `min_contract_version` from 1 to 2.
+
+Enhancements:
+
+* Add `Size`, `Checksum`, and `Checksum Algorithm` to `globus task show --successful-transfers` output.
+
+Added:
+
+* Add new `--delete-destination-extra` flag to `globus timer create transfer` and `globus transfer` that mirrors the existing `--delete` flags' behaviors.
+* Add deprecation warning to the old `--delete` flag.
+
 == 3.31.0 (2024-10-15)
 
 Bugfixes:

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -6,8 +6,7 @@
 
 Bugfixes:
 
-* Remove the legacy Automate Transfer AP scope from Timers' scope dependencies.
-* Update `CURRENT_SCOPE_CONTRACT_VERSION` and Timers' `min_contract_version` from 1 to 2.
+* Timers' scope data have changed. Users interacting with Timers will be prompted to login again.
 
 Enhancements:
 

--- a/changelog.d/20241015_111820_max.tuecke_sc_35029_deprecate_delete_flag.md
+++ b/changelog.d/20241015_111820_max.tuecke_sc_35029_deprecate_delete_flag.md
@@ -1,4 +1,0 @@
-### Added
-
-* Added new `--delete-destination-extra` flag to `globus timer create transfer` and `globus transfer` that mirrors the existing `--delete` flags' behaviors.
-* Added deprecation warning to the old `--delete` flag.

--- a/changelog.d/20241017_122919_max.tuecke_sc_35029_transfer_usage_error.md
+++ b/changelog.d/20241017_122919_max.tuecke_sc_35029_transfer_usage_error.md
@@ -1,4 +1,0 @@
-### Bugfixes
-
-* Fixed `globus transfer` usage error checks to reject `--no-recursive --delete-destination-extra` and `--no-recursive --delete`.
-    * Updated `globus timer create transfer` usage error checks to mirror the `globus transfer` logic.

--- a/changelog.d/20241105_161119_max.tuecke_sc_35400_timers_scope_update.md
+++ b/changelog.d/20241105_161119_max.tuecke_sc_35400_timers_scope_update.md
@@ -1,4 +1,0 @@
-### Bugfixes
-
-* Removed the legacy Automate Transfer AP scope from Timers' scope dependencies.
-* Updated `CURRENT_SCOPE_CONTRACT_VERSION` and Timers' `min_contract_version` from 1 to 2.

--- a/changelog.d/20241108_100250_derek_sc_27244_checksum_and_size_successful_transfer_fields.md
+++ b/changelog.d/20241108_100250_derek_sc_27244_checksum_and_size_successful_transfer_fields.md
@@ -1,4 +1,0 @@
-
-### Enhancements
-
-* Added `Size`, `Checksum`, and `Checksum Algorithm` to `globus task show --successful-transfers` output.

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -7,7 +7,7 @@ if t.TYPE_CHECKING:
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.31.0"
+__version__ = "3.32.0"
 
 # app name to send as part of SDK requests
 app_name = f"Globus CLI v{__version__}"


### PR DESCRIPTION
Bugfixes:

* Remove the legacy Automate Transfer AP scope from Timers' scope dependencies.
* Update `CURRENT_SCOPE_CONTRACT_VERSION` and Timers' `min_contract_version` from 1 to 2.

Enhancements:

* Add `Size`, `Checksum`, and `Checksum Algorithm` to `globus task show --successful-transfers` output.

Added:

* Add new `--delete-destination-extra` flag to `globus timer create transfer` and `globus transfer` that mirrors the existing `--delete` flags' behaviors.
* Add deprecation warning to the old `--delete` flag.
