### PR TITLE
add access permission expiration support

### DIFF
--- a/changelog.d/20241220_115422_aaschaer_permission_expiration.md
+++ b/changelog.d/20241220_115422_aaschaer_permission_expiration.md
@@ -1,0 +1,12 @@
+### Bugfixes
+
+* Fixed principal output parsing for `globus endpoint permission` and `globus endpoint role` commands.
+
+### Enhancements
+
+* Added the `--expiration-date` option to `globus endpoint permission create` and `globus endpoint permission update`.
+* Added `Expiration Date` as a text output field for `globus endpoint permission show`.
+
+### Other
+
+* `--permissions` is no longer a required option for `globus endpoint permission update`.

--- a/src/globus_cli/commands/endpoint/permission/_common.py
+++ b/src/globus_cli/commands/endpoint/permission/_common.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import typing as t
+
+import click
+
 from globus_cli.termio import formatters
+from globus_cli.types import AnyCommand
+
+C = t.TypeVar("C", bound=AnyCommand)
 
 
 class AclPrincipalFormatter(formatters.auth.PrincipalDictFormatter):
@@ -18,3 +25,10 @@ class AclPrincipalFormatter(formatters.auth.PrincipalDictFormatter):
     # it could be made multi-environment using `globus_sdk.config.get_webapp_url()`
     def render_group_id(self, group_id: str) -> str:
         return f"https://app.globus.org/groups/{group_id}"
+
+
+def expiration_date_option(f: C) -> C:
+    return click.option(
+        "--expiration-date",
+        help="Expiration date for the permission in ISO 8601 format",
+    )(f)

--- a/src/globus_cli/commands/endpoint/permission/create.py
+++ b/src/globus_cli/commands/endpoint/permission/create.py
@@ -9,6 +9,8 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command, security_principal_opts
 from globus_cli.termio import Field, display
 
+from ._common import expiration_date_option
+
 
 @command(
     "create",
@@ -50,6 +52,7 @@ $ globus endpoint permission create $ep_id:/ --permissions rw --identity go@glob
     help="A custom message to add to email notifications",
 )
 @click.argument("endpoint_plus_path", type=ENDPOINT_PLUS_REQPATH)
+@expiration_date_option
 @LoginManager.requires_login("auth", "transfer")
 def create_command(
     login_manager: LoginManager,
@@ -59,6 +62,7 @@ def create_command(
     endpoint_plus_path: tuple[uuid.UUID, str | None],
     notify_email: str | None,
     notify_message: str | None,
+    expiration_date: str | None,
 ) -> None:
     """
     Create a new access control rule on the target endpoint, granting users new
@@ -105,6 +109,7 @@ def create_command(
         path=path,
         notify_email=notify_email,
         notify_message=notify_message,
+        expiration_date=expiration_date,
     )
 
     res = transfer_client.add_endpoint_acl_rule(endpoint_id, rule_data)

--- a/src/globus_cli/commands/endpoint/permission/show.py
+++ b/src/globus_cli/commands/endpoint/permission/show.py
@@ -47,5 +47,6 @@ def show_command(
                 formatter=AclPrincipalFormatter(auth_client=auth_client),
             ),
             Field("Path", "path"),
+            Field("Expiration Date", "expiration_date"),
         ],
     )

--- a/src/globus_cli/termio/formatters/auth.py
+++ b/src/globus_cli/termio/formatters/auth.py
@@ -90,6 +90,8 @@ class PrincipalURNFormatter(PrincipalFormatter):
 
 class PrincipalDictFormatter(PrincipalFormatter):
     def parse(self, value: t.Any) -> tuple[str, str]:
+        if isinstance(value, globus_sdk.GlobusHTTPResponse):
+            value = value.data
         if not isinstance(value, dict):
             raise ValueError("cannot format principal from non-dict data")
 

--- a/tests/files/api_fixtures/endpoint_acl_operations.yaml
+++ b/tests/files/api_fixtures/endpoint_acl_operations.yaml
@@ -2,6 +2,7 @@ metadata:
   user_id: "25de0aed-aa83-4600-a1be-a62a910af116"
   username: "foo@globusid.org"
   endpoint_id: "1405823f-0597-4a16-b296-46d4f0ae4b15"
+  permission_id: "fbe71e48-9fb4-4265-a5b5-4408d8bb5d1b"
 
 auth:
   - path: /v2/api/identities
@@ -32,3 +33,28 @@ transfer:
         "access_id": 12345,
         "message": "Access rule created successfully."
       }
+  - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15/access/fbe71e48-9fb4-4265-a5b5-4408d8bb5d1b
+    method: put
+    json:
+      {
+        "DATA_TYPE": "result",
+        "code": "Updated",
+        "message": "Access rule 'fbe71e48-9fb4-4265-a5b5-4408d8bb5d1b' updated successfully",
+        "request_id": "abc123",
+        "resource": "/endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15/access/fbe71e48-9fb4-4265-a5b5-4408d8bb5d1b"
+      }
+  - path: /endpoint/1405823f-0597-4a16-b296-46d4f0ae4b15/access/fbe71e48-9fb4-4265-a5b5-4408d8bb5d1b
+    method: get
+    json:
+      {
+      "DATA_TYPE": "access",
+      "create_time": "2024-12-16T21:30:15+00:00",
+      "expiration_date": "2025-01-01T00:00:00+00:00",
+      "id": "fbe71e48-9fb4-4265-a5b5-4408d8bb5d1b",
+      "path": "/",
+      "permissions": "rw",
+      "principal": "25de0aed-aa83-4600-a1be-a62a910af116",
+      "principal_type": "identity",
+      "role_id": null,
+      "role_type": null
+    }


### PR DESCRIPTION
SC: https://app.shortcut.com/globus/story/30787/cli-support-showing-and-setting-expiration-date-field-for-acls

Main changes are the addition of `--expiration-date` to `globus endpoint permission create` and `globus endpoint permission update` and the `Expiration Date` output field for `globus endpoint permission show`

`--permissions` is also no longer a required option for `permission update` so users may only update expiration date.

I found a bug in the parsing of principal outputs while working on this caused by the `PrincipalDictFormatter` erroring on response objects being passed. Allowing it to accept `GlobusHTTPResponse` and extract their data seemed like the simplest fix.

Also includes fixtures and tests for `permission show` and `permission update` which were previously untested.