### PR TITLE
Begin testing on Python 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,10 +23,11 @@ jobs:
               - "3.10"
               - "3.11"
               - "3.12"
+              - "3.13"
             tox-post-environments:
               - "py3.8-mindeps"
               - "py3.8-sdkmain"
-              - "py3.12-sdkmain"
+              - "py3.13-sdkmain"
             cache-key-prefix: "linux"
             cache-key-hash-files:
               - "setup.py"
@@ -34,7 +35,7 @@ jobs:
           - name: "macOS"
             runner: "macos-latest"
             cpythons:
-              - "3.12"
+              - "3.13"
             tox-environments-from-pythons: true
             cache-key-prefix: "macos"
             cache-key-hash-files:
@@ -43,7 +44,7 @@ jobs:
           - name: "Windows"
             runner: "windows-latest"
             cpythons:
-              - "3.12"
+              - "3.13"
             tox-environments-from-pythons: true
             cache-key-prefix: "windows"
             cache-key-hash-files:
@@ -52,7 +53,7 @@ jobs:
           - name: "Quality"
             runner: "ubuntu-latest"
             cpythons:
-              - "3.12"
+              - "3.13"
             tox-environments:
               - "mypy"
               - "reference"

--- a/changelog.d/20250106_150212_sirosen_support_313.md
+++ b/changelog.d/20250106_150212_sirosen_support_313.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add official support for Python 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.8"
 dependencies = [

--- a/tests/functional/test_cli_profile_list.py
+++ b/tests/functional/test_cli_profile_list.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 
 import pytest
 from globus_sdk.tokenstorage import SQLiteAdapter
@@ -6,8 +7,11 @@ from globus_sdk.tokenstorage import SQLiteAdapter
 
 def _add_namespace_to_test_storage(storage, namespace, token_data):
     alt_storage = SQLiteAdapter(":memory:", namespace=namespace)
-    alt_storage._connection = storage._connection
-    alt_storage.store(token_data)
+    try:
+        with mock.patch.object(alt_storage, "_connection", storage._connection):
+            alt_storage.store(token_data)
+    finally:
+        alt_storage.close()
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     clean
-    py{3.12,3.11,3.10,3.9,3.8}
+    py{3.13,3.12,3.11,3.10,3.9,3.8}
     py3.8-mindeps
     cov-combine
     cov-report


### PR DESCRIPTION
In the changelog, this is noted as "official support for Python 3.13".

No major changes other than testing configs.
Fixes a failure to close sqlite connections in tests. (3.13 is stricter about `ResourceWarning`.)
