### PR TITLE
Fix mypy configuration in tox and CI, control python versions and update click-type-test usages

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,8 @@ jobs:
             cpythons:
               - "3.13"
             tox-environments:
-              - "mypy"
+              - "mypy-py38"
+              - "mypy-py313"
               - "reference"
               - "twine-check"
             cache-key-prefix: "quality"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,8 +55,8 @@ jobs:
             cpythons:
               - "3.13"
             tox-environments:
-              - "mypy-py38"
-              - "mypy-py313"
+              - "mypy-minpython"
+              - "mypy-maxpython"
               - "reference"
               - "twine-check"
             cache-key-prefix: "quality"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     "pytest>=7",
     "pytest-xdist<4",
     "pytest-timeout<3",
-    "click-type-test==1.0.0;python_version>='3.10'",
+    "click-type-test==1.1.0;python_version>='3.10'",
     "responses==0.25.3",
     # loading test fixture data
     "ruamel.yaml==0.18.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,14 @@ test = [
 [project.scripts]
 globus = "globus_cli:main"
 
+[dependency-groups]
+typing = [
+    "mypy==1.14.1",
+    "types-jwt",
+    "types-requests",
+    "types-jmespath",
+]
+
 [tool.setuptools.dynamic.version]
 attr = "globus_cli.version.__version__"
 

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -23,14 +23,17 @@ class QueryParamType(click.ParamType):
         return "Key=Value"
 
     def get_type_annotation(self, param: click.Parameter) -> type:
-        return tuple[str, str]
+        # this is a "<typing special form>" vs "type" issue, so type ignore for now
+        # click-type-test has an issue for improving this, with details, see:
+        #   https://github.com/sirosen/click-type-test/issues/14
+        return t.Tuple[str, str]  # type: ignore[return-value]
 
     def convert(
         self,
         value: str | None,
         param: click.Parameter | None,
         ctx: click.Context | None,
-    ) -> t.Tuple[str, str] | None:
+    ) -> tuple[str, str] | None:
         value = super().convert(value, param, ctx)
         if value is None:
             return None
@@ -45,14 +48,17 @@ class HeaderParamType(click.ParamType):
         return "Key:Value"
 
     def get_type_annotation(self, param: click.Parameter) -> type:
-        return tuple[str, str]
+        # this is a "<typing special form>" vs "type" issue, so type ignore for now
+        # click-type-test has an issue for improving this, with details, see:
+        #   https://github.com/sirosen/click-type-test/issues/14
+        return t.Tuple[str, str]  # type: ignore[return-value]
 
     def convert(
         self,
         value: str | None,
         param: click.Parameter | None,
         ctx: click.Context | None,
-    ) -> t.Tuple[str, str] | None:
+    ) -> tuple[str, str] | None:
         value = super().convert(value, param, ctx)
         if value is None:
             return None

--- a/src/globus_cli/commands/gcp/set_subscription_id.py
+++ b/src/globus_cli/commands/gcp/set_subscription_id.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import typing as t
 import uuid
 
 import click
@@ -13,15 +12,9 @@ from globus_cli.termio import display
 
 
 class GCPSubscriptionIdType(click.ParamType):
-    def get_type_annotation(self, _: click.Parameter) -> type:
-        return t.cast(type, uuid.UUID | ExplicitNullType)
-
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
-    ) -> t.Any:
-        if ctx and ctx.resilient_parsing:
-            return None
-
+    ) -> uuid.UUID | ExplicitNullType:
         if value.lower() == "null":
             return EXPLICIT_NULL
 

--- a/src/globus_cli/commands/gcs/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/gcs/endpoint/set_subscription_id.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import typing as t
 import uuid
 
@@ -10,17 +11,16 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import display
 
+if sys.version_info >= (3, 9):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 class GCSSubscriptionIdType(click.ParamType):
-    def get_type_annotation(self, _: click.Parameter) -> type:
-        return t.cast(type, uuid.UUID | t.Literal["DEFAULT"] | ExplicitNullType)
-
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
-    ) -> t.Any:
-        if ctx and ctx.resilient_parsing:
-            return None
-
+    ) -> uuid.UUID | Literal["DEFAULT"] | ExplicitNullType:
         if value.lower() == "null":
             return EXPLICIT_NULL
         elif value.lower() == "default":

--- a/src/globus_cli/commands/gcs/endpoint/update.py
+++ b/src/globus_cli/commands/gcs/endpoint/update.py
@@ -19,15 +19,12 @@ F = t.TypeVar("F", bound=AnyCallable)
 
 
 class SubscriptionIdType(click.ParamType):
-    def get_type_annotation(self, _: click.Parameter) -> type:
-        return t.cast(type, str | ExplicitNullType)
-
     def get_metavar(self, _: click.Parameter) -> t.Optional[str]:
         return "[<uuid>|DEFAULT|null]"
 
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
-    ) -> t.Any:
+    ) -> str | ExplicitNullType | None:
         if value is None or (ctx and ctx.resilient_parsing):
             return None
         if value.lower() == "null":

--- a/src/globus_cli/commands/login.py
+++ b/src/globus_cli/commands/login.py
@@ -57,15 +57,12 @@ Clients are always "logged in"
 class GCSEndpointType(click.ParamType):
     name = "GCS Server"
 
-    def get_type_annotation(self, _: click.Parameter) -> type:
-        return t.cast(type, t.Union[uuid.UUID, tuple[uuid.UUID, uuid.UUID]])
-
     def get_metavar(self, _: t.Optional[click.Parameter]) -> str:
         return "<endpoint_id>[:<collection_id>]"
 
     def convert(
         self, value: t.Any, param: Parameter | None, ctx: Context | None
-    ) -> t.Any:
+    ) -> uuid.UUID | tuple[uuid.UUID, uuid.UUID]:
         if isinstance(value, uuid.UUID):
             return value
         elif isinstance(value, tuple) and len(value) == 2:

--- a/src/globus_cli/parsing/param_classes.py
+++ b/src/globus_cli/parsing/param_classes.py
@@ -34,7 +34,7 @@ class OneUseOption(click.Option):
             return bool
 
         if isinstance(self.type, EndpointPlusPath):
-            return self.type.get_type_annotation(self) | None  # type: ignore[return-value]  # noqa: E501
+            return t.Union[self.type.get_type_annotation(self), None]  # type: ignore[return-value]  # noqa: E501
 
         raise NotImplementedError(
             "OneUseOption requires a type annotation in this case."

--- a/src/globus_cli/parsing/param_types/endpoint_plus_path.py
+++ b/src/globus_cli/parsing/param_types/endpoint_plus_path.py
@@ -23,10 +23,13 @@ class EndpointPlusPath(click.ParamType):
         super().__init__(*args, **kwargs)
 
     def get_type_annotation(self, param: click.Parameter) -> type:
+        # this is a "<typing special form>" vs "type" issue, so type ignore for now
+        # click-type-test has an issue for improving this, with details, see:
+        #   https://github.com/sirosen/click-type-test/issues/14
         if self.path_required:
-            return tuple[uuid.UUID, str]
+            return t.Tuple[uuid.UUID, str]  # type: ignore[return-value]
         else:
-            return tuple[uuid.UUID, str | None]
+            return t.Tuple[uuid.UUID, t.Union[str, None]]  # type: ignore[return-value]
 
     def get_metavar(self, param: click.Parameter | None) -> str:
         """

--- a/tox.ini
+++ b/tox.ini
@@ -43,8 +43,8 @@ commands =
     localsdk: python -c 'import os, subprocess, sys; subprocess.run([sys.executable, "-m", "pip", "install", "-e", os.environ["GLOBUS_SDK_PATH"]])'
     coverage run -m pytest {posargs}
 depends =
-    py{3.12,3.11,3.10,3.9,3.8}{,-mindeps}: clean
-    cov-combine: py{3.12,3.11,3.10,3.9,3.8}{,-mindeps}
+    py{3.13,3.12,3.11,3.10,3.9,3.8}{,-mindeps}: clean
+    cov-combine: py{3.13,3.12,3.11,3.10,3.9,3.8}{,-mindeps}
     cov-report: cov-combine
 
 [testenv:clean]

--- a/tox.ini
+++ b/tox.ini
@@ -76,10 +76,10 @@ commands = pre-commit run --all-files
 [testenv:mypy]
 dependency_groups = typing
 commands = mypy {posargs:src/}
-[testenv:mypy-py38]
+[testenv:mypy-minpython]
 base = mypy
 commands = mypy --python-version "3.8" {posargs:src/}
-[testenv:mypy-py313]
+[testenv:mypy-maxpython]
 base = mypy
 commands = mypy --python-version "3.13" {posargs:src/}
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     cov-combine
     cov-report
     mypy
-minversion = 4.3.5
+minversion = 4.22.0
 
 [testenv]
 package = wheel
@@ -74,16 +74,14 @@ skip_install = true
 commands = pre-commit run --all-files
 
 [testenv:mypy]
-base_python =
-    python3.12
-    python3.11
-    python3.10
-deps =
-    mypy==1.10.1
-    types-jwt
-    types-requests
-    types-jmespath
+dependency_groups = typing
 commands = mypy {posargs:src/}
+[testenv:mypy-py38]
+base = mypy
+commands = mypy --python-version "3.8" {posargs:src/}
+[testenv:mypy-py313]
+base = mypy
+commands = mypy --python-version "3.13" {posargs:src/}
 
 [testenv:reference]
 allowlist_externals = find


### PR DESCRIPTION
The overall goal of this PR is a cleanup to our `mypy` usage to get CI back into a healthy state.
We want to remove `base_python` specification (which is what's causing `tox_uv` to fail in surprising ways), and to achieve this a minor refactor is in order.

Updating to the latest `mypy` version and explicitly testing it on our lowest supported Python version (3.8) fails due to runtime usages which are never _in fact_ reached on lower Pythons, but which `mypy` can't be expected to recognize as such.
Refine these to pass on `py3.8`, then update so that CI is running `mypy --python-version 3.8` and `mypy --python-version 3.13`.

A very minor, unrelated bugfix to tox `depends` config is included.
