### PR TITLE
Refine usage of click.Context.resilient_parsing

### DIFF
--- a/src/globus_cli/commands/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/endpoint/set_subscription_id.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import typing as t
 import uuid
 
 import click
@@ -11,14 +10,9 @@ from globus_cli.termio import display
 
 
 class SubscriptionIdType(click.ParamType):
-    def get_type_annotation(self, param: click.Parameter) -> type:
-        return t.cast(type, str)
-
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
-    ) -> t.Any:
-        if value is None or (ctx and ctx.resilient_parsing):
-            return None
+    ) -> str:
         if value.lower() == "null":
             return "null"
         try:

--- a/src/globus_cli/commands/gcs/endpoint/update.py
+++ b/src/globus_cli/commands/gcs/endpoint/update.py
@@ -24,9 +24,7 @@ class SubscriptionIdType(click.ParamType):
 
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
-    ) -> str | ExplicitNullType | None:
-        if value is None or (ctx and ctx.resilient_parsing):
-            return None
+    ) -> str | ExplicitNullType:
         if value.lower() == "null":
             return EXPLICIT_NULL
         if value.lower() == "default":

--- a/src/globus_cli/parsing/shell_completion.py
+++ b/src/globus_cli/parsing/shell_completion.py
@@ -80,6 +80,8 @@ compdef _globus_completion globus;
 
 def print_completer_option(f: C) -> C:
     def callback(ctx: click.Context, param: click.Parameter, value: str | None) -> None:
+        # if `resilient_parsing=True`, shell completion is being executed, so we should
+        # be careful to skip the callback contents, which would echo output and exit
         if not value or ctx.resilient_parsing:
             return
 


### PR DESCRIPTION
`resilient_parsing` is used to skip option evaluation logic during shell completion. In most cases, it's *not* needed, since resilient parsing will suppress usage related exceptions, but we were applying it in several options which didn't need it. Remove it from these.

Interestingly, we also have a _perfect_ demonstration case for when `resilient_parsing` should be checked in our completer printing options. In that case, add a comment which will hopefully help explain `resilient_parsing` to any reader.
