### PR TITLE
Update dependency group + local dev usages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,11 @@ repos:
   rev: 0.6.8
   hooks:
     - id: alphabetize-codeowners
+# TODO: update URL once `dependency-groups` moves to pypa
+- repo: https://github.com/sirosen/dependency-groups
+  rev: 1.3.0
+  hooks:
+    - id: lint-dependency-groups
 - repo: https://github.com/codespell-project/codespell
   rev: v2.3.0
   hooks:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -4,7 +4,7 @@ Contributing to the Globus CLI
 First off, thank you so much for taking the time to contribute! :+1:
 
 If you want to do local development, you can setup a development virtualenv in
-`.venv` by running `make localdev`.
+`.venv` by running `make install`.
 
 Reporting Bugs & Requesting Features
 ------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 CLI_VERSION=$(shell grep '^__version__' src/globus_cli/version.py | cut -d '"' -f2)
 
 .venv:
-	python -m venv .venv
-	.venv/bin/pip install -U pip
+	python -m venv --upgrade-deps .venv
 	.venv/bin/pip install -e '.'
+	# TODO: update once `pip` v25.1 is released to use `pip install --group`
+	.venv/bin/pip install dependency-groups
+	.venv/bin/pip-install-dependency-groups dev
 
-.PHONY: localdev install
-localdev: .venv
+.PHONY: install
 install: .venv
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,11 @@ typing = [
     "types-requests",
     "types-jmespath",
 ]
+# `dev` is what's installed if you `make install`
+dev = [
+    {include-group = "test"},
+    {include-group = "typing"},
+]
 
 [tool.setuptools.dynamic.version]
 attr = "globus_cli.version.__version__"


### PR DESCRIPTION
These changes are based around fixing the local dev environment we are
providing for contributors via `CONTRIBUTING.adoc`. The target
environment is also the one we expect maintainers to use if they use
IDE integrations (e.g. pycharm) to run tests.

1. Add a new dependency group, `dev` which combines `test` and
   `typing`.
2. Update `make install` to use `dependency-groups` to install `dev`.
3. Add `lint-dependency-groups`.
4. Remove `make localdev` and update doc to instruct users to
   `make install` instead.
