### PR TITLE
Improve the helptext for 'collection delete'

### DIFF
--- a/src/globus_cli/commands/collection/delete.py
+++ b/src/globus_cli/commands/collection/delete.py
@@ -10,8 +10,20 @@ from globus_cli.termio import display
 @LoginManager.requires_login("transfer")
 def collection_delete(login_manager: LoginManager, *, collection_id: uuid.UUID) -> None:
     """
-    Delete an existing Collection. This requires the administrator role on the
-    Endpoint.
+    Delete an existing Collection.
+
+    This requires that you are an owner or administrator on the Collection.
+
+    Endpoint owners and administrators may delete Collections on the Endpoint.
+    For Guest Collections, administrators of the Mapped Collection may also delete.
+
+    If the collection has the 'delete_protection' property set to true, the Collection
+    can not be deleted.
+
+    All Collection-specific roles and 'sharing_policies' are also deleted.
+
+    If a Mapped Collection is deleted, then all Guest Collections and roles associated
+    with it are also deleted.
     """
     gcs_client = login_manager.get_gcs_client(collection_id=collection_id)
     res = gcs_client.delete_collection(collection_id)


### PR DESCRIPTION
This corrects and expands the helptext, after consultation with the
GCS team to confirm accuracy.

Because guest collection owners are the most likely to be confused
about their ability to delete, based on what we've seen, Collection
owner/admin permissions are called out first and separately from the
other roles which grant deletion capabilities.

Most of the content can be pulled from the docs for the delete API:
https://docs.globus.org/globus-connect-server/v5.4/api/openapi_Collections/#deleteCollection
