### PR TITLE
Support GAREs in Flows API error responses

### DIFF
--- a/changelog.d/20250228_131034_ada_add_handling_for_synchronous_gares_from_flows.md
+++ b/changelog.d/20250228_131034_ada_add_handling_for_synchronous_gares_from_flows.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Add support for handling synchronous Globus Auth Requirements Errors (GAREs)
+  when returned by Flows as part of a synchronous API interaction.

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -116,11 +116,13 @@ def handle_internal_auth_requirements(
 
 @sdk_error_handler(
     error_class="FlowsAPIError",
-    condition=lambda err: globus_sdk.gare.is_gare(err.raw_json),
+    condition=lambda err: globus_sdk.gare.is_gare(err.raw_json or {}),
     exit_status=4,
 )
 def handle_flows_gare(exception: globus_sdk.FlowsAPIError) -> int | None:
-    gare = globus_sdk.gare.to_gare(exception.raw_json)
+    gare = globus_sdk.gare.to_gare(exception.raw_json or {})
+    if not gare:
+        raise ValueError("Expected a GARE, but got None")
 
     _handle_gare(gare)
 
@@ -497,7 +499,8 @@ def _handle_gare(gare: globus_sdk.gare.GARE, message: str | None = None) -> None
     required_scopes = gare.authorization_parameters.required_scopes
     if required_scopes:
         _concrete_consent_required_hook(
-            required_scopes=required_scopes, message=message
+            required_scopes=required_scopes,
+            message=message or _DEFAULT_CONSENT_REAUTH_MESSAGE,
         )
 
     session_policies = gare.authorization_parameters.session_required_policies

--- a/src/globus_cli/exception_handling/hooks.py
+++ b/src/globus_cli/exception_handling/hooks.py
@@ -6,6 +6,7 @@ import typing as t
 
 import click
 import globus_sdk
+import globus_sdk.gare
 
 from globus_cli.endpointish import WrongEntityTypeError
 from globus_cli.login_manager import MissingLoginError
@@ -104,26 +105,24 @@ def handle_internal_auth_requirements(
         )
         return 255
 
-    required_scopes = gare.authorization_parameters.required_scopes
-    if required_scopes:
-        _concrete_consent_required_hook(
-            required_scopes=required_scopes, message=exception.message
-        )
-
-    session_policies = gare.authorization_parameters.session_required_policies
-    session_identities = gare.authorization_parameters.session_required_identities
-    session_domains = gare.authorization_parameters.session_required_single_domain
-    if session_policies or session_identities or session_domains:
-        _concrete_session_hook(
-            policies=session_policies,
-            identities=session_identities,
-            domains=session_domains,
-            message=exception.message or _DEFAULT_SESSION_REAUTH_MESSAGE,
-        )
+    _handle_gare(gare, exception.message)
 
     if exception.epilog:
         click.echo("\n* * *\n")
         click.echo(exception.epilog)
+
+    return None
+
+
+@sdk_error_handler(
+    error_class="FlowsAPIError",
+    condition=lambda err: globus_sdk.gare.is_gare(err.raw_json),
+    exit_status=4,
+)
+def handle_flows_gare(exception: globus_sdk.FlowsAPIError) -> int | None:
+    gare = globus_sdk.gare.to_gare(exception.raw_json)
+
+    _handle_gare(gare)
 
     return None
 
@@ -492,6 +491,25 @@ def missing_login_error_hook(exception: MissingLoginError) -> None:
         click.style("MissingLoginError: ", fg="yellow") + exception.message,
         err=True,
     )
+
+
+def _handle_gare(gare: globus_sdk.gare.GARE, message: str | None = None) -> None:
+    required_scopes = gare.authorization_parameters.required_scopes
+    if required_scopes:
+        _concrete_consent_required_hook(
+            required_scopes=required_scopes, message=message
+        )
+
+    session_policies = gare.authorization_parameters.session_required_policies
+    session_identities = gare.authorization_parameters.session_required_identities
+    session_domains = gare.authorization_parameters.session_required_single_domain
+    if session_policies or session_identities or session_domains:
+        _concrete_session_hook(
+            policies=session_policies,
+            identities=session_identities,
+            domains=session_domains,
+            message=message or _DEFAULT_SESSION_REAUTH_MESSAGE,
+        )
 
 
 def register_all_hooks() -> None:


### PR DESCRIPTION
I've limited this to Flows for now to avoid reasoning about whether this will do the proper thing in all services that can return a GARE (though, I suspect that it would, but that exploration will significantly expand the scope of this change to accommodate a Flows bugfix). Note that because the declaration order creates a precedence, this handler must be declared prior to `session_hook` (which will also evaluate to true). A subsequent unit of work could probably turn this into a generic GARE handler and remove `session_hook` entirely.

This work is needed to support the resolution of [sc-19841](https://app.shortcut.com/globus/story/19841) via the CLI. That story provides a reproducer.

Happy to add tests for this, if we think there are specific characteristics of the change that are valuable to exercise in the test suite.

Signed-off-by: Ada <ada@globus.org>
