### PR TITLE
Handle empty table data in output printing, discovered and tested against 'flows list'

### DIFF
--- a/changelog.d/20250325_155212_sirosen_handle_empty_flow_list.md
+++ b/changelog.d/20250325_155212_sirosen_handle_empty_flow_list.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Fix printing behavior on empty table data to avoid failures. The CLI
+  will now correctly print the header row for empty table outputs.

--- a/tests/functional/flows/test_list_flows.py
+++ b/tests/functional/flows/test_list_flows.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from globus_sdk._testing import load_response_set
+from globus_sdk._testing import RegisteredResponse, load_response_set
 
 
 def test_list_flows(run_line):
@@ -97,3 +97,15 @@ def test_list_flows_sorted(run_line):
         assert row[2] == meta["flow_owner"]
 
     assert titles_in_order == sorted(titles_in_order)
+
+
+def test_list_flows_empty_list(run_line):
+    RegisteredResponse(service="flows", path="/flows", json={"flows": []}).add()
+
+    expected = (
+        "Flow ID | Title | Owner | Created At | Updated At\n"
+        "------- | ----- | ----- | ---------- | ----------\n"
+    )
+
+    result = run_line("globus flows list")
+    assert result.output == expected


### PR DESCRIPTION
This is a broad bug, but was first found by doing a `globus flows list` under an account with no flows, which is why that example is used as a driving use case.

- Add a regression test for the empty flow list bug
- Fix handling of empty table data when printing
