### PR TITLE
Release v3.33.1

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -2,6 +2,13 @@
 
 // scriv-insert-here
 
+== 3.33.1 (2025-03-25)
+
+Bugfixes:
+
+* Fix printing behavior on empty table data to avoid failures. The CLI
+  will now correctly print the header row for empty table outputs.
+
 == 3.33.0 (2025-03-12)
 
 Bugfixes:

--- a/changelog.d/20250325_155212_sirosen_handle_empty_flow_list.md
+++ b/changelog.d/20250325_155212_sirosen_handle_empty_flow_list.md
@@ -1,4 +1,0 @@
-### Bugfixes
-
-* Fix printing behavior on empty table data to avoid failures. The CLI
-  will now correctly print the header row for empty table outputs.

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -7,7 +7,7 @@ if t.TYPE_CHECKING:
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.33.0"
+__version__ = "3.33.1"
 
 # app name to send as part of SDK requests
 app_name = f"Globus CLI v{__version__}"


### PR DESCRIPTION
# Changelog

## Bugfixes

* Fix printing behavior on empty table data to avoid failures. The CLI will now correctly print the header row for empty table outputs.
