### PR TITLE
Change the name of the Globus Timers service rendered in the `globus api timer` command

### DIFF
--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -370,7 +370,7 @@ For example, a call of
 
     globus api {legacy_name} GET /foo/bar
 
-sends a 'GET' request to '{_get_url(service_name)}foo/bar'
+sends a 'GET' request to `{_get_url(service_name)}foo/bar`
 """
 
     if service_name != "gcs":

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -117,7 +117,7 @@ e.g. '1h30m', '500s', '10d'
     ),
 )
 @mutex_option_group("--delete", "--delete-destination-extra")
-@LoginManager.requires_login("auth", "timer", "transfer")
+@LoginManager.requires_login("auth", "timers", "transfer")
 def transfer_command(
     login_manager: LoginManager,
     *,

--- a/src/globus_cli/commands/timer/delete.py
+++ b/src/globus_cli/commands/timer/delete.py
@@ -11,7 +11,7 @@ from ._common import DELETED_TIMER_FORMAT_FIELDS
 
 @command("delete", short_help="Delete a timer.")
 @click.argument("TIMER_ID", type=click.UUID)
-@LoginManager.requires_login("timer")
+@LoginManager.requires_login("timers")
 def delete_command(login_manager: LoginManager, *, timer_id: uuid.UUID) -> None:
     """
     Delete a timer.

--- a/src/globus_cli/commands/timer/list.py
+++ b/src/globus_cli/commands/timer/list.py
@@ -6,7 +6,7 @@ from ._common import TIMER_FORMAT_FIELDS
 
 
 @command("list", short_help="List your timers.")
-@LoginManager.requires_login("timer")
+@LoginManager.requires_login("timers")
 def list_command(login_manager: LoginManager) -> None:
     """
     List your timers.

--- a/src/globus_cli/commands/timer/pause.py
+++ b/src/globus_cli/commands/timer/pause.py
@@ -9,7 +9,7 @@ from globus_cli.termio import display
 
 @command("pause", short_help="Pause a timer.")
 @click.argument("TIMER_ID", type=click.UUID)
-@LoginManager.requires_login("timer")
+@LoginManager.requires_login("timers")
 def pause_command(login_manager: LoginManager, *, timer_id: uuid.UUID) -> None:
     """
     Pause a timer.

--- a/src/globus_cli/commands/timer/resume.py
+++ b/src/globus_cli/commands/timer/resume.py
@@ -29,7 +29,7 @@ if t.TYPE_CHECKING:
         "if additional steps are required to successfully resume the timer."
     ),
 )
-@LoginManager.requires_login("timer")
+@LoginManager.requires_login("timers")
 def resume_command(
     login_manager: LoginManager,
     *,

--- a/src/globus_cli/commands/timer/show.py
+++ b/src/globus_cli/commands/timer/show.py
@@ -11,7 +11,7 @@ from ._common import TIMER_FORMAT_FIELDS
 
 @command("show", short_help="Display a timer.")
 @click.argument("TIMER_ID", type=click.UUID)
-@LoginManager.requires_login("timer")
+@LoginManager.requires_login("timers")
 def show_command(login_manager: LoginManager, *, timer_id: uuid.UUID) -> None:
     """
     Display information about a particular timer.

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -79,7 +79,7 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
                 SearchScopes.all,
             ],
         }
-        self["timer"] = {
+        self["timers"] = {
             "min_contract_version": 2,
             "resource_server": TimersScopes.resource_server,
             "nice_server_name": "Globus Timers",

--- a/src/globus_cli/types.py
+++ b/src/globus_cli/types.py
@@ -41,5 +41,5 @@ JsonValue: TypeAlias = t.Union[
 
 
 ServiceNameLiteral: TypeAlias = t.Literal[
-    "auth", "transfer", "groups", "search", "timer", "flows"
+    "auth", "transfer", "groups", "search", "timers", "flows"
 ]

--- a/tests/unit/test_login_manager.py
+++ b/tests/unit/test_login_manager.py
@@ -1,6 +1,5 @@
 import datetime
 import re
-import sys
 import typing as t
 import uuid
 from unittest import mock
@@ -340,7 +339,6 @@ def test_compute_timer_scope_multiple_data_access():
     assert computed == f"{start_part}*{foo_scope} *{bar_scope} *{baz_scope}{end_part}"
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="test requires py3.8+")
 def test_cli_scope_requirements_exactly_match_service_name_literal():
     scope_requirements_keys = list(CLI_SCOPE_REQUIREMENTS)
 


### PR DESCRIPTION
_Observed while working on a different task._

----

The goal of this change is to fix the name of the Globus Timers service in the `globus api timer` help text.

In addition, the rendering of the example service/route request URL should now be code text.

![image](https://github.com/user-attachments/assets/e906cf75-b1ae-485b-a6ef-1aea6f1abf64)
