### PR TITLE
Make `globus api timers` the canonical command

### DIFF
--- a/changelog.d/20250410_141842_sirosen_rename_timers_api_command.md
+++ b/changelog.d/20250410_141842_sirosen_rename_timers_api_command.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* The `globus api timer` command has been renamed to `globus api timers`.
+  `globus api timer` is temporarily retained for backwards compatibility.

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -27,13 +27,15 @@ def _register_stub_transfer_response():
 
 
 @pytest.mark.parametrize(
-    "service_name", ["gcs", "auth", "flows", "groups", "search", "timer", "transfer"]
+    "service_name",
+    ["gcs", "auth", "flows", "groups", "search", "timers", "timer", "transfer"],
 )
 @pytest.mark.parametrize("is_error_response", (False, True))
 def test_api_command_get(run_line, service_name, add_gcs_login, is_error_response):
+    sdk_service_name = "timer" if service_name == "timers" else service_name
     load_response(
         RegisteredResponse(
-            service=service_name,
+            service=sdk_service_name,
             status=500 if is_error_response else 200,
             path="/foo",
             json={"foo": "bar"},


### PR DESCRIPTION
- `timer` is kept as a compatibility alias (hidden, and therefore it will be removed from docs)

- the `service_name` in API commands is now distinguished from the `command_name` so that we can narrow types and get appropriate lookup behaviors to power the `timer` command

- the `globus api` tests pass `"timer"` to the SDK consistently for response mocking (necessary for `globus api timers` testing to work)
