### PR TITLE
Fix ordering of task list date filters

### DIFF
--- a/changelog.d/20250416_141934_sirosen_fix_task_date_filters.md
+++ b/changelog.d/20250416_141934_sirosen_fix_task_date_filters.md
@@ -1,0 +1,3 @@
+### Bugfixes
+
+* Fix the order of time-based filters for `globus task list`

--- a/src/globus_cli/commands/task/list.py
+++ b/src/globus_cli/commands/task/list.py
@@ -213,10 +213,10 @@ def task_list(
         [
             _process_filterval("label", label_data),
             _process_filterval(
-                "request_time", [filter_requested_before, filter_requested_after]
+                "request_time", [filter_requested_after, filter_requested_before]
             ),
             _process_filterval(
-                "completion_time", [filter_completed_before, filter_completed_after]
+                "completion_time", [filter_completed_after, filter_completed_before]
             ),
         ]
     )

--- a/tests/functional/task/test_task_list.py
+++ b/tests/functional/task/test_task_list.py
@@ -166,10 +166,10 @@ def test_task_list_control_filter_request_and_completion_time(
 
     if use_request_time:
         request_time_filter = parsed_filters["request_time"].split(",")
-        assert request_time_filter == [before or "", after or ""]
+        assert request_time_filter == [after or "", before or ""]
     if use_completion_time:
         completion_time_filter = parsed_filters["completion_time"].split(",")
-        assert completion_time_filter == [before or "", after or ""]
+        assert completion_time_filter == [after or "", before or ""]
 
 
 @pytest.mark.parametrize("number_of_ids", (1, 3, 5))


### PR DESCRIPTION
In #767 this ordering was "fixed" incorrectly. The "after" filter
should come first and the "before" filter should come second, so that
the date filters are formulated as

    completion_time:<after>,<before>
    request_time:<after>,<before>

The reason being, each of these forms a bound on the date range.
This was confirmed in the Get Task List documentation.[^1]

Revert that incorrect change and update the relevant test to assert
the correct ordering.

Resolves #1099

[^1]: https://docs.globus.org/api/transfer/task/#get_task_list
