### PR TITLE
Implement flow start notification policy parsing

### DIFF
--- a/changelog.d/20250417_235715_sirosen_add_flow_run_notify_policy.md
+++ b/changelog.d/20250417_235715_sirosen_add_flow_run_notify_policy.md
@@ -3,4 +3,4 @@
 * `globus flows start` now accepts `--activity-notification-policy` which can
   be a comma-delimited list of statuses or a JSON policy document. When
   provided, the notification policy allows users to configure when the run will
-  trigger email notifications .
+  trigger email notifications.

--- a/changelog.d/20250417_235715_sirosen_add_flow_run_notify_policy.md
+++ b/changelog.d/20250417_235715_sirosen_add_flow_run_notify_policy.md
@@ -1,0 +1,6 @@
+### Enhancements
+
+* `globus flows start` now accepts `--activity-notification-policy` which can
+  be a comma-delimited list of statuses or a JSON policy document. When
+  provided, the notification policy allows users to configure when the run will
+  trigger email notifications .

--- a/src/globus_cli/commands/flows/start.py
+++ b/src/globus_cli/commands/flows/start.py
@@ -206,8 +206,9 @@ class ActivityNotificationPolicyType(JSONStringOrFile):
     help="""
         The activity notification policy for the run.
 
-        This may be given as a JSON file or JSON data containing a full policy
-        document, or a comma-delimited list of statuses for notification.
+        This may be given as a comma-delimited list of statuses for notification;
+        alternatively, this can also be provided as JSON data--or a path to a
+        JSON file--containing a full notification policy document.
     """,
 )
 @LoginManager.requires_login("flows")

--- a/src/globus_cli/commands/flows/start.py
+++ b/src/globus_cli/commands/flows/start.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import string
+import typing as t
 import uuid
 
 import click
@@ -9,7 +12,126 @@ from globus_cli.parsing import JSONStringOrFile, ParsedJSONData, command, flow_i
 from globus_cli.termio import Field, display, formatters
 from globus_cli.types import JsonValue
 
+if t.TYPE_CHECKING:
+    from click.shell_completion import CompletionItem
+
 ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
+
+
+class ActivityNotificationPolicyType(JSONStringOrFile):
+    """
+    An ActivityNotificationPolicy, parsed on the CLI is
+    - a comma-delimited list of choices
+    OR
+    - a JSON filename
+    OR
+    - a JSON string
+
+    NB: because this inherits JSONStringOrFile, it also accepts `file:<path>` syntax.
+    """
+
+    choices = ("INACTIVE", "FAILED", "SUCCEEDED")
+
+    def get_metavar(self, param: click.Parameter) -> str:
+        return f"[{{{','.join(self.choices)}}}|JSON_FILE|JSON]"
+
+    def convert(
+        self, value: str, param: click.Parameter | None, ctx: click.Context | None
+    ) -> ParsedJSONData:
+        if self._is_nonfile_comma_delimited_str(value):
+            return self._parse_comma_delimited(value, param, ctx)
+        # the super().convert() return type needs to be ignored because
+        # it is annotated as 'ExplicitNullType|ParsedJSONData' but the null case is
+        # not reachable because we haven't set a null value
+        return super().convert(value, param, ctx)  # type: ignore[return-value]
+
+    def _is_nonfile_comma_delimited_str(self, value: str) -> bool:
+        """Determine if an input is a comma-delimited list of values.
+        Furthermore, require it to not be a valid filename.
+
+        The heuristic used is
+        - split on commas
+        - are all of the elements of that split alphanumeric strings
+
+        Anything else gets passed to JSON parsing.
+        """
+        # real filename or stdin
+        if os.path.exists(value) or value == "-":
+            return False
+
+        alphabet = set(string.ascii_letters + string.digits)
+        return all(set(x) < alphabet for x in value.split(","))
+
+    def _parse_comma_delimited(
+        self, value: str, param: click.Parameter | None, ctx: click.Context | None
+    ) -> ParsedJSONData:
+        """
+        Parse comma-delimited choice input (case insensitive) and return the
+        result in the form of a ParsedJSONData object with no filename,
+        containing the appropriate policy document.
+        """
+        # empty string -> [], not [""]
+        parts = value.split(",") if value else []
+        # strip out empty strings, which makes for smooth handling of
+        # inputs like "FAILED,INACTIVE," (trailing comma)
+        parts = [p for p in parts if p != ""]
+
+        invalid_choices = [p for p in parts if p.upper() not in self.choices]
+        if invalid_choices:
+            if len(invalid_choices) == 1:
+                self.fail(f"{invalid_choices[0]!r} was not a valid choice.", param, ctx)
+            else:
+                self.fail(f"{invalid_choices!r} were not valid choices.", param, ctx)
+
+        data = {"status": [p.upper() for p in parts]}
+        return ParsedJSONData(None, data)
+
+    def shell_complete(
+        self, ctx: click.Context, param: click.Parameter, incomplete: str
+    ) -> list[CompletionItem]:
+        from click.shell_completion import CompletionItem
+
+        # if the caller used `--activity-notification-policy <TAB>`, show all options
+        # from the list
+        if incomplete == "":
+            return [CompletionItem(c) for c in self.choices]
+
+        # if the string looks like a comma-delimited string, and doesn't match
+        # a filename then completion should treat it as a comma-delimited
+        # string
+        if self._is_nonfile_comma_delimited_str(incomplete):
+            # no comma? could be the start of the first string
+            # e.g., `--activity-notification-policy inac<TAB>` ('inac' -> 'INACTIVE')
+            #
+            # commas? split them, grab the last element, and try working with that
+            # e.g., `--activity-notification-policy FAILED,INAC<TAB>`
+            #       (FAILED,INAC -> FAILED,INACTIVE)
+            #
+            # these are actually the same case -- split on commas, get the last
+            # string, and use that for completion
+            split = incomplete.split(",")
+            rightmost = split[-1]
+
+            # before we complete, figure out which choices are already completed
+            # we want 'FAILED,' -> FAILED,{INACTIVE|SUCCEEDED}
+            # not 'FAILED,' -> FAILED,{FAILED|INACTIVE|SUCCEEDED}
+            already_seen_choices = [
+                c
+                for c in self.choices
+                if any(c.startswith(part.upper()) for part in split[:-1])
+            ]
+            unseen_choices = [c for c in self.choices if c not in already_seen_choices]
+
+            return [
+                CompletionItem(",".join(split[:-1] + [c]))
+                for c in unseen_choices
+                if c.startswith(rightmost.upper())
+            ]
+
+        # it didn't look like a comma-separated string?
+        # then presumably it's JSON or a filename
+        # complete as a filename (which means no completion on JSON strings)
+        return [CompletionItem(incomplete, type="file")]
 
 
 @command("start", short_help="Start a flow.")
@@ -78,6 +200,16 @@ ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
         to create a list of tags.
     """,
 )
+@click.option(
+    "--activity-notification-policy",
+    type=ActivityNotificationPolicyType(),
+    help="""
+        The activity notification policy for the run.
+
+        This may be given as a JSON file or JSON data containing a full policy
+        document, or a comma-delimited list of statuses for notification.
+    """,
+)
 @LoginManager.requires_login("flows")
 def start_command(
     login_manager: LoginManager,
@@ -88,11 +220,26 @@ def start_command(
     managers: tuple[str, ...],
     monitors: tuple[str, ...],
     tags: tuple[str, ...],
+    activity_notification_policy: ParsedJSONData | None,
 ) -> None:
     """
     Start a flow.
 
-    FLOW_ID must be a UUID.
+    This creates a new run, and will return the run ID for monitoring and
+    future interactions with that run of the flow.
+    The input data will be validated against the Flow's input schema if one is
+    declared.
+
+    Use tags and labels to make runs searchable, and set monitors and managers
+    to allow other users to interact with the run.
+
+    The notification policy defaults to `"INACTIVE"`. You can set it to the full
+    set of statuses, as in
+
+    \b
+    --activity-notification-policy 'INACTIVE,SUCCEEDED,FAILED'
+
+    Or pass a full notification policy document as JSON.
     """
 
     if input_document is None:
@@ -102,6 +249,10 @@ def start_command(
             raise click.UsageError("Flow input must be a JSON object")
         input_document_json = input_document.data
 
+    notify_policy = None
+    if activity_notification_policy:
+        notify_policy = activity_notification_policy.data
+
     flow_client = login_manager.get_specific_flow_client(flow_id)
     response = flow_client.run_flow(
         body=input_document_json,
@@ -109,6 +260,7 @@ def start_command(
         tags=list(tags),
         run_managers=list(managers),
         run_monitors=list(monitors),
+        activity_notification_policy=notify_policy,
     )
 
     auth_client = login_manager.get_auth_client()

--- a/src/globus_cli/commands/flows/start.py
+++ b/src/globus_cli/commands/flows/start.py
@@ -83,7 +83,7 @@ class ActivityNotificationPolicyType(JSONStringOrFile):
             else:
                 self.fail(f"{invalid_choices!r} were not valid choices.", param, ctx)
 
-        data = {"status": [p.upper() for p in parts]}
+        data: JsonValue = {"status": [p.upper() for p in parts]}
         return ParsedJSONData(None, data)
 
     def shell_complete(
@@ -249,9 +249,10 @@ def start_command(
             raise click.UsageError("Flow input must be a JSON object")
         input_document_json = input_document.data
 
-    notify_policy = None
+    notify_policy: dict[str, t.Any] | None = None
     if activity_notification_policy:
-        notify_policy = activity_notification_policy.data
+        # type ignore as this is JSON data which we know is constrained to a dict
+        notify_policy = activity_notification_policy.data  # type: ignore[assignment]
 
     flow_client = login_manager.get_specific_flow_client(flow_id)
     response = flow_client.run_flow(

--- a/tests/functional/flows/test_start_flow.py
+++ b/tests/functional/flows/test_start_flow.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 import json
 import re
+import typing as t
 
+import pytest
+import responses
 from globus_sdk._testing import RegisteredResponse, load_response
 
 
@@ -15,11 +20,138 @@ def test_start_flow_text_output(run_line, add_flow_login):
     run_managers = response.metadata["request_params"]["run_managers"]
     add_flow_login(flow_id)
 
+    identity_info = _setup_identity_mock_response(
+        response.json["run_owner"], run_managers, run_monitors
+    )
+
+    # Construct the command line.
+    arguments = [f"'{flow_id}'", "--input", f"'{json.dumps(body)}'"]
+    for run_manager in run_managers:
+        arguments.extend(("--manager", f"'{run_manager}'"))
+    for run_monitor in run_monitors:
+        arguments.extend(("--monitor", f"'{run_monitor}'"))
+    for tag in tags:
+        arguments.extend(("--tag", f"'{tag}'"))
+    if label is not None:
+        arguments.extend(("--label", f"'{label}'"))
+
+    result = run_line(f"globus flows start {' '.join(arguments)}")
+
+    # all fields present
+    expected_fields = {
+        "Flow ID",
+        "Flow title",
+        "Run ID",
+        "Run label",
+        "Run owner",
+        "Run managers",
+        "Run monitors",
+        "Run tags",
+    }
+    actual_fields = set(re.findall(r"^[\w ]+(?=:)", result.output, flags=re.M))
+    assert expected_fields == actual_fields, "Expected and actual field sets differ"
+
+    tag_match = re.search(r"^Run tags:\s+(?P<tags>.+)$", result.output, flags=re.M)
+    assert tag_match is not None
+    assert ", ".join(tags) in tag_match.group("tags")
+
+    owner_match = re.search(r"^Run owner:\s+(?P<owner>.+)$", result.output, flags=re.M)
+    assert owner_match is not None
+    assert owner_match.group("owner") == identity_info["owner"]["username"]
+
+    managers_match = re.search(
+        r"^Run managers:\s+(?P<managers>.+)$", result.output, flags=re.M
+    )
+    assert managers_match is not None
+    assert managers_match.group("managers") == ", ".join(
+        identity["username"] for identity in identity_info["run_managers"]
+    )
+
+    monitors_match = re.search(
+        r"^Run monitors:\s+(?P<monitors>.+)$", result.output, flags=re.M
+    )
+    assert monitors_match is not None
+    assert monitors_match.group("monitors") == ", ".join(
+        identity["username"] for identity in identity_info["run_monitors"]
+    )
+
+
+def test_start_flow_rejects_non_object_input(run_line, add_flow_login):
+    # setup test requirements for success to ensure that the test won't be sensitive to
+    # the order in which checks which happen
+    # (e.g. login check happening before the input shape check)
+    response = load_response("flows.run_flow")
+    flow_id = response.metadata["flow_id"]
+    add_flow_login(flow_id)
+
+    result = run_line(
+        ["globus", "flows", "start", flow_id, "--input", json.dumps(["foo", "bar"])],
+        assert_exit_code=2,
+    )
+    assert "Flow input must be a JSON object" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "activity_arg, expect_sent_policy",
+    (
+        (None, None),
+        ("FAILED", {"status": ["FAILED"]}),
+        ("INACTIVE,SUCCEEDED,FAILED", {"status": ["INACTIVE", "SUCCEEDED", "FAILED"]}),
+        ('{"status": ["INACTIVE", "FAILED"]}', {"status": ["INACTIVE", "FAILED"]}),
+        ("succeeded,", {"status": ["SUCCEEDED"]}),
+    ),
+)
+def test_start_flow_sends_expected_activity_notification_policy(
+    run_line, add_flow_login, activity_arg, expect_sent_policy
+):
+    response = load_response("flows.run_flow")
+    flow_id = response.metadata["flow_id"]
+    add_flow_login(flow_id)
+
+    _setup_identity_mock_response(
+        response.json["run_owner"],
+        response.metadata["request_params"]["run_managers"],
+        response.metadata["request_params"]["run_monitors"],
+    )
+
+    add_args = []
+    if activity_arg is not None:
+        add_args = ["--activity-notification-policy", activity_arg]
+
+    run_line(
+        [
+            "globus",
+            "flows",
+            "start",
+            flow_id,
+        ]
+        + add_args
+    )
+
+    flows_requests = [
+        call.request
+        for call in responses.calls
+        if call.request.url.startswith("https://flows.automate.globus.org")
+    ]
+    assert len(flows_requests) == 1
+    start_req = flows_requests[0]
+    sent_body = json.loads(start_req.body)
+
+    if expect_sent_policy is not None:
+        assert "activity_notification_policy" in sent_body
+        assert sent_body["activity_notification_policy"] == expect_sent_policy
+    else:
+        assert "activity_notification_policy" not in sent_body
+
+
+def _setup_identity_mock_response(
+    run_owner: str, run_managers: list[str], run_monitors: list[str]
+) -> dict[str, t.Any]:
     # Configure identities.
     owner_identity = {
         "username": "yogi@jellystone.park",
         "name": "Yogi",
-        "id": response.json["run_owner"].split(":")[-1],
+        "id": run_owner.split(":")[-1],
         "identity_provider": "c8abac57-560c-46c8-b386-f116ed8793d5",
         "organization": "Hanna-Barbera",
         "status": "used",
@@ -70,68 +202,8 @@ def test_start_flow_text_output(run_line, add_flow_login):
         )
     )
 
-    # Construct the command line.
-    arguments = [f"'{flow_id}'", "--input", f"'{json.dumps(body)}'"]
-    for run_manager in run_managers:
-        arguments.extend(("--manager", f"'{run_manager}'"))
-    for run_monitor in run_monitors:
-        arguments.extend(("--monitor", f"'{run_monitor}'"))
-    for tag in tags:
-        arguments.extend(("--tag", f"'{tag}'"))
-    if label is not None:
-        arguments.extend(("--label", f"'{label}'"))
-
-    result = run_line(f"globus flows start {' '.join(arguments)}")
-
-    # all fields present
-    expected_fields = {
-        "Flow ID",
-        "Flow title",
-        "Run ID",
-        "Run label",
-        "Run owner",
-        "Run managers",
-        "Run monitors",
-        "Run tags",
+    return {
+        "owner": owner_identity,
+        "run_managers": run_manager_identities,
+        "run_monitors": run_monitor_identities,
     }
-    actual_fields = set(re.findall(r"^[\w ]+(?=:)", result.output, flags=re.M))
-    assert expected_fields == actual_fields, "Expected and actual field sets differ"
-
-    tag_match = re.search(r"^Run tags:\s+(?P<tags>.+)$", result.output, flags=re.M)
-    assert tag_match is not None
-    assert ", ".join(tags) in tag_match.group("tags")
-
-    owner_match = re.search(r"^Run owner:\s+(?P<owner>.+)$", result.output, flags=re.M)
-    assert owner_match is not None
-    assert owner_match.group("owner") == owner_identity["username"]
-
-    managers_match = re.search(
-        r"^Run managers:\s+(?P<managers>.+)$", result.output, flags=re.M
-    )
-    assert managers_match is not None
-    assert managers_match.group("managers") == ", ".join(
-        identity["username"] for identity in run_manager_identities
-    )
-
-    monitors_match = re.search(
-        r"^Run monitors:\s+(?P<monitors>.+)$", result.output, flags=re.M
-    )
-    assert monitors_match is not None
-    assert monitors_match.group("monitors") == ", ".join(
-        identity["username"] for identity in run_monitor_identities
-    )
-
-
-def test_start_flow_rejects_non_object_input(run_line, add_flow_login):
-    # setup test requirements for success to ensure that the test won't be sensitive to
-    # the order in which checks which happen
-    # (e.g. login check happening before the input shape check)
-    response = load_response("flows.run_flow")
-    flow_id = response.metadata["flow_id"]
-    add_flow_login(flow_id)
-
-    result = run_line(
-        ["globus", "flows", "start", flow_id, "--input", json.dumps(["foo", "bar"])],
-        assert_exit_code=2,
-    )
-    assert "Flow input must be a JSON object" in result.stderr

--- a/tests/unit/param_types/test_run_flow_activity_notification_type.py
+++ b/tests/unit/param_types/test_run_flow_activity_notification_type.py
@@ -1,0 +1,197 @@
+import contextlib
+import json
+import sys
+
+import click
+import pytest
+
+from globus_cli.commands.flows.start import ActivityNotificationPolicyType
+from globus_cli.parsing import ParsedJSONData
+
+
+@click.command()
+@click.option("-o", type=ActivityNotificationPolicyType())
+def simple_command(o):
+    if o is None:
+        click.echo("nil")
+    else:
+        assert isinstance(o, ParsedJSONData)
+        click.echo(f"filename: {o.filename or 'null'}")
+        click.echo(f"data: {json.dumps(o.data, sort_keys=True)}")
+
+
+def test_activity_notification_policy_metavar_rendering(runner):
+    # in helptext, it shows up with the correct metavar
+    result = runner.invoke(simple_command, ["--help"])
+    assert "-o [{INACTIVE,FAILED,SUCCEEDED}|JSON_FILE|JSON]" in result.output
+
+
+@pytest.mark.parametrize(
+    "input_str,parsed_as",
+    (
+        # typical cases, including repetition and mixed case
+        ("INACTIVE", ["INACTIVE"]),
+        ("INACTIVE,INACTIVE", ["INACTIVE", "INACTIVE"]),
+        ("inactive,succeeded", ["INACTIVE", "SUCCEEDED"]),
+        (
+            "FAILED,inactive,Failed,Succeeded",
+            ["FAILED", "INACTIVE", "FAILED", "SUCCEEDED"],
+        ),
+        # trailing comma -- ignored
+        ("FAILED,", ["FAILED"]),
+    ),
+)
+def test_activity_notification_policy_parses_comma_delimited_opts(
+    runner, input_str, parsed_as
+):
+    result = runner.invoke(simple_command, ["-o", input_str])
+    expect_data = json.dumps({"status": parsed_as})
+    assert result.output == f"filename: null\ndata: {expect_data}\n"
+
+
+@pytest.mark.parametrize(
+    "input_str, bad_values",
+    (
+        ("active", ["active"]),
+        ("innactivve", ["innactivve"]),
+        ("failure", ["failure"]),
+        ("failure,success", ["failure", "success"]),
+        ("failure,inactive,success", ["failure", "success"]),
+    ),
+)
+def test_activity_notification_policy_rejects_unknown_comma_delimited_opts(
+    runner, input_str, bad_values
+):
+    result = runner.invoke(simple_command, ["-o", input_str])
+    assert result.exit_code == 2
+    if len(bad_values) == 1:
+        assert f"{bad_values[0]!r} was not a valid choice." in result.output
+    else:
+        assert f"{bad_values!r} were not valid choices." in result.output
+
+
+def test_activity_notification_policy_can_parse_inline_json(runner):
+    result = runner.invoke(simple_command, ["-o", '"baz"'])
+    assert result.output == 'filename: null\ndata: "baz"\n'
+    result = runner.invoke(simple_command, ["-o", '{"foo": 1}'])
+    assert result.output == 'filename: null\ndata: {"foo": 1}\n'
+
+    # notably, an inline 'null' will hit the parse-path for a comma-delimited list
+    # and fail choice verification
+    result = runner.invoke(simple_command, ["-o", "null"])
+    assert result.exit_code == 2
+    assert "'null' was not a valid choice." in result.output
+
+
+def test_activity_notification_policy_rejects_invalid_inline_json(runner):
+    # invalid JSON data causes errors
+    result = runner.invoke(simple_command, ["-o", '{"foo": 1,}'])
+    assert result.exit_code == 2
+    assert "parameter value did not contain valid JSON" in result.output
+
+
+def test_activity_notification_policy_can_parse_json_file(runner, tmpdir):
+    # given the path to a file with valid JSON, it parses the result
+    # functions with or without the `file:` prefix
+    valid_file = tmpdir.mkdir("valid").join("file1.json")
+    valid_file.write('{"foo": 1}\n')
+    result = runner.invoke(simple_command, ["-o", "file:" + str(valid_file)])
+    assert result.output == f'filename: {valid_file}\ndata: {{"foo": 1}}\n'
+    result = runner.invoke(simple_command, ["-o", str(valid_file)])
+    assert result.output == f'filename: {valid_file}\ndata: {{"foo": 1}}\n'
+
+
+def test_activity_notification_policy_rejects_invalid_json_file(runner, tmpdir):
+    # given the path to a file with invalid JSON, it raises an error
+    invalid_file = tmpdir.mkdir("invalid").join("file1.json")
+    invalid_file.write('{"foo": 1,}\n')
+    result = runner.invoke(simple_command, ["-o", str(invalid_file)])
+    assert result.exit_code == 2
+    assert "did not contain valid JSON" in result.output
+
+
+def test_activity_notification_policy_can_parse_json(runner, tmpdir):
+    # given a path to a file which does not exist, it raises an appropriate error
+    missing_file = tmpdir.join("missing.json")
+    result = runner.invoke(simple_command, ["-o", "file:" + str(missing_file)])
+    assert result.exit_code == 2
+    assert "FileNotFound" in result.output
+    assert "does not exist" in result.output
+
+    # the same, but without the `file:` prefix
+    result = runner.invoke(simple_command, ["-o", str(missing_file)])
+    assert result.exit_code == 2
+    assert "FileNotFound" in result.output
+    assert "does not exist" in result.output
+
+
+def test_activity_notification_policy_can_parse_json_from_stdin(runner, tmpdir):
+    # can be given raw json objects on stdin and parses them faithfully
+    result = runner.invoke(simple_command, ["-o", "-"], input="null\n")
+    assert result.output == "filename: -\ndata: null\n"
+    result = runner.invoke(simple_command, ["-o", "-"], input='"baz"\n')
+    assert result.output == 'filename: -\ndata: "baz"\n'
+    result = runner.invoke(simple_command, ["-o", "-"], input='{"foo": 1}\n')
+    assert result.output == 'filename: -\ndata: {"foo": 1}\n'
+
+    # and handles malformed inputs to stdin
+    result = runner.invoke(simple_command, ["-o", "-"], input="[\n")
+    assert result.exit_code == 2
+    assert "stdin did not contain valid JSON" in result.output
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="contextlib.chdir added in 3.11")
+def test_activity_notification_policy_completion_matches_files(
+    get_completions, tmp_path
+):
+    file = tmp_path / "some_file.json"
+    file.touch()
+    with contextlib.chdir(tmp_path):
+        completion_items = get_completions(
+            simple_command, ["-o"], "some_", as_strings=False
+        )
+        assert len(completion_items) == 1
+        result = completion_items[0]
+        assert result.type == "file"
+        assert result.value == "some_"
+
+
+def test_activity_notification_policy_completion_expands_to_choices_with_no_input(
+    get_completions,
+):
+    completion_items = get_completions(simple_command, ["-o"], "", as_strings=False)
+    assert len(completion_items) == 3
+    for result in completion_items:
+        assert result.type == "plain"
+    assert {result.value for result in completion_items} == {
+        "INACTIVE",
+        "SUCCEEDED",
+        "FAILED",
+    }
+
+
+def test_activity_notification_policy_completion_expands_choice_list_one_result(
+    get_completions,
+):
+    completion_items = get_completions(
+        simple_command, ["-o"], "FAILED,I", as_strings=False
+    )
+    assert len(completion_items) == 1
+    result = completion_items[0]
+    assert result.type == "plain"
+    assert result.value == "FAILED,INACTIVE"
+
+
+def test_activity_notification_policy_completion_expands_choice_list_two_results(
+    get_completions,
+):
+    completion_items = get_completions(
+        simple_command, ["-o"], "FAILED,", as_strings=False
+    )
+    assert len(completion_items) == 2
+    for result in completion_items:
+        assert result.type == "plain"
+    assert {result.value for result in completion_items} == {
+        "FAILED,INACTIVE",
+        "FAILED,SUCCEEDED",
+    }


### PR DESCRIPTION
`globus flows start` has a new option,
`--activity-notification-policy`, with specialized custom parsing. It
accepts either a comma-delimited list or a JSON blob (or file),
deriving from our existing JSON support.

A simple heuristic tries to determine which type of input is being
given, checking if it "looks like comma delimited names" and
dispatching between the parse paths as appropriate.
The same heuristic drives tab completion, letting the completer switch
between the two modes.

Unit tests confirm the functionality to ensure that it parses as
desired in a variety of scenarios, and emits appropriate errors.

The resulting parsed policy object is then simply passed to
`start_flow`.

Additionally, in order to provide good helptext for this option, the
overall helptext for `globus flows start` has been enhanced.
