### PR TITLE
add support for activity-notifications for GCP and GCS

### DIFF
--- a/changelog.d/20250421_132124_pjhinton_sc_40253_guest_activity_notification_support.md
+++ b/changelog.d/20250421_132124_pjhinton_sc_40253_guest_activity_notification_support.md
@@ -1,0 +1,7 @@
+### Enhancements
+
+* Guest collections may be configured to send email notifications for
+  transfer tasks to `administrator`, `activity_manager`, and
+  `activity_monitor` roles with the `--activity-notifications`
+  option. The option is supported for both `globus gcp collection` and
+  `globus gcs collection` guest create and update commands.

--- a/src/globus_cli/commands/collection/create/guest.py
+++ b/src/globus_cli/commands/collection/create/guest.py
@@ -17,6 +17,7 @@ from globus_cli.endpointish import EntityType
 from globus_cli.login_manager import LoginManager, MissingLoginError
 from globus_cli.login_manager.context import LoginContext
 from globus_cli.parsing import command, endpointish_params, mutex_option_group
+from globus_cli.parsing.shared_options import activity_notifications_option
 from globus_cli.services.gcs import CustomGCSClient
 from globus_cli.termio import display
 
@@ -42,6 +43,7 @@ from globus_cli.termio import display
 @mutex_option_group("--user-credential-id", "--local-username")
 @endpointish_params.create(name="collection")
 @identity_id_option
+@activity_notifications_option("GCS")
 @click.option(
     "--enable-https/--disable-https",
     "enable_https",
@@ -74,6 +76,7 @@ def collection_create_guest(
     organization: str | None | ExplicitNullType,
     user_message: str | None | ExplicitNullType,
     user_message_link: str | None | ExplicitNullType,
+    activity_notifications: dict[str, list[str]] | None | ExplicitNullType,
     verify: dict[str, bool],
 ) -> None:
     """
@@ -99,6 +102,7 @@ def collection_create_guest(
 
     converted_kwargs: dict[str, t.Any] = ExplicitNullType.nullify_dict(
         {
+            "activity_notification_policy": activity_notifications,
             "collection_base_path": collection_base_path,
             "contact_info": contact_info,
             "contact_email": contact_email,

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -18,6 +18,7 @@ from globus_cli.parsing import (
     emptyable_opt_list_callback,
     endpointish_params,
 )
+from globus_cli.parsing.shared_options import activity_notifications_option
 from globus_cli.termio import Field, display
 
 _MULTI_USE_OPTION_STR = "Give this option multiple times in a single command"
@@ -104,10 +105,12 @@ class _FullDataField(Field):
         'Set a value of "" to clear this.'
     ),
 )
+@activity_notifications_option("GCS")
 @LoginManager.requires_login("auth", "transfer")
 def collection_update(
     login_manager: LoginManager,
     *,
+    activity_notifications: dict[str, list[str]] | None | ExplicitNullType,
     collection_id: uuid.UUID,
     display_name: str | None,
     description: str | None | ExplicitNullType,
@@ -175,6 +178,7 @@ def collection_update(
             "user_message_link": user_message_link,
             "sharing_users_allow": sharing_users_allow,
             "sharing_users_deny": sharing_users_deny,
+            "activity_notification_policy": activity_notifications,
         }
     )
     converted_kwargs.update(verify)

--- a/src/globus_cli/commands/gcp/create/guest.py
+++ b/src/globus_cli/commands/gcp/create/guest.py
@@ -7,6 +7,7 @@ import click
 from globus_cli.constants import ExplicitNullType
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import ENDPOINT_PLUS_REQPATH, command, endpointish_params
+from globus_cli.parsing.shared_options import activity_notifications_option
 from globus_cli.termio import Field, display
 
 from ._common import deprecated_verify_option
@@ -20,6 +21,7 @@ from ._common import deprecated_verify_option
 )
 @click.argument("HOST_GCP_PATH", type=ENDPOINT_PLUS_REQPATH)
 @deprecated_verify_option
+@activity_notifications_option("GCP")
 @LoginManager.requires_login("transfer")
 def guest_command(
     login_manager: LoginManager,
@@ -37,6 +39,7 @@ def guest_command(
     organization: str | None | ExplicitNullType,
     verify: dict[str, bool],
     disable_verify: bool | None,
+    activity_notifications: dict[str, list[str]] | None | ExplicitNullType,
 ) -> None:
     """
     Create a new Guest Collection on a Globus Connect Personal Endpoint
@@ -66,6 +69,7 @@ def guest_command(
         keywords=keywords,
         default_directory=default_directory,
         force_encryption=force_encryption,
+        guest_collection_activity_notification_policy=activity_notifications,
         **verify,
     )
 

--- a/src/globus_cli/commands/gcp/update/guest.py
+++ b/src/globus_cli/commands/gcp/update/guest.py
@@ -5,6 +5,7 @@ import uuid
 from globus_cli.constants import ExplicitNullType
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import collection_id_arg, command, endpointish_params
+from globus_cli.parsing.shared_options import activity_notifications_option
 from globus_cli.termio import display
 
 
@@ -15,10 +16,12 @@ from globus_cli.termio import display
     keyword_style="string",
     skip=("user_message", "user_message_link", "public"),
 )
+@activity_notifications_option("GCP")
 @LoginManager.requires_login("transfer")
 def guest_command(
     login_manager: LoginManager,
     *,
+    activity_notifications: dict[str, list[str]] | None | ExplicitNullType,
     collection_id: uuid.UUID,
     display_name: str | None,
     contact_email: str | None | ExplicitNullType,
@@ -52,6 +55,7 @@ def guest_command(
         keywords=keywords,
         default_directory=default_directory,
         force_encryption=force_encryption,
+        guest_collection_activity_notification_policy=activity_notifications,
         **verify,
     )
 

--- a/src/globus_cli/parsing/param_types/__init__.py
+++ b/src/globus_cli/parsing/param_types/__init__.py
@@ -4,6 +4,10 @@ from .endpoint_plus_path import (
     ENDPOINT_PLUS_REQPATH,
     EndpointPlusPath,
 )
+from .guest_activity_notify_param import (
+    GCSManagerGuestActivityNotificationParamType,
+    TransferGuestActivityNotificationParamType,
+)
 from .identity_type import IdentityType, ParsedIdentity
 from .json_strorfile import JSONStringOrFile, ParsedJSONData
 from .location import LocationType
@@ -18,6 +22,7 @@ __all__ = (
     "ENDPOINT_PLUS_OPTPATH",
     "ENDPOINT_PLUS_REQPATH",
     "EndpointPlusPath",
+    "GCSManagerGuestActivityNotificationParamType",
     "IdentityType",
     "JSONStringOrFile",
     "LocationType",
@@ -27,5 +32,6 @@ __all__ = (
     "StringOrNull",
     "TaskPath",
     "TimedeltaType",
+    "TransferGuestActivityNotificationParamType",
     "UrlOrNull",
 )

--- a/src/globus_cli/parsing/param_types/guest_activity_notify_param.py
+++ b/src/globus_cli/parsing/param_types/guest_activity_notify_param.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import click
+from click.shell_completion import CompletionItem
+
+from globus_cli._click_compat import shim_get_metavar
+from globus_cli.constants import ExplicitNullType
+
+
+class GCSManagerGuestActivityNotificationParamType(click.ParamType):
+    """
+    For the GCS Manager API:
+
+    * Status values are lowercase strings.
+
+        {
+            "status": ["failed", "succeeded],
+            ...
+        }
+
+    * Disabling all notifications is expressed by setting all elements to
+      empty lists.
+
+        {
+            "status": [],
+            "transfer_use": []
+        }
+    """
+
+    VALID_STATUSES = {
+        "succeeded",
+        "failed",
+    }
+
+    VALID_TRANSFER_USES = {
+        "source",
+        "destination",
+    }
+
+    VALID_NOTIFICATION_VALUES = VALID_TRANSFER_USES | VALID_STATUSES
+
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
+        return "{all,succeeded,failed,source,destination}"
+
+    def convert(
+        self,
+        value: str,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> dict[str, list[str]] | ExplicitNullType:
+
+        if value == "":
+            return {
+                "status": [],
+                "transfer_use": [],
+            }
+
+        if value.lower() == "all":
+            return {
+                "status": sorted(self.VALID_STATUSES),
+                "transfer_use": sorted(self.VALID_TRANSFER_USES),
+            }
+
+        policy: dict[str, list[str]] = {
+            "status": [],
+            "transfer_use": [],
+        }
+
+        # ignore white space, parse input sans case-sensitivity
+        lowercase_vals: set[str] = {s.strip().lower() for s in value.split(",") if s}
+
+        if "all" in lowercase_vals:
+            raise click.UsageError(
+                '--activity-notifications cannot accept "all" with other values'
+            )
+
+        val: str
+        if lowercase_vals <= self.VALID_NOTIFICATION_VALUES:
+            for val in lowercase_vals:
+                if val in self.VALID_TRANSFER_USES:
+                    policy["transfer_use"].append(val)
+                else:
+                    policy["status"].append(val)
+        else:
+            invalid_values = sorted(lowercase_vals - self.VALID_NOTIFICATION_VALUES)
+            raise click.UsageError(
+                "--activity-notifications received these invalid values: "
+                f"{invalid_values}"
+            )
+
+        # Fill in implied values.
+        # If statuses were given but no uses, all uses are listed.
+        # If uses were given but no statuses, all statuses are listed.
+        for k, v in policy.items():
+            if k == "transfer_use" and not v:
+                policy[k] = list(self.VALID_TRANSFER_USES)
+            elif k == "status" and not v:
+                policy[k] = list(self.VALID_STATUSES)
+
+        return policy
+
+    def shell_complete(
+        self, ctx: click.Context, param: click.Parameter, incomplete: str
+    ) -> list[CompletionItem]:
+        all_compoundable_options = ["destination", "failed", "source", "succeeded"]
+
+        all_options = ["all"] + all_compoundable_options
+
+        # if the caller used `--activity_notifications <TAB>`, show all options
+        # if the caller used `--activity_notifications <TAB>`, show `source` and
+        # `succeeded` the logic below assumes there were commas
+        if "," not in incomplete:
+            return [CompletionItem(o) for o in all_options if o.startswith(incomplete)]
+
+        # grab the last partial name from the list
+        # e.g. if the caller used `--activity-notifications source,succ<TAB>`, then
+        #      collect `succ` as the last incomplete fragment
+        #
+        # also collect the valid completed parts for comparisons
+        *already_contains, last_incomplete_fragment = incomplete.split(",")
+
+        # trim out empty strings; this will be reassembled later into the completed
+        # option and this removal will help result in translating `failed,,source`
+        # into `failed,source`
+        already_contains = [s for s in already_contains if s != ""]
+
+        # for possible options to complete, remove the set of already completed values
+        #
+        # e.g. `--acrivity-notifications failed,f<TAB>` will offer no completion, since
+        # `failed` was already used
+        # this also means that `--activity-notifications source,<TAB>` will offer
+        # `destination`, `failed`, and `succeeded` but not `source`.
+        #
+        # convert to a sorted list in case completion behavior is order-sensitive
+        possible_options = sorted(set(all_compoundable_options) - set(already_contains))
+
+        # now limit those options to those which start with the last fragment
+        #
+        # if the option was complete, it may be considered the only possible option
+        # i.e. `--activity-notifiations failed,succeeded,source,destination<TAB>`
+        # indicates valid usage
+        #
+        # if the option was blank, as in `--activity-notifications source,<TAB>`, then
+        # last_incomplete_fragment is "" and this filter won't remove anything
+        possible_options = [
+            o for o in possible_options if o.startswith(last_incomplete_fragment)
+        ]
+
+        # if the list became empty, we trust that the user has input a value
+        # which has some meaning unknown to the completer
+        # e.g. `--activity-notifications succeeded,UNKNOWN`
+        if possible_options == []:
+            possible_options = [last_incomplete_fragment]
+
+        # handle a corner case!
+        #
+        # all options were used with a trailing comma:
+        #    --activity-notifications source,destination,failed,succeeded,
+        if possible_options == [""]:
+            return [CompletionItem(",".join(already_contains))]
+
+        return [
+            CompletionItem(",".join(already_contains + [o])) for o in possible_options
+        ]
+
+
+class TransferGuestActivityNotificationParamType(
+    GCSManagerGuestActivityNotificationParamType
+):
+    """
+    For the Transfer API:
+
+    * Status values are uppercase strings.
+
+        {
+            "status": ["FAILED", "SUCCEEDED],
+            ...
+        }
+
+    * Disabling all notifications is expressed by a ``null`` value.
+    """
+
+    def convert(
+        self,
+        value: str,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> dict[str, list[str]] | ExplicitNullType:
+
+        policy: dict[str, list[str]] | ExplicitNullType = super().convert(
+            value, param, ctx
+        )
+
+        if isinstance(policy, dict):
+            if not (policy["status"] and policy["transfer_use"]):
+                return ExplicitNullType()
+            policy["status"] = [x.upper() for x in policy["status"]]
+
+        return policy

--- a/src/globus_cli/parsing/shared_options/__init__.py
+++ b/src/globus_cli/parsing/shared_options/__init__.py
@@ -15,7 +15,11 @@ from globus_cli.parsing.command_state import (
     show_server_timing_option,
     verbose_option,
 )
-from globus_cli.parsing.param_types import NotificationParamType
+from globus_cli.parsing.param_types import (
+    GCSManagerGuestActivityNotificationParamType,
+    NotificationParamType,
+    TransferGuestActivityNotificationParamType,
+)
 from globus_cli.types import AnyCommand
 
 C = t.TypeVar("C", bound=AnyCommand)
@@ -376,3 +380,40 @@ def local_user_option(f: C) -> C:
             "collections."
         ),
     )(f)
+
+
+def activity_notifications_option(
+    gc_type: t.Literal["GCP", "GCS"],
+) -> t.Callable[[C], C]:
+
+    def decorator(f: C) -> C:
+
+        help = (
+            "Comma-separated list of conditions. "
+            "Activity-monitoring roles on a guest collection will receive email "
+            "notifications when a matching transfer task completes.\n\n"
+            "'source' and 'destination' filter to tasks where the collection is the "
+            "source or destination of the transfer, respectively. "
+            "Similarly, 'succeeded' and 'failed' filter based on the task's status. "
+            "'all' enables notifications for all transfer tasks. "
+            'Use "" to remove the activity notification policy.\n\n'
+            "For example, a value of 'destination,failed' sends notifications "
+            "only when the collection is the destination and the transfer failed."
+        )
+
+        if gc_type == "GCP":
+            return click.option(
+                "--activity-notifications",
+                default=None,
+                help=help,
+                type=TransferGuestActivityNotificationParamType(),
+            )(f)
+        else:
+            return click.option(
+                "--activity-notifications",
+                default=None,
+                help=help,
+                type=GCSManagerGuestActivityNotificationParamType(),
+            )(f)
+
+    return decorator

--- a/tests/unit/param_types/test_guest_activity_notification_param.py
+++ b/tests/unit/param_types/test_guest_activity_notification_param.py
@@ -1,0 +1,242 @@
+import click
+import pytest
+
+from globus_cli.parsing.param_types.guest_activity_notify_param import (
+    GCSManagerGuestActivityNotificationParamType,
+    TransferGuestActivityNotificationParamType,
+)
+
+
+@click.command()
+@click.option(
+    "--activity-notifications",
+    type=TransferGuestActivityNotificationParamType(),
+)
+def activity_notifications_cmd(activity_notifications):
+    if not activity_notifications:
+        click.echo("activity_notifications=None")
+        return
+    click.echo(f"len(activity_notifications)={len(activity_notifications)}")
+    for k in sorted(activity_notifications.keys()):
+        click.echo(f"activity_notifications.{k}={sorted(activity_notifications[k])}")
+
+
+def test_activity_notifications_no_opts(runner):
+    result = runner.invoke(activity_notifications_cmd)
+    assert result.exit_code == 0
+    assert result.output == "activity_notifications=None\n"
+
+
+def test_activity_notifications_opt_empty(runner):
+    result = runner.invoke(activity_notifications_cmd, ["--activity-notifications", ""])
+    assert result.exit_code == 0
+    assert result.output == "activity_notifications=None\n"
+
+
+@pytest.mark.parametrize("arg", ("all,failed",))
+def test_activity_notifications_opt_mutually_exclusive(runner, arg):
+    result = runner.invoke(
+        activity_notifications_cmd, ["--activity-notifications", arg]
+    )
+    assert result.exit_code == 2
+    assert (
+        '--activity-notifications cannot accept "all" with other values'
+        in result.output
+    )
+
+
+def test_activity_notifications_opt_invalid(runner):
+
+    arg = "foo,Bar,BAZ"
+
+    result = runner.invoke(
+        activity_notifications_cmd, ["--activity-notifications", arg]
+    )
+    assert result.exit_code == 2
+    assert (
+        "--activity-notifications received these invalid values: ['bar', 'baz', 'foo']"
+        in result.output
+    )
+
+
+@pytest.mark.parametrize("arg", ("all", "All", "ALL"))
+def test_activity_notifications_opt_all(runner, arg):
+    result = runner.invoke(
+        activity_notifications_cmd, ["--activity-notifications", arg]
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == """\
+len(activity_notifications)=2
+activity_notifications.status=['FAILED', 'SUCCEEDED']
+activity_notifications.transfer_use=['destination', 'source']
+"""
+    )
+
+
+@pytest.mark.parametrize("arg", ("failed", "Failed", "FAILED"))
+def test_activity_notifications_opt_failed(runner, arg):
+    result = runner.invoke(
+        activity_notifications_cmd, ["--activity-notifications", arg]
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == """\
+len(activity_notifications)=2
+activity_notifications.status=['FAILED']
+activity_notifications.transfer_use=['destination', 'source']
+"""
+    )
+
+
+@pytest.mark.parametrize("arg", ("succeeded", "Succeeded", "SUCCEEDED"))
+def test_activity_notifications_opt_succeeded(runner, arg):
+    result = runner.invoke(
+        activity_notifications_cmd, ["--activity-notifications", arg]
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == """\
+len(activity_notifications)=2
+activity_notifications.status=['SUCCEEDED']
+activity_notifications.transfer_use=['destination', 'source']
+"""
+    )
+
+
+@pytest.mark.parametrize("arg", ("destination", "Destination", "DESTINATION"))
+def test_activity_notifications_opt_destination(runner, arg):
+    result = runner.invoke(
+        activity_notifications_cmd, ["--activity-notifications", arg]
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == """\
+len(activity_notifications)=2
+activity_notifications.status=['FAILED', 'SUCCEEDED']
+activity_notifications.transfer_use=['destination']
+"""
+    )
+
+
+@pytest.mark.parametrize("arg", ("source", "Source", "SOURCE"))
+def test_activity_notifications_opt_source(runner, arg):
+    result = runner.invoke(
+        activity_notifications_cmd, ["--activity-notifications", arg]
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == """\
+len(activity_notifications)=2
+activity_notifications.status=['FAILED', 'SUCCEEDED']
+activity_notifications.transfer_use=['source']
+"""
+    )
+
+
+@pytest.mark.parametrize(
+    "arg,expected",
+    (
+        ["source,succeeded", {"status": ["SUCCEEDED"], "transfer_use": ["source"]}],
+        ["failed,destination", {"status": ["FAILED"], "transfer_use": ["destination"]}],
+        [
+            "failed,source,destination",
+            {"status": ["FAILED"], "transfer_use": ["destination", "source"]},
+        ],
+        [
+            "failed,source,succeeded",
+            {"status": ["FAILED", "SUCCEEDED"], "transfer_use": ["source"]},
+        ],
+        [
+            "destination,failed,source,succeeded",
+            {
+                "status": ["FAILED", "SUCCEEDED"],
+                "transfer_use": ["destination", "source"],
+            },
+        ],
+        [
+            "destination, failed,source, succeeded",
+            {
+                "status": ["FAILED", "SUCCEEDED"],
+                "transfer_use": ["destination", "source"],
+            },
+        ],
+        [
+            "source, destination",
+            {
+                "status": ["FAILED", "SUCCEEDED"],
+                "transfer_use": ["destination", "source"],
+            },
+        ],
+    ),
+)
+def test_activity_notifications_opt_mixed(runner, arg, expected):
+    result = runner.invoke(
+        activity_notifications_cmd, ["--activity-notifications", arg]
+    )
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == f"""\
+len(activity_notifications)=2
+activity_notifications.status={expected["status"]}
+activity_notifications.transfer_use={expected["transfer_use"]}
+"""
+    )
+
+
+@pytest.mark.parametrize(
+    "incomplete_value, expected_completions",
+    (
+        ("", {"all", "destination", "failed", "source", "succeeded"}),
+        ("a", {"all"}),
+        ("al", {"all"}),
+        ("all", {"all"}),
+        ("dest", {"destination"}),
+        ("destination", {"destination"}),
+        ("s", {"source", "succeeded"}),
+        ("so", {"source"}),
+        ("su", {"succeeded"}),
+        ("destination,succ", {"destination,succeeded"}),
+        ("destination,succeeded", {"destination,succeeded"}),
+        (
+            "succeeded,",
+            {"succeeded,destination", "succeeded,failed", "succeeded,source"},
+        ),
+        (
+            ",,succeeded,",
+            {"succeeded,destination", "succeeded,failed", "succeeded,source"},
+        ),
+        (",,succeeded,,f", {"succeeded,failed"}),
+        (",", {"destination", "failed", "source", "succeeded"}),
+        (
+            "succeeded,failed,destination,source,",
+            {"succeeded,failed,destination,source"},
+        ),
+        (",,,succeeded,,,,failed,source,", {"succeeded,failed,source,destination"}),
+        ("succeeded,UNKNOWN", {"succeeded,UNKNOWN"}),
+        (",,succeeded,UNKNOWN", {"succeeded,UNKNOWN"}),
+    ),
+)
+def test_activity_notifications_shell_complete(
+    runner, incomplete_value, expected_completions
+):
+    param_type = GCSManagerGuestActivityNotificationParamType()
+    param = click.Option(["--activity-notifications"], type=param_type)
+    completions = param_type.shell_complete(
+        click.Context(activity_notifications_cmd), param, incomplete_value
+    )
+    got_values = {c.value for c in completions}
+    assert got_values == expected_completions
+
+
+def test_activity_notifications_metavar_in_help(runner):
+    # running `--help` should show the custom metavar for `--activity-notifications`
+    result = runner.invoke(activity_notifications_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "{all,succeeded,failed,source,destination}" in result.output


### PR DESCRIPTION
The code in this PR  implements a syntax based on the GCS CLI's approach to configuring guest collection activity notification policies. Guest collection create and update operations accept a new command line option:

--activity-notifications

To enable notifications under any circumstance, simply set the value of the option to `all`. Specifying an empty string (`""`) will disable all notifications.

Finer grained policies may be specified through a syntax that employs comma-separated strings corresponding to the role of the collection in the transfer (`transfer_use`) and outcome of the transfer (`status`).

The valid values for status are `"succeeded"` and `"failed"`. For `transfer_use`, `"source"` and `"destination"` are accepted.

The syntax builds up the policy structure that looks like this:

```
{
    "status": [(string), (string)...],
    "transfer_use": [(string), (string)...]
}
```

Specifying a policy value for one of the attributes while leaving out values of the others will implicitly enable all other values from the other attribute. For example, if `failed` is given, this is equal to the policy:

```
{
    "status": ["FAILED"],
    "transfer_use": ["source", "destination"]
}
```

Specifying one value for each attribute enables only those situations. Fore example, specifying the value `destination,succeeded` is equivalent to:

```
{
    "status": ["SUCCEEDED"],
    "transfer_use": ["destination"]
}
```

The syntax above is implemented through two click.ParamType subclasses:

`GCSManagerGuestActivityNotificationParamType`
`TransferGuestActivityNotificationParamType`

Two classes exist because of some differences between the GCS Manager API and the Transfer API.  GCS collection document schema 1.14.0 implements the status values as all lowercase, whereas Transfer expresses them as all capitals because that is how they are represented elsewhere in the API.

Because of the way the code for the GCS commands weed out null values from payloads, the `convert()` methods emit different structures for the `"" `string case. For the GCS class, the structure looks like:

```
{
    "status": [],
    "transfer_use": []
}
```

whereas the Transfer class yields an `ExplictNullType` instance.

Both routes rely on a common decorator (`activity_notifications_option`), which takes a string value of `"GCS"` or `"GCP"` to determine whether the data type class associated with the option will be the GCS or Transfer variant.

There is also support for shell completion on this option. Code borrows heavily (if not shamelessly) from the `NotifyParamType`.

There is complete unit test coverage for option parsing and shell completion.

A changelog fragment for `--activity-notifications` is provided.