### PR TITLE
Add support for `filter_roles` option when listing flows and runs

### DIFF
--- a/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
+++ b/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
@@ -1,6 +1,6 @@
 
 ### Enhancements
 
-* Updated `--filter-roles` parameter in  `globus flows list` to be
+* Updated `--filter-role` parameter in  `globus flows list` to be
   supplied multiple times to specify multiple roles.
-* Added `--filter-roles` parameter to `globus flows run list`.
+* Added `--filter-role` parameter to `globus flows run list`.

--- a/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
+++ b/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
@@ -1,7 +1,6 @@
 
 ### Enhancements
 
-* Updated `--filter-role` parameter in  `globus flows list` to be
+* Updated `--filter-roles` parameter in  `globus flows list` to be
   supplied multiple times to specify multiple roles.
-* Added `--filter-role` parameter to `globus flows run list` which can
-  be supplied multiple times to specify multiple roles.
+* * Added `--filter-roles` parameter to `globus flows run list`.

--- a/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
+++ b/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
@@ -1,0 +1,7 @@
+
+### Enhancements
+
+* Updated `--filter-role` parameter in  `globus flows list` to be
+  supplied multiple times to specify multiple roles.
+* Added `--filter-role` parameter to `globus flows run list` which can
+  be supplied multiple times to specify multiple roles.

--- a/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
+++ b/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
@@ -3,4 +3,4 @@
 
 * Updated `--filter-roles` parameter in  `globus flows list` to be
   supplied multiple times to specify multiple roles.
-* * Added `--filter-roles` parameter to `globus flows run list`.
+* Added `--filter-roles` parameter to `globus flows run list`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "globus-sdk==3.55.0",
+    "globus-sdk==3.56.0",
     "click>=8.1.4,<9",
     "jmespath==1.0.1",
     "packaging>=17.0",

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -36,6 +36,7 @@ ORDER_BY_FIELDS = (
 @command("list")
 @click.option(
     "--filter-role",
+    "filter_roles",
     type=click.Choice(ROLE_TYPES),
     help="Filter results by the flow's role type associated with the caller",
     multiple=True,
@@ -79,7 +80,7 @@ ORDER_BY_FIELDS = (
 def list_command(
     login_manager: LoginManager,
     *,
-    filter_role: tuple[
+    filter_roles: tuple[
         t.Literal[
             "flow_viewer",
             "flow_starter",
@@ -113,7 +114,7 @@ def list_command(
     paginator = Paginator.wrap(flows_client.list_flows)
     flow_iterator = PagingWrapper(
         paginator(
-            filter_roles=",".join(filter_role),
+            filter_roles=filter_roles,  # type: ignore[arg-type],
             filter_fulltext=filter_fulltext,
             orderby=",".join(f"{field} {order}" for field, order in orderby),
         ).items(),

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -10,7 +10,14 @@ from globus_cli.parsing import ColonDelimitedChoiceTuple, command
 from globus_cli.termio import Field, display, formatters
 from globus_cli.utils import PagingWrapper
 
-ROLE_TYPES = ("flow_viewer", "flow_starter", "flow_administrator", "flow_owner")
+ROLE_TYPES = (
+    "flow_viewer",
+    "flow_starter",
+    "flow_administrator",
+    "flow_owner",
+    "run_manager",
+    "run_monitor",
+)
 ORDER_BY_FIELDS = (
     "id",
     "scope_string",
@@ -31,6 +38,7 @@ ORDER_BY_FIELDS = (
     "--filter-role",
     type=click.Choice(ROLE_TYPES),
     help="Filter results by the flow's role type associated with the caller",
+    multiple=True,
 )
 @click.option(
     "--filter-fulltext",
@@ -71,10 +79,17 @@ ORDER_BY_FIELDS = (
 def list_command(
     login_manager: LoginManager,
     *,
-    filter_role: (
-        t.Literal["flow_viewer", "flow_starter", "flow_administrator", "flow_owner"]
-        | None
-    ),
+    filter_role: tuple[
+        t.Literal[
+            "flow_viewer",
+            "flow_starter",
+            "flow_administrator",
+            "flow_owner",
+            "run_manager",
+            "run_monitor",
+        ],
+        ...,
+    ],
     orderby: tuple[
         tuple[
             t.Literal[
@@ -98,7 +113,7 @@ def list_command(
     paginator = Paginator.wrap(flows_client.list_flows)
     flow_iterator = PagingWrapper(
         paginator(
-            filter_role=filter_role,
+            filter_roles=",".join(filter_role),
             filter_fulltext=filter_fulltext,
             orderby=",".join(f"{field} {order}" for field, order in orderby),
         ).items(),

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -114,7 +114,7 @@ def list_command(
     paginator = Paginator.wrap(flows_client.list_flows)
     flow_iterator = PagingWrapper(
         paginator(
-            filter_roles=filter_roles,  # type: ignore[arg-type],
+            filter_roles=filter_roles,  # type: ignore[arg-type]
             filter_fulltext=filter_fulltext,
             orderby=",".join(f"{field} {order}" for field, order in orderby),
         ).items(),

--- a/src/globus_cli/commands/flows/run/list.py
+++ b/src/globus_cli/commands/flows/run/list.py
@@ -33,6 +33,7 @@ ROLE_TYPES = (
 )
 @click.option(
     "--filter-role",
+    "filter_roles",
     type=click.Choice(ROLE_TYPES),
     help="Filter results by the run's role type associated with the caller",
     multiple=True,
@@ -51,7 +52,7 @@ def list_command(
     *,
     limit: int,
     filter_flow_id: tuple[uuid.UUID, ...],
-    filter_role: tuple[
+    filter_roles: tuple[
         t.Literal[
             "run_owner",
             "run_manager",
@@ -75,7 +76,7 @@ def list_command(
     run_iterator = PagingWrapper(
         paginator(
             filter_flow_id=filter_flow_id,
-            filter_roles=",".join(filter_role),
+            filter_roles=filter_roles,  # type: ignore[arg-type],
         ).items(),
         json_conversion_key="runs",
         limit=limit,

--- a/src/globus_cli/commands/flows/run/list.py
+++ b/src/globus_cli/commands/flows/run/list.py
@@ -76,7 +76,7 @@ def list_command(
     run_iterator = PagingWrapper(
         paginator(
             filter_flow_id=filter_flow_id,
-            filter_roles=filter_roles,  # type: ignore[arg-type],
+            filter_roles=filter_roles,  # type: ignore[arg-type]
         ).items(),
         json_conversion_key="runs",
         limit=limit,

--- a/src/globus_cli/commands/flows/run/list.py
+++ b/src/globus_cli/commands/flows/run/list.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing as t
 import uuid
 
 import click
@@ -9,6 +10,14 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command
 from globus_cli.termio import Field, display
 from globus_cli.utils import PagingWrapper
+
+ROLE_TYPES = (
+    "run_owner",
+    "run_manager",
+    "run_monitor",
+    "flow_run_manager",
+    "flow_run_monitor",
+)
 
 
 @command("list")
@@ -23,6 +32,12 @@ from globus_cli.utils import PagingWrapper
     type=click.UUID,
 )
 @click.option(
+    "--filter-role",
+    type=click.Choice(ROLE_TYPES),
+    help="Filter results by the run's role type associated with the caller",
+    multiple=True,
+)
+@click.option(
     "--limit",
     default=25,
     show_default=True,
@@ -32,7 +47,20 @@ from globus_cli.utils import PagingWrapper
 )
 @LoginManager.requires_login("flows")
 def list_command(
-    login_manager: LoginManager, *, limit: int, filter_flow_id: tuple[uuid.UUID, ...]
+    login_manager: LoginManager,
+    *,
+    limit: int,
+    filter_flow_id: tuple[uuid.UUID, ...],
+    filter_role: tuple[
+        t.Literal[
+            "run_owner",
+            "run_manager",
+            "run_monitor",
+            "flow_run_manager",
+            "flow_run_monitor",
+        ],
+        ...,
+    ],
 ) -> None:
     """
     List runs.
@@ -45,7 +73,10 @@ def list_command(
 
     paginator = Paginator.wrap(flows_client.list_runs)
     run_iterator = PagingWrapper(
-        paginator(filter_flow_id=filter_flow_id).items(),
+        paginator(
+            filter_flow_id=filter_flow_id,
+            filter_roles=",".join(filter_role),
+        ).items(),
         json_conversion_key="runs",
         limit=limit,
     )

--- a/tests/files/api_fixtures/flows_list.yaml
+++ b/tests/files/api_fixtures/flows_list.yaml
@@ -20,7 +20,7 @@ flows:
     method: get
     query_params:
       orderby: "updated_at DESC"
-      filter_role: flow_viewer
+      filter_roles: flow_viewer
     json:
       {
         "flows": [
@@ -49,6 +49,32 @@ flows:
       }
   - path: /flows
     method: get
+    json:
+      {
+        "flows": [
+          {
+            "id": "id-b",
+            "title": "Fairytale Index",
+            "flow_owner": "shrek@globus.org",
+            "created_at": "2007-05-18T00:00:00",
+            "updated_at": "2007-05-18T00:00:00",
+          },
+          {
+            "id": "id-a",
+            "title": "Swamp Transfer",
+            "flow_owner": "shrek@globus.org",
+            "created_at": "2001-04-01T00:00:00",
+            "updated_at": "2004-05-19T00:00:00",
+          }
+        ]
+      }
+  - path: /flows
+    method: get
+    query_params:
+      orderby: "updated_at DESC"
+      filter_roles:
+        - flow_viewer
+        - run_manager
     json:
       {
         "flows": [

--- a/tests/functional/flows/test_list_flows.py
+++ b/tests/functional/flows/test_list_flows.py
@@ -25,7 +25,7 @@ def test_list_flows_json(run_line):
     json.loads(result.output)
 
 
-def test_list_flows_filter_role(run_line):
+def test_list_flows_filter_role_single(run_line):
     load_response_set("cli.flows_list")
 
     expected = (
@@ -37,6 +37,22 @@ def test_list_flows_filter_role(run_line):
     )
 
     result = run_line("globus flows list --filter-role flow_viewer")
+    assert result.output == expected
+
+
+def test_list_flows_filter_role_multiple(run_line):
+    load_response_set("cli.flows_list")
+
+    expected = (
+        "Flow ID | Title           | Owner            | Created At          | Updated At         \n"  # noqa: E501
+        "------- | --------------- | ---------------- | ------------------- | -------------------\n"  # noqa: E501
+        "id-b    | Fairytale Index | shrek@globus.org | 2007-05-18 00:00:00 | 2007-05-18 00:00:00\n"  # noqa: E501
+        "id-a    | Swamp Transfer  | shrek@globus.org | 2001-04-01 00:00:00 | 2004-05-19 00:00:00\n"  # noqa: E501
+    )
+
+    result = run_line(
+        "globus flows list --filter-role flow_viewer --filter-role run_manager"
+    )
     assert result.output == expected
 
 

--- a/tests/functional/flows/test_list_runs.py
+++ b/tests/functional/flows/test_list_runs.py
@@ -1,9 +1,9 @@
 import uuid
 
 import pytest
+from globus_sdk._testing import load_response
 
 from globus_cli.commands.flows.run.list import ROLE_TYPES
-from globus_sdk._testing import load_response
 
 
 def test_list_runs_simple(run_line):

--- a/tests/functional/flows/test_list_runs.py
+++ b/tests/functional/flows/test_list_runs.py
@@ -74,3 +74,35 @@ def test_list_runs_paginated_response(run_line, limit_delta):
             uuid.UUID(row[0])
         except ValueError:
             pytest.fail(f"Run ID is not a valid UUID: {row[0]}")
+
+
+def test_list_runs_filter_role(run_line):
+    load_response("flows.list_runs").metadata
+
+    result = run_line(
+        [
+            "globus",
+            "flows",
+            "run",
+            "list",
+            "--filter-role",
+            "run_owner",
+            "--filter-role",
+            "flow_run_manager",
+        ]
+    )
+    output_lines = result.output.split("\n")
+    assert len(output_lines) == 4
+
+    header_line = output_lines[0]
+    header_row = [item.strip() for item in header_line.split(" | ")]
+    assert header_row == ["Run ID", "Flow Title", "Run Label", "Status"]
+
+
+def test_list_runs_invalid_filter_role(run_line):
+    load_response("flows.list_runs")
+
+    run_line(
+        "globus flows run list --filter-role up-up-down-down-left-right-left-right-b-a",
+        assert_exit_code=2,
+    )


### PR DESCRIPTION
[sc-40419](https://app.shortcut.com/globus/story/40419)
## Changelog
### Enhancements
 
 * Updated `--filter-role` parameter in  `globus flows list` to be
   supplied multiple times to specify multiple roles.
 * Added `--filter-role` parameter to `globus flows run list`, which can
   be supplied multiple times to specify multiple roles.