### PR TITLE
Ignore the SDK 'filter_role' warning in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,12 @@ profile = "black"
 
 [tool.pytest.ini_options]
 addopts = "--timeout 3 --color=yes"
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    # ignore SDK warnings for 'filter_role' until
+    # 'filter_roles' update is applied
+    "ignore:The `filter_role` parameter is deprecated.:globus_sdk.exc.RemovedInV4Warning:",
+]
 
 [tool.scriv]
 version = "literal: src/globus_cli/version.py: __version__"


### PR DESCRIPTION
Until we switch from 'filter_role' to 'filter_roles', which is in
progress (#1106), CI is failing against SDK-main.
This allows it to pass.
