### PR TITLE
Update license to SPDX license expression in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.rst"
 authors = [
     { name = "Stephen Rosen", email = "sirosen@globus.org" },
 ]
+license = "Apache-2.0"
 keywords = [
     "globus",
     "cli",
@@ -17,7 +18,6 @@ keywords = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Addresses the deprecation warning emitted during the [quality / tox tests](https://github.com/globus/globus-cli/actions/runs/14845737469/job/41679077612#step:18:208) in the project github actions workflow:

```
!!
  dist._finalize_license_expression()
/tmp/build-env-ow7a46lk/lib/python3.13/site-packages/setuptools/dist.py:761: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```