### PR TITLE
Update to support click==8.2.0

### DIFF
--- a/src/globus_cli/_click_compat.py
+++ b/src/globus_cli/_click_compat.py
@@ -22,14 +22,18 @@ def shim_get_metavar(f: C) -> C:
     the 8.2.0+ APIs.
 
     Under 8.2.0, `ctx: click.Context` is passed, while older versions do not.
-    Therefore, do nothing on 8.2.0+ and pass `click.get_current_context()' if
-    the older click version is in use.
+    Therefore, do nothing on 8.2.0+ and pass `ctx=None' if the older click
+    version is in use.
+
+    NOTE: we pass `ctx=None` which violates the declared types (but works at
+    runtime) because when running under older click versions, there may not be
+    a current click context.
     """
     if OLDER_CLICK_API:
 
         @functools.wraps(f)
         def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
-            return f(*args, **kwargs, ctx=click.get_current_context())
+            return f(*args, **kwargs, ctx=None)
 
         return wrapper  # type: ignore[return-value]
 

--- a/src/globus_cli/_click_compat.py
+++ b/src/globus_cli/_click_compat.py
@@ -34,3 +34,18 @@ def shim_get_metavar(f: C) -> C:
         return wrapper  # type: ignore[return-value]
 
     return f
+
+
+def shim_get_missing_message(f: C) -> C:
+    """
+    Shim `get_missing_message` in a similar way to `get_metavar` above.
+    """
+    if OLDER_CLICK_API:
+
+        @functools.wraps(f)
+        def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
+            return f(*args, **kwargs, ctx=click.get_current_context())
+
+        return wrapper  # type: ignore[return-value]
+
+    return f

--- a/src/globus_cli/_click_compat.py
+++ b/src/globus_cli/_click_compat.py
@@ -1,0 +1,10 @@
+"""
+A compatibility module for handling click v8.2.0+ and 8.1.x API differences.
+"""
+
+import importlib.metadata
+
+CLICK_VERSION = importlib.metadata.version("click")
+
+OLDER_CLICK_API = CLICK_VERSION.startswith("8.1.")
+NEWER_CLICK_API = not OLDER_CLICK_API

--- a/src/globus_cli/_click_compat.py
+++ b/src/globus_cli/_click_compat.py
@@ -2,9 +2,35 @@
 A compatibility module for handling click v8.2.0+ and 8.1.x API differences.
 """
 
+import functools
 import importlib.metadata
+import typing as t
+
+import click
+
+C = t.TypeVar("C", bound=t.Callable[..., t.Any])
 
 CLICK_VERSION = importlib.metadata.version("click")
 
 OLDER_CLICK_API = CLICK_VERSION.startswith("8.1.")
 NEWER_CLICK_API = not OLDER_CLICK_API
+
+
+def shim_get_metavar(f: C) -> C:
+    """
+    Make a ParamType.get_metavar function compatible with both the 8.1.x and
+    the 8.2.0+ APIs.
+
+    Under 8.2.0, `ctx: click.Context` is passed, while older versions do not.
+    Therefore, do nothing on 8.2.0+ and pass `click.get_current_context()' if
+    the older click version is in use.
+    """
+    if OLDER_CLICK_API:
+
+        @functools.wraps(f)
+        def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
+            return f(*args, **kwargs, ctx=click.get_current_context())
+
+        return wrapper  # type: ignore[return-value]
+
+    return f

--- a/src/globus_cli/commands/api.py
+++ b/src/globus_cli/commands/api.py
@@ -9,6 +9,7 @@ import click
 import globus_sdk
 
 from globus_cli import termio, version
+from globus_cli._click_compat import shim_get_metavar
 from globus_cli.login_manager import LoginManager, is_client_login
 from globus_cli.login_manager.scopes import CLI_SCOPE_REQUIREMENTS
 from globus_cli.parsing import command, endpoint_id_arg, group, mutex_option_group
@@ -19,7 +20,8 @@ C = t.TypeVar("C", bound=AnyCommand)
 
 
 class QueryParamType(click.ParamType):
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return "Key=Value"
 
     def get_type_annotation(self, param: click.Parameter) -> type:
@@ -44,7 +46,8 @@ class QueryParamType(click.ParamType):
 
 
 class HeaderParamType(click.ParamType):
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return "Key:Value"
 
     def get_type_annotation(self, param: click.Parameter) -> type:

--- a/src/globus_cli/commands/collection/list.py
+++ b/src/globus_cli/commands/collection/list.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import typing as t
 import uuid
 
@@ -11,8 +12,22 @@ from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import Field, display, formatters
 from globus_cli.utils import PagingWrapper
 
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
-class ChoiceSlugified(click.Choice):
+# until our minimum click version is 8.2.0+ , we need to handle the fact that
+# click.Choice became a generic in 8.2.0
+# we cannot leave it without a defined type parameter, as we have
+# "no-any-generics" set for mypy
+if t.TYPE_CHECKING:
+    ChoiceType: TypeAlias = click.Choice[str]
+else:
+    ChoiceType = click.Choice
+
+
+class ChoiceSlugified(ChoiceType):
     """
     Allow either hyphens or underscores, e.g. both 'mapped-collections' or
     'mapped_collections'

--- a/src/globus_cli/commands/collection/update.py
+++ b/src/globus_cli/commands/collection/update.py
@@ -34,12 +34,6 @@ class _FullDataField(Field):
 @collection_id_arg
 @endpointish_params.update(name="collection")
 @click.option(
-    "--force-encryption/--no-force-encryption",
-    "force_encryption",
-    default=None,
-    help="When set, all transfers to and from this collection are always encrypted.",
-)
-@click.option(
     "--sharing-restrict-paths",
     type=JSONStringOrFile(null="null"),
     help=(

--- a/src/globus_cli/commands/flows/start.py
+++ b/src/globus_cli/commands/flows/start.py
@@ -7,6 +7,7 @@ import uuid
 
 import click
 
+from globus_cli._click_compat import shim_get_metavar
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import JSONStringOrFile, ParsedJSONData, command, flow_id_arg
 from globus_cli.termio import Field, display, formatters
@@ -32,7 +33,8 @@ class ActivityNotificationPolicyType(JSONStringOrFile):
 
     choices = ("INACTIVE", "FAILED", "SUCCEEDED")
 
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return f"[{{{','.join(self.choices)}}}|JSON_FILE|JSON]"
 
     def convert(

--- a/src/globus_cli/commands/gcs/endpoint/update.py
+++ b/src/globus_cli/commands/gcs/endpoint/update.py
@@ -7,6 +7,7 @@ import uuid
 import click
 import globus_sdk
 
+from globus_cli._click_compat import shim_get_metavar
 from globus_cli.commands.gcs.endpoint._common import GCS_ENDPOINT_FIELDS
 from globus_cli.constants import EXPLICIT_NULL, ExplicitNullType
 from globus_cli.login_manager import LoginManager
@@ -19,7 +20,8 @@ F = t.TypeVar("F", bound=AnyCallable)
 
 
 class SubscriptionIdType(click.ParamType):
-    def get_metavar(self, _: click.Parameter) -> t.Optional[str]:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return "[<uuid>|DEFAULT|null]"
 
     def convert(

--- a/src/globus_cli/commands/list_commands.py
+++ b/src/globus_cli/commands/list_commands.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import typing as t
-
 import click
 
 from globus_cli.parsing import command
@@ -46,9 +44,8 @@ def list_commands() -> None:
     """
     # get the root context (the click context for the entire CLI tree)
     root_ctx = click.get_current_context().find_root()
-    ctx, subcmds, subgroups = walk_contexts(
-        "globus", t.cast(click.MultiCommand, root_ctx.command)
-    )
+    root_command: click.Group = root_ctx.command  # type: ignore[assignment]
+    ctx, subcmds, subgroups = walk_contexts("globus", root_command)
     _print_tree(ctx, subcmds, subgroups)
     # get an extra newline at the end
     click.echo("")

--- a/src/globus_cli/commands/login.py
+++ b/src/globus_cli/commands/login.py
@@ -8,6 +8,7 @@ from click import Context, Parameter
 from globus_sdk.scopes import GCSCollectionScopeBuilder, GCSEndpointScopeBuilder
 from globus_sdk.services.flows import SpecificFlowClient
 
+from globus_cli._click_compat import shim_get_metavar
 from globus_cli.login_manager import LoginManager, is_client_login
 from globus_cli.parsing import command, no_local_server_option
 from globus_cli.termio import verbosity
@@ -57,7 +58,8 @@ Clients are always "logged in"
 class GCSEndpointType(click.ParamType):
     name = "GCS Server"
 
-    def get_metavar(self, _: t.Optional[click.Parameter]) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return "<endpoint_id>[:<collection_id>]"
 
     def convert(

--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -16,6 +16,7 @@ from shutil import get_terminal_size
 
 import click
 
+from globus_cli._click_compat import OLDER_CLICK_API
 from globus_cli.exception_handling import custom_except_hook
 from globus_cli.termio import env_interactive
 
@@ -175,18 +176,22 @@ class GlobusCommandGroup(click.Group):
             )
         return cmd_object
 
-    def invoke(self, ctx: click.Context) -> t.Any:
-        # if no subcommand was given (but, potentially, flags were passed),
-        # ctx.protected_args will be empty
-        # improves upon the built-in detection given on click.Group by
-        # no_args_is_help , since that treats options (without a subcommand) as
-        # being arguments and blows up with a "Missing command" failure
-        # for reference to the original version (as of 2017-02-26):
-        # https://github.com/pallets/click/blob/02ea9ee7e864581258b4902d6e6c1264b0226b9f/click/core.py#L1039-L1052
-        if self.no_args_is_help and not ctx.protected_args:
-            click.echo(ctx.get_help())
-            ctx.exit()
-        return super().invoke(ctx)
+    # only redefine `invoke()` if we're on click<8.2.0
+    # on newer versions, the behavior is improved upstream
+    if OLDER_CLICK_API:
+
+        def invoke(self, ctx: click.Context) -> t.Any:
+            # if no subcommand was given (but, potentially, flags were passed),
+            # ctx.protected_args will be empty
+            # improves upon the built-in detection given on click.Group by
+            # no_args_is_help , since that treats options (without a subcommand) as
+            # being arguments and blows up with a "Missing command" failure
+            # for reference to the original version (as of 2017-02-26):
+            # https://github.com/pallets/click/blob/02ea9ee7e864581258b4902d6e6c1264b0226b9f/click/core.py#L1039-L1052
+            if self.no_args_is_help and not ctx.protected_args:
+                click.echo(ctx.get_help())
+                ctx.exit()
+            return super().invoke(ctx)
 
 
 class TopLevelGroup(GlobusCommandGroup):

--- a/src/globus_cli/parsing/commands.py
+++ b/src/globus_cli/parsing/commands.py
@@ -96,7 +96,7 @@ class GlobusCommand(click.Command):
                 combined_opts: dict[str, list[tuple[str, str]]] = {
                     combined_name: [] for combined_name in self.opts_to_combine.values()
                 }
-                parser: click.parser.OptionParser = self.make_parser(ctx)
+                parser = self.make_parser(ctx)
                 values, _, order = parser.parse_args(args=list(args))
                 # values is a dict of value lists keyed by their option name
                 # in order for that value and order is a list of option names

--- a/src/globus_cli/parsing/param_types/delimited.py
+++ b/src/globus_cli/parsing/param_types/delimited.py
@@ -4,6 +4,8 @@ import typing as t
 
 import click
 
+from globus_cli._click_compat import shim_get_metavar
+
 
 class CommaDelimitedList(click.ParamType):
     def __init__(
@@ -16,7 +18,8 @@ class CommaDelimitedList(click.ParamType):
         self.convert_values = convert_values
         self.choices = list(choices) if choices is not None else None
 
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         if self.choices is not None:
             return "{" + ",".join(self.choices) + "}"
         return "TEXT,TEXT,..."

--- a/src/globus_cli/parsing/param_types/delimited.py
+++ b/src/globus_cli/parsing/param_types/delimited.py
@@ -4,7 +4,14 @@ import typing as t
 
 import click
 
-from globus_cli._click_compat import shim_get_metavar
+from globus_cli._click_compat import (
+    OLDER_CLICK_API,
+    shim_get_metavar,
+    shim_get_missing_message,
+)
+
+if t.TYPE_CHECKING:
+    from click.shell_completion import CompletionItem
 
 
 class CommaDelimitedList(click.ParamType):
@@ -55,19 +62,63 @@ class CommaDelimitedList(click.ParamType):
         return resolved
 
 
-class ColonDelimitedChoiceTuple(click.Choice):
+class ColonDelimitedChoiceTuple(click.ParamType):
+    """
+    A colon-delimited choice type which wraps the existing click.Choice type.
+
+    It accepts colon-separated options as its input, and uses the underlying
+    choice type to implement behaviors amongst those options.
+    As its output (`convert()`), it produces tuples, with the elements split on
+    `:` characters.
+
+    It uses the `get_type_annotation()` hook from `click-type-test` to indicate
+    the exact literal type which should be used to annotate the parameter it
+    passes.
+    """
+
+    name = "colon_delimited_choice"
+
     def __init__(
         self,
         *,
         choices: t.Sequence[str],
         case_sensitive: bool = True,
     ) -> None:
-        super().__init__(choices, case_sensitive=case_sensitive)
+        super().__init__()
+        self.inner_choice_param = click.Choice(choices, case_sensitive=case_sensitive)
 
         self.unpacked_choices = self._unpack_choices()
 
+    def to_info_dict(self) -> dict[str, t.Any]:
+        return self.inner_choice_param.to_info_dict()
+
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str | None:
+        if OLDER_CLICK_API:
+            # type checking on newer click versions will flag this, but incorrectly so
+            return self.inner_choice_param.get_metavar(param)  # type: ignore[call-arg]
+        return self.inner_choice_param.get_metavar(param, ctx)
+
+    @shim_get_missing_message
+    def get_missing_message(
+        self, param: click.Parameter, ctx: click.Context | None
+    ) -> str:
+        if OLDER_CLICK_API:
+            # type checking on newer click versions will flag this, but incorrectly so
+            return self.inner_choice_param.get_missing_message(
+                param=param  # type: ignore[call-arg]
+            )
+        return self.inner_choice_param.get_missing_message(param=param, ctx=ctx)
+
+    def shell_complete(
+        self, ctx: click.Context, param: click.Parameter, incomplete: str
+    ) -> list[CompletionItem]:
+        return self.inner_choice_param.shell_complete(ctx, param, incomplete)
+
     def _unpack_choices(self) -> list[tuple[str, ...]]:
-        split_choices = [tuple(choice.split(":")) for choice in self.choices]
+        split_choices = [
+            tuple(choice.split(":")) for choice in self.inner_choice_param.choices
+        ]
         if len(split_choices) == 0:
             raise NotImplementedError("No choices")
         choice_len = len(split_choices[0])
@@ -96,4 +147,4 @@ class ColonDelimitedChoiceTuple(click.Choice):
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
     ) -> tuple[str, ...]:
-        return tuple(super().convert(value, param, ctx).split(":"))
+        return tuple(self.inner_choice_param.convert(value, param, ctx).split(":"))

--- a/src/globus_cli/parsing/param_types/endpoint_plus_path.py
+++ b/src/globus_cli/parsing/param_types/endpoint_plus_path.py
@@ -5,6 +5,8 @@ import uuid
 
 import click
 
+from globus_cli._click_compat import shim_get_metavar
+
 
 class EndpointPlusPath(click.ParamType):
     """
@@ -31,7 +33,8 @@ class EndpointPlusPath(click.ParamType):
         else:
             return t.Tuple[uuid.UUID, t.Union[str, None]]  # type: ignore[return-value]
 
-    def get_metavar(self, param: click.Parameter | None) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         """
         Default metavar for this instance of the type.
         """

--- a/src/globus_cli/parsing/param_types/identity_type.py
+++ b/src/globus_cli/parsing/param_types/identity_type.py
@@ -6,6 +6,8 @@ from collections import namedtuple
 
 import click
 
+from globus_cli._click_compat import shim_get_metavar
+
 ParsedIdentity = namedtuple("ParsedIdentity", ["value", "idtype"])
 
 
@@ -84,7 +86,8 @@ class IdentityType(click.ParamType):
 
         self.fail(f"'{value}' does not appear to be a valid identity", param=param)
 
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return self.metavar
 
     @property

--- a/src/globus_cli/parsing/param_types/json_strorfile.py
+++ b/src/globus_cli/parsing/param_types/json_strorfile.py
@@ -8,6 +8,7 @@ import typing as t
 
 import click
 
+from globus_cli._click_compat import shim_get_metavar
 from globus_cli.constants import EXPLICIT_NULL, ExplicitNullType
 from globus_cli.types import JsonValue
 
@@ -57,7 +58,8 @@ class JSONStringOrFile(click.ParamType):
         self.null = null
         super().__init__(*args, **kwargs)
 
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return "[JSON_FILE|JSON|file:JSON_FILE]"
 
     def shell_complete(

--- a/src/globus_cli/parsing/param_types/notify_param.py
+++ b/src/globus_cli/parsing/param_types/notify_param.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import click
 from click.shell_completion import CompletionItem
 
+from globus_cli._click_compat import shim_get_metavar
+
 
 def _empty_dict_callback(
     ctx: click.Context, param: click.Parameter, value: dict[str, bool] | None
@@ -15,7 +17,8 @@ def _empty_dict_callback(
 class NotificationParamType(click.ParamType):
     STANDARD_CALLBACK = _empty_dict_callback
 
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return "{on,off,succeeded,failed,inactive}"
 
     def convert(

--- a/src/globus_cli/parsing/param_types/nullable.py
+++ b/src/globus_cli/parsing/param_types/nullable.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 import click
 
+from globus_cli._click_compat import shim_get_metavar
 from globus_cli.constants import EXPLICIT_NULL, ExplicitNullType
 
 
@@ -13,7 +14,8 @@ class StringOrNull(click.ParamType):
     be converted into an EXPLICIT_NULL
     """
 
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return "TEXT"
 
     def convert(
@@ -31,7 +33,8 @@ class UrlOrNull(StringOrNull):
     http or https URL.
     """
 
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return "TEXT"
 
     def convert(
@@ -56,7 +59,8 @@ class IntOrNull(click.ParamType):
     be converted into an EXPLICIT_NULL
     """
 
-    def get_metavar(self, param: click.Parameter) -> str:
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
         return "[INT|null]"
 
     def convert(

--- a/src/globus_cli/reflect.py
+++ b/src/globus_cli/reflect.py
@@ -16,13 +16,13 @@ from globus_cli.commands import main as main_entrypoint
 from globus_cli.types import ClickContextTree
 
 
-def load_main_entrypoint() -> click.MultiCommand:
-    return t.cast(click.MultiCommand, main_entrypoint)
+def load_main_entrypoint() -> click.Group:
+    return main_entrypoint
 
 
 def walk_contexts(
     name: str,
-    cmd: click.MultiCommand,
+    cmd: click.Group,
     parent_ctx: click.Context | None = None,
     skip_hidden: bool = True,
 ) -> ClickContextTree:
@@ -57,7 +57,7 @@ def walk_contexts(
 
 def iter_all_commands(
     *,
-    cli_main: click.MultiCommand | None = None,
+    cli_main: click.Group | None = None,
     tree: ClickContextTree | None = None,
     skip_hidden: bool = True,
 ) -> t.Iterator[click.Context]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from globus_sdk.transport import RequestsTransport
 from ruamel.yaml import YAML
 
 import globus_cli
+from globus_cli._click_compat import NEWER_CLICK_API
 from globus_cli.login_manager.scopes import CURRENT_SCOPE_CONTRACT_VERSION
 
 yaml = YAML()
@@ -228,7 +229,10 @@ def test_file_dir():
 
 @pytest.fixture
 def cli_runner():
-    return CliRunner(mix_stderr=False)
+    if NEWER_CLICK_API:
+        return CliRunner()
+    else:
+        return CliRunner(mix_stderr=False)
 
 
 @pytest.fixture

--- a/tests/functional/endpoint/test_endpoint_create.py
+++ b/tests/functional/endpoint/test_endpoint_create.py
@@ -12,7 +12,7 @@ def test_gcp_creation(run_line):
     """
     load_response_set("cli.gcp_create")
     result = run_line("globus endpoint create --personal personal_create -F json")
-    res = json.loads(result.output)
+    res = json.loads(result.stdout)
     assert res["DATA_TYPE"] == "endpoint_create_result"
     assert res["code"] == "Created"
     assert "id" in res
@@ -28,7 +28,7 @@ def test_shared_creation(run_line, go_ep1_id):
         "globus endpoint create share_create "
         "-F json --shared {}:/~/".format(go_ep1_id)
     )
-    res = json.loads(result.output)
+    res = json.loads(result.stdout)
     assert res["DATA_TYPE"] == "endpoint_create_result"
     assert res["code"] == "Created"
     assert "Shared endpoint" in res["message"]
@@ -42,7 +42,7 @@ def test_gcs_creation(run_line):
     """
     load_response_set("cli.endpoint_operations")
     result = run_line("globus endpoint create gcs_create --server -F json")
-    res = json.loads(result.output)
+    res = json.loads(result.stdout)
     assert res["DATA_TYPE"] == "endpoint_create_result"
     assert res["code"] == "Created"
     assert res["globus_connect_setup_key"] is None


### PR DESCRIPTION
This changeset makes us compatible with the latest `click` version without dropping support for older versions.

Primarily, it adds `globus_cli._click_compat` for compatibility-related code which can detect which version of `click` we're using and for shim decorators.
Several minor tweaks, e.g. moves from MultiCommand to Group, are needed as well.

Two items deserve special call-outs:
- a test around EPIPE changed here; it turns out the test has been broken for years but was passing spuriously
- ColonDelimitedChoiceTuple now uses composition and "has a choice option", not inheritance ("is a choice option")

The commits are each small, isolated parts so that each one can be easily reviewed and understood.