### PR TITLE
Release v3.35.0

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -2,6 +2,29 @@
 
 // scriv-insert-here
 
+== 3.35.0 (2025-05-20)
+
+Enhancements:
+
+* Add `--run-manager` and `--run-monitor` options to `globus flows create`.
+* Add `--run-managers` and `--run-monitors` options to `globus flows update`.
+* Add "Run Managers" and "Run Monitors" to the output of `globus flows show`.
+
+* `globus flows start` now accepts `--activity-notification-policy`,
+  which can be a comma-delimited list of statuses or a JSON policy document.
+  When provided, the notification policy allows users to configure
+  when the run will trigger email notifications.
+
+* Guest collections may be configured to send email notifications for transfer tasks
+  to `administrator`, `activity_manager`, and `activity_monitor` roles
+  with the `--activity-notifications` option.
+  The option is supported for both `globus gcp collection` and `globus gcs collection`
+  guest create and update commands.
+
+* Allow the `globus flows list` `--filter-role` parameter to be supplied multiple times
+  to specify multiple roles.
+* Add `--filter-role` parameter to `globus flows run list`.
+
 == 3.34.0 (2025-04-18)
 
 Bugfixes:

--- a/changelog.d/20250411_105010_8730430+m1yag1.md
+++ b/changelog.d/20250411_105010_8730430+m1yag1.md
@@ -1,5 +1,0 @@
-### Enhancements
-
-* Added `--run-manager` and `--run-monitor` options to `globus flows create`.
-* Added `--run-managers` and `--run-monitors` options to `globus flows update`.
-* Added "Run Managers" and "Run Monitors" to the output of `globus flows show`.

--- a/changelog.d/20250417_235715_sirosen_add_flow_run_notify_policy.md
+++ b/changelog.d/20250417_235715_sirosen_add_flow_run_notify_policy.md
@@ -1,6 +1,0 @@
-### Enhancements
-
-* `globus flows start` now accepts `--activity-notification-policy` which can
-  be a comma-delimited list of statuses or a JSON policy document. When
-  provided, the notification policy allows users to configure when the run will
-  trigger email notifications.

--- a/changelog.d/20250421_132124_pjhinton_sc_40253_guest_activity_notification_support.md
+++ b/changelog.d/20250421_132124_pjhinton_sc_40253_guest_activity_notification_support.md
@@ -1,7 +1,0 @@
-### Enhancements
-
-* Guest collections may be configured to send email notifications for
-  transfer tasks to `administrator`, `activity_manager`, and
-  `activity_monitor` roles with the `--activity-notifications`
-  option. The option is supported for both `globus gcp collection` and
-  `globus gcs collection` guest create and update commands.

--- a/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
+++ b/changelog.d/20250430_152200_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.md
@@ -1,6 +1,0 @@
-
-### Enhancements
-
-* Updated `--filter-role` parameter in  `globus flows list` to be
-  supplied multiple times to specify multiple roles.
-* Added `--filter-role` parameter to `globus flows run list`.

--- a/src/globus_cli/version.py
+++ b/src/globus_cli/version.py
@@ -7,7 +7,7 @@ if t.TYPE_CHECKING:
 
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.34.0"
+__version__ = "3.35.0"
 
 # app name to send as part of SDK requests
 app_name = f"Globus CLI v{__version__}"


### PR DESCRIPTION
Enhancements:

* Add `--run-manager` and `--run-monitor` options to `globus flows create`.
* Add `--run-managers` and `--run-monitors` options to `globus flows update`.
* Add "Run Managers" and "Run Monitors" to the output of `globus flows show`.

* `globus flows start` now accepts `--activity-notification-policy`,
  which can be a comma-delimited list of statuses or a JSON policy document.
  When provided, the notification policy allows users to configure
  when the run will trigger email notifications.

* Guest collections may be configured to send email notifications for transfer tasks
  to `administrator`, `activity_manager`, and `activity_monitor` roles
  with the `--activity-notifications` option.
  The option is supported for both `globus gcp collection` and `globus gcs collection`
  guest create and update commands.

* Allow the `globus flows list` `--filter-role` parameter to be supplied multiple times
  to specify multiple roles.
* Add `--filter-role` parameter to `globus flows run list`.

