### PR TITLE
Fix test suite compatibility with click 8.2.1

### DIFF
--- a/src/globus_cli/utils.py
+++ b/src/globus_cli/utils.py
@@ -165,10 +165,7 @@ def shlex_process_stream(
     """
     import shlex
 
-    # use readlines() rather than implicit file read line looping to force
-    # python to properly capture EOF (otherwise, EOF acts as a flush and
-    # things get weird)
-    for lineno, line in enumerate(stream.readlines()):
+    for lineno, line in enumerate(stream.read().splitlines()):
         # get the argument vector:
         # do a shlex split to handle quoted paths with spaces in them
         # also lets us have comments with #

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -59,7 +59,7 @@ def test_shlex_process_stream_success():
         values.append(bar)
 
     text_like = unittest.mock.Mock()
-    text_like.readlines.return_value = ["alpha\n", "beta  # gamma\n"]
+    text_like.read.return_value = "alpha\nbeta  # gamma\n"
     text_like.name = "alphabet.txt"
 
     with outer_main.make_context("main", []):
@@ -80,7 +80,7 @@ def test_shlex_process_stream_error_handling(capsys):
         values.append(bar)
 
     text_like = unittest.mock.Mock()
-    text_like.readlines.return_value = ["alpha beta\n"]
+    text_like.read.return_value = "alpha beta\n"
     text_like.name = "alphabet.txt"
 
     with pytest.raises(click.exceptions.Exit) as excinfo:


### PR DESCRIPTION
click 8.2.1 has a test framework change that raises `EOFError`.

It is considered a bug fix for click, but the exception was uncaught and caused test suite failures in the CLI.

A comment regarding the usage of `.readlines()` instead of -- presumably -- writing `enumerate(stream)` is honored by calling `.read()` and then splitting the lines.

However, the comment itself is removed. It was written in 2016, when Python 3.5 was the latest version of Python, and may not be relevant any longer.