### PR TITLE
Remove README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,3 @@
-.. image:: https://github.com/globus/globus-cli/workflows/build/badge.svg?event=push
-    :alt: build status
-    :target: https://github.com/globus/globus-cli/actions?query=workflow%3Abuild
-
-.. image:: https://img.shields.io/pypi/v/globus-cli.svg
-    :alt: Latest Released Version
-    :target: https://pypi.org/project/globus-cli/
-
-.. image:: https://img.shields.io/pypi/pyversions/globus-cli.svg
-    :alt: Supported Python Versions
-    :target: https://img.shields.io/pypi/pyversions/globus-cli.svg
-
-
 Globus CLI
 ==========
 


### PR DESCRIPTION
These represent a risk, as they rely on external services (like shields.io) and current repository state ("build status").

Driving home that point, the build status badge is broken and this has harmed the rendering of all past versions' READMEs hosted on PyPI.