### PR TITLE
Fix `filter_roles` for `globus flows list`

### DIFF
--- a/changelog.d/20250529_094218_sirosen_quick_fix_flows_list.md
+++ b/changelog.d/20250529_094218_sirosen_quick_fix_flows_list.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Fix a bug in the latest version of `globus flows list` which caused the
+  command to send malformed query parameters and fail

--- a/src/globus_cli/commands/flows/list.py
+++ b/src/globus_cli/commands/flows/list.py
@@ -114,7 +114,9 @@ def list_command(
     paginator = Paginator.wrap(flows_client.list_flows)
     flow_iterator = PagingWrapper(
         paginator(
-            filter_roles=filter_roles,
+            # `filter_roles=()` results in an API error
+            # the query param sent by the SDK would be `filter_roles=` (empty string)
+            filter_roles=filter_roles or None,
             filter_fulltext=filter_fulltext,
             orderby=",".join(f"{field} {order}" for field, order in orderby),
         ).items(),

--- a/tests/functional/flows/test_list_flows.py
+++ b/tests/functional/flows/test_list_flows.py
@@ -1,7 +1,8 @@
 import json
+import urllib.parse
 import uuid
 
-from globus_sdk._testing import RegisteredResponse, load_response_set
+from globus_sdk._testing import RegisteredResponse, get_last_request, load_response_set
 
 
 def test_list_flows(run_line):
@@ -16,6 +17,16 @@ def test_list_flows(run_line):
 
     result = run_line("globus flows list")
     assert result.output == expected
+
+    # confirm that none of the filtering parameters were sent to the API
+    # and that the default orderby was sent
+    last_req = get_last_request()
+    parsed_url = urllib.parse.urlparse(last_req.url)
+    parsed_params = urllib.parse.parse_qs(parsed_url.query)
+    assert "filter_fulltext" not in parsed_params
+    assert "filter_roles" not in parsed_params
+    assert "orderby" in parsed_params
+    assert parsed_params["orderby"] == ["updated_at DESC"]
 
 
 def test_list_flows_json(run_line):


### PR DESCRIPTION
This was being passed with a default of `()`, the empty tuple. The SDK
translates this to an empty string, which the service rejects.

As a quick/immediate fix, make it `or None` so that no parameter will
be included in requests.

It was not possible to set `default=None` in the option declaration
for `filter_roles` because of the way `click` treats `multiple=True`
options -- the default is `()` even if you set an explicit default of
`None`.
