### PR TITLE
Update the lower-bound for build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.2"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
resolves #1121

The lower bounded versions of our build requirements need to support
all of the features which we're using.

In #1111 we switched to PEP 639 license metadata, but we didn't update
the lower bound for `setuptools`. This closes that gap -- setuptools
v77.0.1 is the earliest available version with SPDX license expression
field support.

---

_Aside_

We could test for this by always doing a build with our lowest possible build version as well, but there are some avenues to explore in terms of how to rig it up. I don't want the metadata fix to be blocked on exploration of build testing tools.