### PR TITLE
Reorder (consent_required_hook, session_hook)

### DIFF
--- a/changelog.d/20250605_094658_sirosen_hook_order_fix.md
+++ b/changelog.d/20250605_094658_sirosen_hook_order_fix.md
@@ -1,0 +1,3 @@
+### Bugfixes
+
+* Fix the ordering of session error checks in order to handle new API error formats.

--- a/src/globus_cli/exception_handling/hooks/__init__.py
+++ b/src/globus_cli/exception_handling/hooks/__init__.py
@@ -52,7 +52,7 @@ def _sort_all_hooks() -> t.Iterable[DeclaredHook[t.Any]]:
         [null_data_error_handler, json_error_handler],
         # next, authn and session requirements, from most specific to most general
         [handle_internal_auth_requirements, handle_flows_gare],
-        [session_hook, consent_required_hook],
+        [consent_required_hook, session_hook],
         # CLI internal error types, which cannot be confused with external causes
         [missing_login_error_hook, wrong_endpoint_type_error_hook],
         # service-specific hooks uncaptured by earlier checks


### PR DESCRIPTION
These two error hooks are adjacent to one another in the CLI's error
handling hooks, and their ordering has historically not been
significant. Prior to formulation of the GARE format, the two error
classes they handled were mutually exclusive.

Now that APIs can respond with GARE-formatted ConsentRequired data,
it's important that the ConsentRequired handler
(consent_required_hook) is checked first.

A new unit test captures this change.
