### PR TITLE
Address a CI caching issue

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
               - "py3.13-sdkmain"
             cache-key-prefix: "linux"
             cache-key-hash-files:
-              - "setup.py"
+              - "pyproject.toml"
 
           - name: "macOS"
             runner: "macos-latest"
@@ -39,7 +39,7 @@ jobs:
             tox-environments-from-pythons: true
             cache-key-prefix: "macos"
             cache-key-hash-files:
-              - "setup.py"
+              - "pyproject.toml"
 
           - name: "Windows"
             runner: "windows-latest"
@@ -48,7 +48,7 @@ jobs:
             tox-environments-from-pythons: true
             cache-key-prefix: "windows"
             cache-key-hash-files:
-              - "setup.py"
+              - "pyproject.toml"
 
           - name: "Quality"
             runner: "ubuntu-latest"
@@ -63,7 +63,7 @@ jobs:
             cache-files:
               - ".mypy_cache/"
             cache-key-hash-files:
-              - "setup.py"
+              - "pyproject.toml"
 
     uses: "globus/workflows/.github/workflows/tox.yaml@f41714f6a8b102569807b348fce50960f9617df8" # v1.2
     with:


### PR DESCRIPTION
`pyproject.toml` needs to be targeted for cache busting, not `setup.py`, which is almost completely empty.

The practical effect of this is that the cache isn't busted and tox environments are restored successfully. However, tox then needs to recreate the test environments because the SDK version no longer matches what's installed in the cached tox environments, which is a waste of CI time.