### PR TITLE
Update to globus-sdk==3.62.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "globus-sdk==3.60.0",
+    "globus-sdk==3.62.0",
     "click>=8.1.4,<9",
     "jmespath==1.0.1",
     "packaging>=17.0",


### PR DESCRIPTION
This is unblocked now that we've handled the latest deprecations.
