### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,15 +18,14 @@ jobs:
           - name: "Linux"
             runner: "ubuntu-latest"
             cpythons:
-              - "3.8"
               - "3.9"
               - "3.10"
               - "3.11"
               - "3.12"
               - "3.13"
             tox-post-environments:
-              - "py3.8-mindeps"
-              - "py3.8-sdkmain"
+              - "py3.9-mindeps"
+              - "py3.9-sdkmain"
               - "py3.13-sdkmain"
             cache-key-prefix: "linux"
             cache-key-hash-files:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   rev: v3.20.0
   hooks:
     - id: pyupgrade
-      args: ["--py38-plus"]
+      args: ["--py39-plus"]
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 25.1.0
   hooks:

--- a/changelog.d/20250804_155742_sirosen_remove_py38.md
+++ b/changelog.d/20250804_155742_sirosen_remove_py38.md
@@ -1,0 +1,3 @@
+### Other
+
+* Python 3.8 is no longer supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: POSIX",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "globus-sdk==3.62.0",
     "click>=8.1.4,<9",

--- a/src/globus_cli/commands/gcs/endpoint/set_subscription_id.py
+++ b/src/globus_cli/commands/gcs/endpoint/set_subscription_id.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 import uuid
 
@@ -11,16 +10,11 @@ from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
 from globus_cli.termio import display
 
-if sys.version_info >= (3, 9):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 class GCSSubscriptionIdType(click.ParamType):
     def convert(
         self, value: str, param: click.Parameter | None, ctx: click.Context | None
-    ) -> uuid.UUID | Literal["DEFAULT"] | ExplicitNullType:
+    ) -> uuid.UUID | t.Literal["DEFAULT"] | ExplicitNullType:
         if value.lower() == "null":
             return EXPLICIT_NULL
         elif value.lower() == "default":

--- a/src/globus_cli/termio/printers/table_printer.py
+++ b/src/globus_cli/termio/printers/table_printer.py
@@ -81,7 +81,7 @@ class TablePrinter(Printer[t.Iterable[t.Any]]):
             cells.append(value.ljust(width, fillchar))
         return " | ".join(cells)
 
-    @functools.lru_cache(maxsize=None)  # noqa: B019
+    @functools.cache  # noqa: B019
     def _column_width(self, table: DataTable, x: int) -> int:
         """The width of a column in the table."""
         values = [table[x, y] for y in range(table.num_rows)]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     cov-clean
-    py{3.13,3.12,3.11,3.10,3.9,3.8}
-    py3.8-mindeps
+    py{3.13,3.12,3.11,3.10,3.9}
+    py3.9-mindeps
     cov-combine
     cov-report
     mypy
@@ -47,7 +47,7 @@ commands = coverage erase
 [testenv:cov-combine]
 base = cov
 commands = coverage combine
-depends = py{3.13,3.12,3.11,3.10,3.9,3.8}{,-mindeps}
+depends = py{3.13,3.12,3.11,3.10,3.9}{,-mindeps}
 [testenv:cov-report]
 base = cov
 commands_pre = coverage html --fail-under=0
@@ -65,7 +65,7 @@ dependency_groups = typing
 commands = mypy {posargs:src/}
 [testenv:mypy-minpython]
 base = mypy
-commands = mypy --python-version "3.8" {posargs:src/}
+commands = mypy --python-version "3.9" {posargs:src/}
 [testenv:mypy-maxpython]
 base = mypy
 commands = mypy --python-version "3.13" {posargs:src/}


### PR DESCRIPTION
- Update requires-python
- Bump all references to 3.8 to 3.9 (e.g., 'mindeps' builds)
- Run pyupgrade to apply requisite changes
