### PR TITLE
Convert coverage from sitecustomize to 'patch'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ globus = "globus_cli:main"
 
 [dependency-groups]
 coverage = [
-    "coverage[toml]>=7"
+    "coverage[toml]>=7.10"
 ]
 yaml = ["ruamel.yaml==0.18.14"]
 test = [
@@ -103,6 +103,7 @@ filterwarnings = [
 
 [tool.coverage.run]
 parallel = true
+patch = ["subprocess"]
 source = ["globus_cli"]
 [tool.coverage.paths]
 source = [

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,6 @@ recreate =
 dependency_groups =
     !mindeps: test
     mindeps: test-mindeps
-# invoke custom plugin code to setup coverage under pytest-xdist
-globus_cli_coverage_sitecustomize = true
 
 # the 'localsdk' factor allows CLI tests to be run against a local repo copy of globus-sdk
 # it requires that the GLOBUS_SDK_PATH env var is set

--- a/toxfile.py
+++ b/toxfile.py
@@ -25,13 +25,6 @@ if t.TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_INJECT_SITECUSTOMIZE = '''
-"""A sitecustomize.py injected by globus_cli_coverage_sitecustomize"""
-import coverage
-
-coverage.process_startup()
-'''
-
 
 @impl
 def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
@@ -40,12 +33,6 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
         of_type=list[str],
         default=[],
         desc="A dir tree to remove before running the environment commands",
-    )
-    env_conf.add_config(
-        keys=["globus_cli_coverage_sitecustomize"],
-        of_type=bool,
-        default=[],
-        desc="Inject a sitecustomize.py to enable `coverage` under pytest-xdist",
     )
 
 
@@ -66,14 +53,3 @@ def tox_before_run_commands(tox_env: ToxEnv) -> None:
         if path.exists():
             log.warning(f"globus_cli_rmtree: {path}")
             shutil.rmtree(path)
-
-    if tox_env.conf.load("globus_cli_coverage_sitecustomize"):
-        site_packages_path = pathlib.Path(tox_env.conf.load("env_site_packages_dir"))
-        inject_sitecustomize_path = site_packages_path / "sitecustomize.py"
-        inject_sitecustomize_path.write_text(_INJECT_SITECUSTOMIZE)
-
-        # It is important that the tox configuration also sets
-        # COVERAGE_PROCESS_START to the coverage configuration file.
-        # If this is not done, `coverage.process_startup` will be a no-op.
-        setenv = tox_env.conf.load("set_env")
-        setenv.update({"COVERAGE_PROCESS_START": "pyproject.toml"})


### PR DESCRIPTION
This needed to wait until after Python 3.8 support dropped, in order to allow use of coverage 7.10+.
