### PR TITLE
Remove `setup.py` compat shim

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
A stub `setup.py` file was useful for a period during `setuptools`'s
transition to full support for `pyproject.toml`. It allowed downstream
repackagers of the CLI to run `python setup.py ...` in order to build
dists (provided they had a modern enough setuptools version).

However, we aren't doing anything with the file and it existed only as
a shim to aid in the transition onto PEP 517 build frontends. Now that
the entire ecosystem has baked for a few years and distributions with
non-setuptools backends are commonplace, it's time to remove it.
