### PR TITLE
Introduce an 'ActivityFormatter' for Timers

### DIFF
--- a/changelog.d/20250916_155003_sirosen_support_timer_activity_field.md
+++ b/changelog.d/20250916_155003_sirosen_support_timer_activity_field.md
@@ -1,0 +1,4 @@
+### Enhancements
+
+* Text display of Timers via commands such as `globus timer show` now includes
+  an `Activity` field which summarizes the status of the Timer.

--- a/tests/functional/timer/test_job_operations.py
+++ b/tests/functional/timer/test_job_operations.py
@@ -58,6 +58,7 @@ DELETE_RESPONSE = RegisteredResponse(
         "stop_after_n": 1,
         "submitted_at": "2022-04-05T16:27:48.805427",
         "update_pending": True,
+        "activity": None,
     },
 )
 

--- a/tests/unit/formatters/test_timer_formatters.py
+++ b/tests/unit/formatters/test_timer_formatters.py
@@ -3,9 +3,11 @@ import datetime
 import pytest
 
 from globus_cli.commands.timer._common import (
+    ActivityFormatter,
     CallbackActionTypeFormatter,
     ScheduleFormatter,
 )
+from globus_cli.termio.formatters import FormattingFailedWarning
 
 
 @pytest.mark.parametrize(
@@ -36,7 +38,7 @@ end_rendered = (
 
 
 @pytest.mark.parametrize(
-    "value, expected_template",
+    "value, expected",
     (
         pytest.param(
             {
@@ -45,7 +47,10 @@ end_rendered = (
                 "start": start_string,
                 "type": "recurring",
             },
-            "every 86400 seconds, starting {start} and running for 3 iterations",
+            (
+                f"every 86400 seconds, starting {start_rendered} and running for "
+                "3 iterations"
+            ),
             id="start-end-count",
         ),
         pytest.param(
@@ -55,7 +60,10 @@ end_rendered = (
                 "start": start_string,
                 "type": "recurring",
             },
-            "every 86400 seconds, starting {start} and running until {end}",
+            (
+                f"every 86400 seconds, starting {start_rendered} and running "
+                f"until {end_rendered}"
+            ),
             id="start-end-datetime",
         ),
         pytest.param(
@@ -63,11 +71,127 @@ end_rendered = (
                 "datetime": start_string,
                 "type": "once",
             },
-            "once at {start}",
+            f"once at {start_rendered}",
             id="start-once",
         ),
     ),
 )
-def test_schedule_formatter(value, expected_template):
-    expected = expected_template.format(start=start_rendered, end=end_rendered)
+def test_schedule_formatter(value, expected):
     assert ScheduleFormatter().render(value) == expected
+
+
+start_string = "1988-12-19T21:00:00+00:00"
+start_rendered = (
+    datetime.datetime.fromisoformat(start_string)
+    .astimezone()
+    .strftime("%Y-%m-%d %H:%M:%S")
+)
+next_run_string = "1992-06-07T10:18:00+00:00"
+next_run_rendered = (
+    datetime.datetime.fromisoformat(next_run_string)
+    .astimezone()
+    .strftime("%Y-%m-%d %H:%M:%S")
+)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        pytest.param([None, None], "This timer is no longer active", id="nulls"),
+        pytest.param(
+            [{"code": "awaiting_next_run"}, next_run_string],
+            f"Awaiting the next run, scheduled to occur at {next_run_rendered}",
+            id="awaiting-next",
+        ),
+        pytest.param(
+            [{"code": "awaiting_next_run"}, None],
+            "Awaiting the next run",
+            id="awaiting-no-next-run-time",
+        ),
+        pytest.param(
+            [{"code": "run_in_progress", "start_timestamp": start_string}, None],
+            f"Awaiting completion of the latest run, started at {start_rendered}",
+            id="in-progress",
+        ),
+        pytest.param(
+            [{"code": "run_in_progress"}, None],
+            "Awaiting completion of the latest run",
+            id="in-progress-no-start-time",
+        ),
+        pytest.param(
+            [{"code": "retrying", "start_timestamp": start_string}, None],
+            f"Retrying current run, started at {start_rendered}",
+            id="retrying",
+        ),
+        pytest.param(
+            [{"code": "retrying"}, None],
+            "Retrying current run",
+            id="retrying-no-start-time",
+        ),
+        pytest.param(
+            [{"code": "paused"}, None], "Paused, awaiting user action", id="paused"
+        ),
+        pytest.param(
+            [{"code": "UNKNOWN_CODE"}, None],
+            "<Unrecognized activity.code: UNKNOWN_CODE>",
+            id="unknown",
+        ),
+    ),
+)
+def test_activity_formatter(value, expected):
+    assert ActivityFormatter().format(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expect_error",
+    (
+        pytest.param({}, "bad activity values", id="non-list"),
+        pytest.param([], "bad activity values", id="empty-list"),
+        pytest.param([None], "bad activity values", id="singleton-list"),
+        pytest.param([None, None, None], "bad activity values", id="list-too-long"),
+        pytest.param(
+            ["paused", None], "malformed 'activity' field", id="non-dict-activity"
+        ),
+        pytest.param(
+            [{"code": 0}, None],
+            "cannot format activity when 'code' is not a string",
+            id="non-string-code",
+        ),
+    ),
+)
+def test_activity_formatter_rejects_unexpected_values(value, expect_error):
+    with pytest.raises(ValueError, match=expect_error):
+        ActivityFormatter().parse(value)
+
+
+@pytest.mark.parametrize(
+    "value, expect_result",
+    (
+        # these next tests check the behavior of the inner date formatter
+        pytest.param(
+            [{"code": "awaiting_next_run"}, 0],
+            "Awaiting the next run, scheduled to occur at 0",
+            id="non-string-next-run",
+        ),
+        pytest.param(
+            [{"code": "awaiting_next_run"}, "not okay"],
+            "Awaiting the next run, scheduled to occur at not okay",
+            id="non-iso-next-run",
+        ),
+        pytest.param(
+            [{"code": "retrying", "start_timestamp": 0}, None],
+            "Retrying current run, started at 0",
+            id="non-string-start-timestamp",
+        ),
+        pytest.param(
+            [{"code": "retrying", "start_timestamp": "not okay"}, None],
+            "Retrying current run, started at not okay",
+            id="non-iso-start-timestamp",
+        ),
+    ),
+)
+def test_activity_formatter_handling_of_invalid_inner_dates(value, expect_result):
+    # when one of the date fields is present but not a valid date, we get handling
+    # from inner date formatting, so we emit errors but still "format"
+    with pytest.warns(FormattingFailedWarning, match="Formatting failed"):
+        assert ActivityFormatter().format(value) == expect_result


### PR DESCRIPTION
~_This PR is a draft until the Timers API releases support for the `activity` field. If we were to release ahead of this feature being available, `Activity` would be inaccurately populated in outputs._~

This was initially held until the relevant feature was released.
It is now live and I've just done some manual testing to confirm that it works.

---

The ActivityFormatter takes two fields from a Timer document, the
`activity` and `next_run`, and formats the results into a string.

To pass data from parsing to rendering, an auxiliary datatype is defined
as part of the formatter: ParsedActivityInfo.

For datetime formatting, we use the existing date formatter, which
localizes times. This also handles malformed data gracefully with a
warning, as confirmed in the unit tests.

---

I've only included unit tests and a very small update to data for some of the functional tests.
More functional tests can be added on request, but I'd like to avoid recapitulating *all* of the unit tests -- feedback on this front is welcome.
