### PR TITLE
Do not pass 'skip_activation_check' to Transfer API

### DIFF
--- a/src/globus_cli/commands/delete.py
+++ b/src/globus_cli/commands/delete.py
@@ -131,7 +131,6 @@ def delete_command(
         local_user=local_user,
         additional_fields={
             "ignore_missing": ignore_missing,
-            "skip_activation_check": skip_activation_check,
             "interpret_globs": enable_globs,
             **notify,
         },

--- a/src/globus_cli/commands/rm.py
+++ b/src/globus_cli/commands/rm.py
@@ -88,7 +88,6 @@ def rm_command(
         local_user=local_user,
         additional_fields={
             "ignore_missing": ignore_missing,
-            "skip_activation_check": skip_activation_check,
             "interpret_globs": enable_globs,
             **notify,
         },

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -392,7 +392,6 @@ def transfer_command(
         deadline=deadline,
         skip_source_errors=skip_source_errors,
         fail_on_quota_errors=fail_on_quota_errors,
-        skip_activation_check=skip_activation_check,
         delete_destination_extra=(delete or delete_destination_extra),
         source_local_user=source_local_user,
         destination_local_user=destination_local_user,


### PR DESCRIPTION
This flag has been deprecated in both the SDK and CLI, and has no longer
has any effect when passed.

By setting it, we now trigger an SDK deprecation warning. Remove the
setting but still accept the flag (which is in its CLI deprecation
phase).
