### PR TITLE
Restrict to `click<8.3`

### DIFF
--- a/changelog.d/20250918_130817_sirosen_click_feature_bound.md
+++ b/changelog.d/20250918_130817_sirosen_click_feature_bound.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Fix incorrect bounds on the version of the `click` library. The upper bound
+  is now declared to exclude the next "feature release" of `click`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "globus-sdk==3.63.0",
-    "click>=8.1.4,<9",
+    "click>=8.1.4,<8.3",
     "jmespath==1.0.1",
     "packaging>=17.0",
     "typing_extensions>=4.0;python_version<'3.11'",


### PR DESCRIPTION
The 8.3 release is the next feature release, which we do not support yet.

Setting an upper bound will prevent broken installs.
