### PR TITLE
Update to support click>=8.3,<8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "globus-sdk==3.63.0",
-    "click>=8.1.4,<8.3",
+    "click>=8.1.4,<8.4",
     "jmespath==1.0.1",
     "packaging>=17.0",
     "typing_extensions>=4.0;python_version<'3.11'",
@@ -56,7 +56,7 @@ test = [
     "pytest>=7",
     "pytest-xdist<4",
     "pytest-timeout<3",
-    "click-type-test==1.1.0;python_version>='3.10'",
+    "click-type-test==1.3.0;python_version>='3.10'",
     "responses==0.25.8",
 ]
 test-mindeps = [


### PR DESCRIPTION
This requires a newer version of `click-type-test` to support the
internal `UNSET` sentinel in `click`.

No changes to the CLI itself appear to be needed.

No changelog should be needed, as we are maintaining a bound by click
feature release, here updated to 8.4. This means that the last changelog
(which did not mention the exact version used in our bounds) remains
accurate in describing coarse-grained changes to the project.
