### PR TITLE
Support filter rules in `timer create transfer`

### DIFF
--- a/changelog.d/20250918_163701_sirosen_transfer_timer_filter_rules.md
+++ b/changelog.d/20250918_163701_sirosen_transfer_timer_filter_rules.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Added support for `--include` and `--exclude` to the `globus timer create transfer` command.

--- a/src/globus_cli/commands/transfer.py
+++ b/src/globus_cli/commands/transfer.py
@@ -12,6 +12,7 @@ from globus_cli.parsing import (
     command,
     encrypt_data_option,
     fail_on_quota_errors_option,
+    filter_rule_options,
     mutex_option_group,
     preserve_timestamp_option,
     skip_source_errors_option,
@@ -136,6 +137,7 @@ fi
 @encrypt_data_option(aliases=("--encrypt",))
 @skip_source_errors_option
 @fail_on_quota_errors_option
+@filter_rule_options
 @click.option(
     "--delete",
     is_flag=True,
@@ -169,32 +171,6 @@ fi
     default=None,
     show_default=True,
     help="Specify an algorithm for --external-checksum or --verify-checksum",
-)
-@click.option(
-    "--include",
-    multiple=True,
-    show_default=True,
-    expose_value=False,  # this is combined into the filter_rules parameter
-    help=(
-        "Include files found with names that match the given pattern in "
-        'recursive transfers. Pattern may include "*", "?", or "[]" for Unix-style '
-        "globbing. This option can be given multiple times along with "
-        "--exclude to control which files are transferred, with earlier "
-        "options having priority."
-    ),
-)
-@click.option(
-    "--exclude",
-    multiple=True,
-    show_default=True,
-    expose_value=False,  # this is combined into the filter_rules parameter
-    help=(
-        "Exclude files found with names that match the given pattern in "
-        'recursive transfers. Pattern may include "*", "?", or "[]" for Unix-style '
-        "globbing. This option can be given multiple times along with "
-        "--include to control which files are transferred, with earlier "
-        "options having priority."
-    ),
 )
 @click.option(
     "--source-local-user",

--- a/src/globus_cli/parsing/__init__.py
+++ b/src/globus_cli/parsing/__init__.py
@@ -38,6 +38,7 @@ from .shared_options.id_args import (
 from .shared_options.transfer_task_options import (
     encrypt_data_option,
     fail_on_quota_errors_option,
+    filter_rule_options,
     preserve_timestamp_option,
     skip_source_errors_option,
     sync_level_option,
@@ -84,6 +85,7 @@ __all__ = [
     "sync_level_option",
     "task_notify_option",
     "fail_on_quota_errors_option",
+    "filter_rule_options",
     "encrypt_data_option",
     "preserve_timestamp_option",
     "skip_source_errors_option",

--- a/src/globus_cli/parsing/shared_options/transfer_task_options.py
+++ b/src/globus_cli/parsing/shared_options/transfer_task_options.py
@@ -125,3 +125,46 @@ def encrypt_data_option(*, aliases: tuple[str, ...] = ()) -> t.Callable[[C], C]:
         )(f)
 
     return decorator
+
+
+def filter_rule_options(f: C) -> C:
+    """
+    Use of this decorator must be used with
+
+        opts_to_combine={
+            "include": "filter_rules",
+            "exclude": "filter_rules",
+        }
+
+    in order to produce correct `filter_rules` list.
+
+    The order of `--include` and `--exclude` determines behavior, and we have to
+    modify parsing to get that ordering information.
+    """
+    f = click.option(
+        "--include",
+        multiple=True,
+        show_default=True,
+        expose_value=False,  # this is combined into the filter_rules parameter
+        help=(
+            "Include files found with names that match the given pattern in "
+            'recursive transfers. Pattern may include "*", "?", or "[]" for Unix-style '
+            "globbing. This option can be given multiple times along with "
+            "--exclude to control which files are transferred, with earlier "
+            "options having priority."
+        ),
+    )(f)
+    f = click.option(
+        "--exclude",
+        multiple=True,
+        show_default=True,
+        expose_value=False,  # this is combined into the filter_rules parameter
+        help=(
+            "Exclude files found with names that match the given pattern in "
+            'recursive transfers. Pattern may include "*", "?", or "[]" for Unix-style '
+            "globbing. This option can be given multiple times along with "
+            "--include to control which files are transferred, with earlier "
+            "options having priority."
+        ),
+    )(f)
+    return f


### PR DESCRIPTION
- Move the definition of `--include/--exclude` out of `globus transfer` and into shared options. It documents the requirement to use `opts_to_combine`, which cannot be trivially encoded into the decorator.
- Add `--include/--exclude` to the `globus timer create transfer`command.
  -  Replicate the logic there for adding filter rules.
  -  Do not replicate the logic for checking filter rules against `--recursive` usages. Now that Transfer supports implicit recursive settings for directory items, it's not clear that this restriction is something we want to keep.
-  Add a test for the new behavior.