### PR TITLE
Remove the deprecated Flows service scope `run`

### DIFF
--- a/changelog.d/20250923_115826_kurtmckee_address_deprecated_flow_scope.md
+++ b/changelog.d/20250923_115826_kurtmckee_address_deprecated_flow_scope.md
@@ -1,0 +1,4 @@
+### Other
+
+* Remove the deprecated Flows service scope `run`
+  from the default list of scopes requested when logging into the CLI.

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -94,7 +94,6 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
             "scopes": [
                 FlowsScopes.manage_flows,
                 FlowsScopes.view_flows,
-                FlowsScopes.run,
                 FlowsScopes.run_status,
                 FlowsScopes.run_manage,
             ],


### PR DESCRIPTION
This addresses a deprecated scope appearing when logging into the CLI for the first time.

The `run_manage` scope is already in the list, so the recommended resolution ("use `run_manage`") is already in place.

> <img width="704" height="115" alt="image" src="https://github.com/user-attachments/assets/3b69d33a-56c8-4b17-a489-9b7908c655f1" />


### Other

* Remove the deprecated Flows service scope `run`
  from the default list of scopes requested when logging into the CLI.
