### PR TITLE
Added flow timer creation

### DIFF
--- a/changelog.d/20251001_095617_derek_sc_38839_globus_timer_create_flow.md
+++ b/changelog.d/20251001_095617_derek_sc_38839_globus_timer_create_flow.md
@@ -1,0 +1,5 @@
+
+### Enhancements
+
+*   Added a new command: `globus timer create flow` to support scheduling recurring
+    flow invocations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "globus-sdk==3.63.0",
+    "globus-sdk==3.65.0",
     "click>=8.1.4,<8.4",
     "jmespath==1.0.1",
     "packaging>=17.0",

--- a/src/globus_cli/commands/flows/start.py
+++ b/src/globus_cli/commands/flows/start.py
@@ -9,7 +9,13 @@ import click
 
 from globus_cli._click_compat import shim_get_metavar
 from globus_cli.login_manager import LoginManager
-from globus_cli.parsing import JSONStringOrFile, ParsedJSONData, command, flow_id_arg
+from globus_cli.parsing import (
+    JSONStringOrFile,
+    ParsedJSONData,
+    command,
+    flow_id_arg,
+    flow_input_document_option,
+)
 from globus_cli.termio import Field, display, formatters
 from globus_cli.types import JsonValue
 
@@ -138,29 +144,7 @@ class ActivityNotificationPolicyType(JSONStringOrFile):
 
 @command("start", short_help="Start a flow.")
 @flow_id_arg
-@click.option(
-    "--input",
-    "input_document",
-    type=JSONStringOrFile(),
-    help="""
-        The JSON input parameters used to start the flow.
-
-        The input document may be specified inline,
-        or it may be a path to a JSON file, prefixed with "file:".
-
-        Example: Inline JSON:
-
-        \b
-            --input '{"src": "~/source"}'
-
-        Example: Path to JSON file:
-
-        \b
-            --input parameters.json
-
-        If unspecified, the default is an empty JSON object ('{}').
-    """,
-)
+@flow_input_document_option
 @click.option(
     "--label",
     type=str,

--- a/src/globus_cli/commands/login.py
+++ b/src/globus_cli/commands/login.py
@@ -162,7 +162,7 @@ class TimerResourceType(click.ParamType):
     "timer_targets",
     "--timer",
     type=TimerResourceType(),
-    help="TODO - Better Help Text",
+    help="A target resource in the form flow:<flow_id>. May be given multiple times.",
     multiple=True,
 )
 def login_command(

--- a/src/globus_cli/commands/login.py
+++ b/src/globus_cli/commands/login.py
@@ -5,7 +5,11 @@ import uuid
 
 import click
 from click import Context, Parameter
-from globus_sdk.scopes import GCSCollectionScopeBuilder, GCSEndpointScopeBuilder
+from globus_sdk.scopes import (
+    GCSCollectionScopeBuilder,
+    GCSEndpointScopeBuilder,
+    TimersScopes,
+)
 from globus_sdk.services.flows import SpecificFlowClient
 
 from globus_cli._click_compat import shim_get_metavar
@@ -93,6 +97,34 @@ class GCSEndpointType(click.ParamType):
         return endpoint_id if not collection_id else (endpoint_id, collection_id)
 
 
+class TimerResourceType(click.ParamType):
+    name = "TIMER_RESOURCE"
+
+    @shim_get_metavar
+    def get_metavar(self, param: click.Parameter, ctx: click.Context) -> str:
+        return "flow:<flow_id>"
+
+    def convert(
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
+    ) -> tuple[t.Literal["flow"], uuid.UUID]:
+        if not isinstance(value, str):
+            self.fail(f"Invalid Timer Resource type: {type(value)}", param, ctx)
+
+        parts = value.split(":")
+        if len(parts) != 2 or parts[0] != "flow":
+            msg = "Invalid resource specification. Please use the form flow:<flow_id>"
+            self.fail(
+                msg,
+                param,
+                ctx,
+            )
+
+        try:
+            return parts[0], uuid.UUID(parts[1])
+        except ValueError:
+            self.fail(f"Flow ID ({parts[1]}) is not a valid UUID", param, ctx)
+
+
 @command(
     "login",
     short_help="Log into Globus to get credentials for the Globus CLI.",
@@ -126,11 +158,19 @@ class GCSEndpointType(click.ParamType):
     """,
     multiple=True,
 )
+@click.option(
+    "timer_targets",
+    "--timer",
+    type=TimerResourceType(),
+    help="TODO - Better Help Text",
+    multiple=True,
+)
 def login_command(
     no_local_server: bool,
     force: bool,
     gcs_servers: tuple[t.Union[uuid.UUID, tuple[uuid.UUID, uuid.UUID]], ...],
     flow_ids: tuple[uuid.UUID, ...],
+    timer_targets: tuple[tuple[t.Literal["flow"], str], ...],
 ) -> None:
     """
     Get credentials for the Globus CLI.
@@ -181,6 +221,11 @@ def login_command(
         flow_scope = SpecificFlowClient(flow_id).scopes
         assert flow_scope is not None
         manager.add_requirement(flow_scope.resource_server, [flow_scope.user])
+
+    for resource_type, resource_id in timer_targets:
+        assert resource_type == "flow"
+        scope = f"{TimersScopes.timer}[{SpecificFlowClient(resource_id).scopes.user}]"
+        manager.add_requirement(TimersScopes.resource_server, [scope])
 
     # if not forcing, stop if user already logged in
     if not force and manager.is_logged_in():

--- a/src/globus_cli/commands/timer/create/__init__.py
+++ b/src/globus_cli/commands/timer/create/__init__.py
@@ -4,7 +4,10 @@ from globus_cli.parsing import group
 @group(
     "create",
     short_help="Create a timer.",
-    lazy_subcommands={"transfer": (".transfer", "transfer_command")},
+    lazy_subcommands={
+        "transfer": (".transfer", "transfer_command"),
+        "flow": (".flow", "flow_command"),
+    },
 )
 def create_command() -> None:
     pass

--- a/src/globus_cli/commands/timer/create/_common.py
+++ b/src/globus_cli/commands/timer/create/_common.py
@@ -8,9 +8,8 @@ import globus_sdk
 from globus_cli.commands.timer._common import DATETIME_FORMATS, ScheduleFormatter
 from globus_cli.parsing import TimedeltaType, mutex_option_group
 from globus_cli.termio import Field, formatters
-from globus_cli.types import AnyCommand
 
-C = t.TypeVar("C", bound=AnyCommand)
+R = t.TypeVar("R")
 
 
 CREATE_FORMAT_FIELDS = [
@@ -33,7 +32,7 @@ TimerSchedule: t.TypeAlias = t.Union[
 ]
 
 
-def timer_schedule_options(f: C) -> C:
+def timer_schedule_options(f: t.Callable[..., R]) -> t.Callable[..., R]:
     """
     A decorator which register "schedule" related timer options on a command.
 
@@ -81,13 +80,13 @@ def timer_schedule_options(f: C) -> C:
     @mutex_option_group("--stop-after-date", "--stop-after-runs")
     @wraps(f)
     def wrapper(
-        *args,
+        *args: t.Any,
         start: datetime | None,
         interval: int | None,
         stop_after_date: datetime | None,
         stop_after_runs: int | None,
-        **kwargs,
-    ) -> t.Callable[[C], C]:
+        **kwargs: t.Any,
+    ) -> R:
         schedule = _create_schedule(start, interval, stop_after_date, stop_after_runs)
 
         return f(*args, schedule=schedule, **kwargs)

--- a/src/globus_cli/commands/timer/create/_common.py
+++ b/src/globus_cli/commands/timer/create/_common.py
@@ -1,0 +1,145 @@
+import typing as t
+from datetime import datetime
+from functools import wraps
+
+import click
+import globus_sdk
+
+from globus_cli.commands.timer._common import DATETIME_FORMATS, ScheduleFormatter
+from globus_cli.parsing import TimedeltaType, mutex_option_group
+from globus_cli.termio import Field, formatters
+from globus_cli.types import AnyCommand
+
+C = t.TypeVar("C", bound=AnyCommand)
+
+
+CREATE_FORMAT_FIELDS = [
+    Field("Timer ID", "job_id"),
+    Field("Name", "name"),
+    Field("Type", "timer_type"),
+    Field("Submitted At", "submitted_at", formatter=formatters.Date),
+    Field("Status", "status"),
+    Field("Last Run", "last_ran_at", formatter=formatters.Date),
+    Field("Next Run", "next_run", formatter=formatters.Date),
+    Field("Schedule", "schedule", formatter=ScheduleFormatter()),
+    Field("Number of Runs", "number_of_runs"),
+    Field("Number of Timer Errors", "number_of_errors"),
+]
+
+
+TimerSchedule: t.TypeAlias = t.Union[
+    globus_sdk.RecurringTimerSchedule,
+    globus_sdk.OnceTimerSchedule,
+]
+
+
+def timer_schedule_options(f: C) -> C:
+    """
+    A decorator which register "schedule" related timer options on a command.
+
+    The options registered are:
+        --start
+        --interval
+        --stop-after-date
+        --stop-after-runs
+
+    While these are registered and enforced in specific ways, the handler function
+    receives a single `schedule: TimerSchedule` loaded argument.
+
+    Usage:
+    >>> @timer_schedule_options
+    >>> def my_great_timer_command(schedule: TimerSchedule):
+    >>>     ...
+    """
+
+    @click.option(
+        "--start",
+        type=click.DateTime(formats=DATETIME_FORMATS),
+        help="Start time for the timer. Defaults to current time.",
+    )
+    @click.option(
+        "--interval",
+        type=TimedeltaType(),
+        help=(
+            """\
+            Interval at which the timer should run. Expressed in weeks, days, hours,
+            minutes, and seconds. Use 'w', 'd', 'h', 'm', and 's' as suffixes to
+            specify. e.g. '1h30m', '500s', '10d'
+            """
+        ),
+    )
+    @click.option(
+        "--stop-after-date",
+        type=click.DateTime(formats=DATETIME_FORMATS),
+        help="Stop running the transfer after this date.",
+    )
+    @click.option(
+        "--stop-after-runs",
+        type=click.IntRange(min=1),
+        help="Stop running the transfer after this number of runs have happened.",
+    )
+    @mutex_option_group("--stop-after-date", "--stop-after-runs")
+    @wraps(f)
+    def wrapper(
+        *args,
+        start: datetime | None,
+        interval: int | None,
+        stop_after_date: datetime | None,
+        stop_after_runs: int | None,
+        **kwargs,
+    ) -> t.Callable[[C], C]:
+        schedule = _create_schedule(start, interval, stop_after_date, stop_after_runs)
+
+        return f(*args, schedule=schedule, **kwargs)
+
+    return wrapper
+
+
+def _create_schedule(
+    start: datetime | None,
+    interval: int | None,
+    stop_after_date: datetime | None,
+    stop_after_runs: int | None,
+) -> TimerSchedule:
+    """
+    Create a composite TimerSchedule object from user input.
+
+    :raises click.UsageError: if the input is invalid/incoherent in some way.
+    :returns: Either a RecurringTimerSchedule or a OnceTimerSchedule
+    """
+    start_ = _to_local_tz(start)
+    if stop_after_runs == 1:
+        if interval is not None:
+            raise click.UsageError("`--interval` is invalid with `--stop-after-runs=1`")
+        return globus_sdk.OnceTimerSchedule(datetime=start_)
+    else:
+        if interval is None:
+            raise click.UsageError(
+                "`--interval` is required unless `--stop-after-runs=1`"
+            )
+
+        end: dict[str, t.Any] | globus_sdk.MissingType = globus_sdk.MISSING
+        # reminder: these two cases are mutex
+        if stop_after_runs is not None:
+            end = {
+                "condition": "iterations",
+                "count": stop_after_runs,
+            }
+        elif stop_after_date is not None:
+            end = {
+                "condition": "time",
+                "datetime": _to_local_tz(stop_after_date),
+            }
+
+        return globus_sdk.RecurringTimerSchedule(
+            interval_seconds=interval, end=end, start=start_
+        )
+
+
+def _to_local_tz(start: datetime | None) -> datetime | globus_sdk.utils.MissingType:
+    if start is None:
+        return globus_sdk.MISSING
+
+    # set the timezone to local system time if the timezone input is not aware
+    start_with_tz = start.astimezone() if start.tzinfo is None else start
+    return start_with_tz

--- a/src/globus_cli/commands/timer/create/_common.py
+++ b/src/globus_cli/commands/timer/create/_common.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import sys
 import typing as t
 from datetime import datetime
 from functools import wraps
@@ -8,6 +11,11 @@ import globus_sdk
 from globus_cli.commands.timer._common import DATETIME_FORMATS, ScheduleFormatter
 from globus_cli.parsing import TimedeltaType, mutex_option_group
 from globus_cli.termio import Field, formatters
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 R = t.TypeVar("R")
 
@@ -26,7 +34,7 @@ CREATE_FORMAT_FIELDS = [
 ]
 
 
-TimerSchedule: t.TypeAlias = t.Union[
+TimerSchedule: TypeAlias = t.Union[
     globus_sdk.RecurringTimerSchedule,
     globus_sdk.OnceTimerSchedule,
 ]

--- a/src/globus_cli/commands/timer/create/flow.py
+++ b/src/globus_cli/commands/timer/create/flow.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import datetime
+import textwrap
+import uuid
+
+import click
+import globus_sdk
+from globus_sdk.scopes import Scope, SpecificFlowScopeBuilder, TimersScopes
+
+from globus_cli.login_manager import LoginManager, is_client_login
+from globus_cli.parsing import (
+    ParsedJSONData,
+    command,
+    flow_id_arg,
+    flow_input_document_option,
+)
+from globus_cli.termio import display
+
+from ._common import CREATE_FORMAT_FIELDS, TimerSchedule, timer_schedule_options
+
+
+@command("flow", short_help="Create a recurring flow timer.")
+@flow_id_arg
+@flow_input_document_option
+@click.option("--name", type=str, help="A name for the timer.")
+@timer_schedule_options
+@LoginManager.requires_login("auth", "flows", "timers")
+def flow_command(
+    login_manager: LoginManager,
+    *,
+    flow_id: uuid.UUID,
+    input_document: ParsedJSONData | None,
+    name: str | None,
+    schedule: TimerSchedule,
+) -> None:
+    """
+    Create a timer that runs a flow on a recurring schedule.
+
+    \b\bExamples (assume the year is 1970, when time began):
+
+    Create a timer which runs a flow daily for the next 10 days.
+
+        globus timer create flow $flow_id --interval 1d --stop-after-runs 10
+
+    Create a timer which runs a flow every week for the rest of the year.
+
+        globus timer create flow $flow_id --interval 7d --stop-after-date 1970-12-31
+
+    Create a timer which runs a flow once on Christmas.
+
+        globus timer create flow $flow_id --start 1970-12-25 --stop-after-runs 1
+    """
+    if name is None:
+        now = datetime.datetime.now().isoformat()
+        name = f"CLI Created Timer [{now}]"
+
+    verify_flow_exists(login_manager, flow_id)
+    verify_requester_has_required_consents(login_manager, flow_id)
+
+    timer_doc = globus_sdk.FlowTimer(
+        flow_id=flow_id,
+        name=name,
+        schedule=schedule,
+        body={"body": input_document or {}},
+    )
+    response = login_manager.get_timer_client().create_timer(timer_doc)
+
+    display(response["timer"], text_mode=display.RECORD, fields=CREATE_FORMAT_FIELDS)
+
+
+def verify_flow_exists(login_manager: LoginManager, flow_id: uuid.UUID) -> None:
+    """
+    Verify that the flow with the given ID exists.
+
+    If it does not exist, print an error message and exit.
+    """
+    try:
+        flow_client = login_manager.get_flows_client()
+        flow_client.get_flow(flow_id)
+    except globus_sdk.GlobusAPIError as e:
+        if e.http_status == 404:
+            click.echo(f"Error: No flow discovered with id '{flow_id}'.", err=True)
+            click.echo("Please verify that you have access to this flow.", err=True)
+            click.get_current_context().exit(2)
+        raise
+
+
+def verify_requester_has_required_consents(
+    login_manager: LoginManager, flow_id: uuid.UUID
+) -> None:
+    """
+    Verify that the request has the proper consents to create a flow timer.
+
+    If an additional consents are required, print instructions and exit.
+    """
+    flow_scope = Scope(SpecificFlowScopeBuilder(str(flow_id)).user)
+    required_scope = Scope(TimersScopes.timer, dependencies=[flow_scope])
+
+    if is_client_login():
+        # Client consents don't require interactive logins.
+        login_manager.add_requirement(TimersScopes.resource_server, [required_scope])
+        return
+
+    requester_id = login_manager.get_current_identity_id()
+    consents = login_manager.get_auth_client().get_consents(requester_id).to_forest()
+
+    if not consents.meets_scope_requirements(required_scope):
+        click.echo(
+            textwrap.dedent(
+                f"""
+                Warning: Flow timer creation requires additional consent.
+                Please resolve with the following command, then rerun your original one:
+
+                    globus login --timer flow:{flow_id}
+                """
+            )
+        )
+        click.get_current_context().exit(4)

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -71,7 +71,6 @@ e.g. '1h30m', '500s', '10d'
     type=str,
     help="A label for the Transfer tasks submitted by the timer.",
 )
-@mutex_option_group("--stop-after-date", "--stop-after-runs")
 @click.option(
     "--delete",
     is_flag=True,
@@ -268,16 +267,6 @@ def transfer_command(
     body = globus_sdk.TransferTimer(name=name, schedule=schedule, body=transfer_data)
     response = timer_client.create_timer(body)
     display(response["timer"], text_mode=display.RECORD, fields=CREATE_FORMAT_FIELDS)
-
-
-def resolve_optional_local_time(
-    start: datetime.datetime | None,
-) -> datetime.datetime | globus_sdk.utils.MissingType:
-    if start is None:
-        return globus_sdk.MISSING
-    # set the timezone to local system time if the timezone input is not aware
-    start_with_tz = start.astimezone() if start.tzinfo is None else start
-    return start_with_tz
 
 
 def _derive_needed_scopes(

--- a/src/globus_cli/commands/timer/create/transfer.py
+++ b/src/globus_cli/commands/timer/create/transfer.py
@@ -12,7 +12,6 @@ from globus_cli.endpointish import Endpointish
 from globus_cli.login_manager import LoginManager, is_client_login
 from globus_cli.parsing import (
     ENDPOINT_PLUS_OPTPATH,
-    TimedeltaType,
     command,
     encrypt_data_option,
     fail_on_quota_errors_option,
@@ -26,26 +25,12 @@ from globus_cli.parsing import (
     transfer_recursive_option,
     verify_checksum_option,
 )
-from globus_cli.termio import Field, display, formatters
+from globus_cli.termio import display
 
-from .._common import DATETIME_FORMATS, ScheduleFormatter
+from ._common import CREATE_FORMAT_FIELDS, TimerSchedule, timer_schedule_options
 
 if t.TYPE_CHECKING:
     from globus_cli.services.auth import CustomAuthClient
-
-
-FORMAT_FIELDS = [
-    Field("Timer ID", "job_id"),
-    Field("Name", "name"),
-    Field("Type", "timer_type"),
-    Field("Submitted At", "submitted_at", formatter=formatters.Date),
-    Field("Status", "status"),
-    Field("Last Run", "last_ran_at", formatter=formatters.Date),
-    Field("Next Run", "next_run", formatter=formatters.Date),
-    Field("Schedule", "schedule", formatter=ScheduleFormatter()),
-    Field("Number of Runs", "number_of_runs"),
-    Field("Number of Timer Errors", "number_of_errors"),
-]
 
 
 INTERVAL_HELP = """\
@@ -79,31 +64,12 @@ e.g. '1h30m', '500s', '10d'
 @fail_on_quota_errors_option
 @task_notify_option
 @filter_rule_options
-@click.option(
-    "--start",
-    type=click.DateTime(formats=DATETIME_FORMATS),
-    help="Start time for the timer. Defaults to current time.",
-)
-@click.option(
-    "--interval",
-    type=TimedeltaType(),
-    help=INTERVAL_HELP,
-)
 @click.option("--name", type=str, help="A name for the timer.")
+@timer_schedule_options
 @click.option(
     "--label",
     type=str,
     help="A label for the Transfer tasks submitted by the timer.",
-)
-@click.option(
-    "--stop-after-date",
-    type=click.DateTime(formats=DATETIME_FORMATS),
-    help="Stop running the transfer after this date.",
-)
-@click.option(
-    "--stop-after-runs",
-    type=click.IntRange(min=1),
-    help="Stop running the transfer after this number of runs have happened.",
 )
 @mutex_option_group("--stop-after-date", "--stop-after-runs")
 @click.option(
@@ -131,15 +97,12 @@ def transfer_command(
     login_manager: LoginManager,
     *,
     name: str | None,
+    schedule: TimerSchedule,
     source: tuple[uuid.UUID, str | None],
     destination: tuple[uuid.UUID, str | None],
     batch: t.TextIO | None,
     recursive: bool | None,
-    start: datetime.datetime | None,
-    interval: int | None,
     label: str | None,
-    stop_after_date: datetime.datetime | None,
-    stop_after_runs: int | None,
     delete: bool,
     delete_destination_extra: bool,
     sync_level: t.Literal["exists", "size", "mtime", "checksum"] | None,
@@ -219,37 +182,6 @@ def transfer_command(
     if (cmd_source_path is None or cmd_dest_path is None) and (not batch):
         raise click.UsageError(
             "Transfer requires either `SOURCE_PATH` and `DEST_PATH` or `--batch`"
-        )
-
-    # Interval must be null iff the timer is 'once', i.e. stop-after-runs == 1.
-    # and it must be non-null if the timer is 'recurring'
-    schedule: globus_sdk.RecurringTimerSchedule | globus_sdk.OnceTimerSchedule
-    start_ = resolve_optional_local_time(start)
-    if stop_after_runs == 1:
-        if interval is not None:
-            raise click.UsageError("`--interval` is invalid with `--stop-after-runs=1`")
-        schedule = globus_sdk.OnceTimerSchedule(datetime=start_)
-    else:
-        if interval is None:
-            raise click.UsageError(
-                "`--interval` is required unless `--stop-after-runs=1`"
-            )
-
-        end: dict[str, t.Any] | globus_sdk.MissingType = globus_sdk.MISSING
-        # reminder: these two cases are mutex
-        if stop_after_runs is not None:
-            end = {
-                "condition": "iterations",
-                "count": stop_after_runs,
-            }
-        elif stop_after_date is not None:
-            end = {
-                "condition": "time",
-                "datetime": resolve_optional_local_time(stop_after_date),
-            }
-
-        schedule = globus_sdk.RecurringTimerSchedule(
-            interval_seconds=interval, end=end, start=start_
         )
 
     # default name, dynamically computed from the current time
@@ -335,7 +267,7 @@ def transfer_command(
     timer_client = login_manager.get_timer_client()
     body = globus_sdk.TransferTimer(name=name, schedule=schedule, body=transfer_data)
     response = timer_client.create_timer(body)
-    display(response["timer"], text_mode=display.RECORD, fields=FORMAT_FIELDS)
+    display(response["timer"], text_mode=display.RECORD, fields=CREATE_FORMAT_FIELDS)
 
 
 def resolve_optional_local_time(

--- a/src/globus_cli/parsing/__init__.py
+++ b/src/globus_cli/parsing/__init__.py
@@ -29,6 +29,7 @@ from .shared_options import (
     task_submission_options,
 )
 from .shared_options.endpointish import endpointish_params
+from .shared_options.flow_options import flow_input_document_option
 from .shared_options.id_args import (
     collection_id_arg,
     endpoint_id_arg,
@@ -75,6 +76,7 @@ __all__ = [
     "endpoint_id_arg",
     "flow_id_arg",
     "run_id_arg",
+    "flow_input_document_option",
     "task_submission_options",
     "delete_and_rm_options",
     "synchronous_task_wait_options",

--- a/src/globus_cli/parsing/shared_options/flow_options.py
+++ b/src/globus_cli/parsing/shared_options/flow_options.py
@@ -1,0 +1,27 @@
+import click
+
+from globus_cli.parsing import JSONStringOrFile
+
+flow_input_document_option = click.option(
+    "--input",
+    "input_document",
+    type=JSONStringOrFile(),
+    help="""
+        The JSON input parameters used to start the flow.
+
+        The input document may be specified inline,
+        or it may be a path to a JSON file, prefixed with "file:".
+
+        Example: Inline JSON:
+
+        \b
+            --input '{"src": "~/source"}'
+
+        Example: Path to JSON file:
+
+        \b
+            --input parameters.json
+
+        If unspecified, the default is an empty JSON object ('{}').
+    """,
+)

--- a/tests/functional/timer/test_create_flow_timer.py
+++ b/tests/functional/timer/test_create_flow_timer.py
@@ -1,0 +1,61 @@
+import uuid
+
+import globus_sdk
+from globus_sdk._testing import RegisteredResponse, load_response
+from globus_sdk.scopes import SpecificFlowScopeBuilder
+
+
+def test_create_flow_timer(run_line, userinfo_mocker, logged_in_user_id):
+    flow_id = load_response(globus_sdk.FlowsClient.get_flow).metadata["flow_id"]
+    load_response(globus_sdk.TimersClient.create_timer, case="flow_timer_success")
+
+    userinfo_meta = userinfo_mocker.configure_unlinked(sub=logged_in_user_id).metadata
+    identity_id = userinfo_meta["sub"]
+    setup_timer_consent_tree_response(identity_id, flow_id)
+
+    result = run_line(f"globus timer create flow {flow_id} --stop-after-runs=1")
+
+    for field in ("Timer ID", "Type", "Number of Runs", "Schedule"):
+        assert f"{field}:" in result.stdout
+
+
+def setup_timer_consent_tree_response(identity_id, *flow_ids):
+    _dummy_consent_fields = {
+        "allows_refresh": True,
+        "atomically_revocable": False,
+        "auto_approved": False,
+        "client": str(uuid.UUID(int=1)),
+        "created": "1970-01-01T00:00:00.000000+00:00",
+        "effective_identity": str(uuid.UUID(int=2)),
+        "last_used": "1970-01-01T00:00:00.000000+00:00",
+        "status": "approved",
+        "updated": "1970-01-01T00:00:00.000000+00:00",
+    }
+    load_response(
+        RegisteredResponse(
+            service="auth",
+            path=f"/v2/api/identities/{identity_id}/consents",
+            method="GET",
+            json={
+                "consents": [
+                    {
+                        "scope_name": globus_sdk.TimersClient.scopes.timer,
+                        "scope": str(uuid.uuid1()),
+                        "dependency_path": [200],
+                        "id": 200,
+                        **_dummy_consent_fields,
+                    },
+                ]
+                + [
+                    {
+                        "scope_name": SpecificFlowScopeBuilder(flow_id).user,
+                        "scope": str(uuid.uuid1()),
+                        "dependency_path": [200, 2000 + idx],
+                        "id": 2000 + idx,
+                        **_dummy_consent_fields,
+                    }
+                    for idx, flow_id in enumerate(flow_ids)
+                ]
+            },
+        )
+    )

--- a/tests/unit/test_click_annotations.py
+++ b/tests/unit/test_click_annotations.py
@@ -11,6 +11,8 @@ click_type_test = pytest.importorskip(
 )
 
 _SKIP_MODULES = (
+    "globus_cli.commands.timer.create.flow",
+    "globus_cli.commands.timer.create.transfer",
     "globus_cli.commands.endpoint.permission.create",
     "globus_cli.commands.endpoint.role.create",
 )

--- a/tests/unit/test_timezone_handling.py
+++ b/tests/unit/test_timezone_handling.py
@@ -2,26 +2,26 @@ import datetime
 
 import globus_sdk
 
-from globus_cli.commands.timer.create.transfer import resolve_optional_local_time
+from globus_cli.commands.timer.create._common import _to_local_tz
 
 EST = datetime.timezone(datetime.timedelta(hours=-5), name="EST")
 
 
-def test_resolve_optional_local_time_converts_none_to_missing():
-    value = resolve_optional_local_time(None)
+def test_timer_create_local_tz_conversion_of_missing():
+    value = _to_local_tz(None)
     assert value is globus_sdk.MISSING
 
 
-def test_resolve_optional_local_time_preserves_existing_tzinfo():
+def test_timer_create_local_tz_conversion_preserves_existing_tzinfo():
     original = datetime.datetime.now().astimezone(EST)
-    resolved = resolve_optional_local_time(original)
+    resolved = _to_local_tz(original)
     assert resolved.tzinfo == EST
     assert resolved == original
 
 
-def test_resolve_optional_local_time_adds_tzinfo_if_missing():
+def test_timer_create_local_tz_conversion_adds_tzinfo_if_missing():
     original = datetime.datetime.now()
-    resolved = resolve_optional_local_time(original)
+    resolved = _to_local_tz(original)
     assert resolved.tzinfo is not None
 
     # but the true time represented remains the same if normalized to a given timezone


### PR DESCRIPTION
## Additions
* Added flow timer creation under the command `globus timer create flow`
  * To support the per-flow consent required by this, added a new flag `globus login --timer flow:<flow_id>` which flow timer creation instructs to use.


## Note
This code was built against https://github.com/globus/globus-sdk-python/pull/1311 and thus won't succeed build/testing with the globus-sdk main branch.

Merge will need to wait until that merges/releases.

## Demo Usage

<details>
<summary>Successful Timer Creation</summary>

<img width="1000" height="765" alt="image" src="https://github.com/user-attachments/assets/748f1f15-e400-48b5-b75f-5c49f918632e" />

</details>

<details>
<summary>Rejected Timer Creation</summary>
<img width="881" height="163" alt="image" src="https://github.com/user-attachments/assets/b41fe376-4346-408b-a580-3e29946de436" />

</details>

