### PR TITLE
Stop testing against SDK's `main` branch in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,8 +25,6 @@ jobs:
               - "3.13"
             tox-post-environments:
               - "py3.9-mindeps"
-              - "py3.9-sdkmain"
-              - "py3.13-sdkmain"
             cache-key-prefix: "linux"
             cache-key-hash-files:
               - "pyproject.toml"


### PR DESCRIPTION
Exactly what it says on the tin.