### PR TITLE
Include always required scopes in computed login scopes

### DIFF
--- a/src/globus_cli/login_manager/manager.py
+++ b/src/globus_cli/login_manager/manager.py
@@ -240,6 +240,10 @@ class LoginManager:
             computed_scopes.extend(defaults)
             if additional_scopes:
                 computed_scopes.extend(additional_scopes)
+
+        for s in self.always_required_scopes:
+            if s not in computed_scopes:
+                computed_scopes.append(s)
         return computed_scopes
 
     def assert_logins(


### PR DESCRIPTION
### Context
A session consent like so:
```
globus session consent 'https://auth.globus.org/scopes/26886a77-fa74-4dd0-8432-57f6ca722cab/flow_26886a77_fa74_4dd0_8432_57f6ca722cab_user[*urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/8062693f-f8c2-46be-86d0-de651a974ff3/data_access]]'
```
Will currently result in a `KeyError: 'id_token'` originating from [this](https://github.com/globus/globus-cli/blob/74b066afdb67b2ae9d44c9a29ce8f40f3bee2fc2/src/globus_cli/login_manager/auth_flows.py#L122) line, as the `openid` scope is needed in order to get the id token.

### Changes
- Updates `_compute_login_scopes` to always include the login manager's `always_required_scopes` in returned computed scopes. 