### PR TITLE
Address example use of sh variable

### DIFF
--- a/src/globus_cli/commands/mkdir.py
+++ b/src/globus_cli/commands/mkdir.py
@@ -17,8 +17,8 @@ from globus_cli.termio import display
 
 [source,bash]
 ----
-$ ep_id=aa752cea-8222-5bc8-acd9-555b090c0ccb
-$ mkdir ep_id:~/testfolder
+$ EP_ID=aa752cea-8222-5bc8-acd9-555b090c0ccb
+$ mkdir $EP_ID:~/testfolder
 ----
 """,
 )


### PR DESCRIPTION
The main detail is to use a dollar character (`$`), but also make use capitals for the example, as many shell scripts do.