### PR TITLE
add Domain field to endpoint search and show

### DIFF
--- a/changelog.d/20251205_152802_aaschaer_domain.md
+++ b/changelog.d/20251205_152802_aaschaer_domain.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Add Domain field to default output of `globus endpoint search` and `globus endpoint show`

--- a/src/globus_cli/commands/endpoint/show.py
+++ b/src/globus_cli/commands/endpoint/show.py
@@ -5,12 +5,14 @@ import click
 from globus_cli.endpointish import Endpointish
 from globus_cli.login_manager import LoginManager
 from globus_cli.parsing import command, endpoint_id_arg
+from globus_cli.services.transfer import DOMAIN_FIELD
 from globus_cli.termio import Field, display, formatters
 
 STANDARD_FIELDS = [
     Field("Display Name", "display_name"),
     Field("ID", "id"),
     Field("Owner", "owner_string"),
+    DOMAIN_FIELD,
     Field("Description", "description", wrap_enabled=True),
     Field("Shareable", "shareable"),
     Field("Keywords", "keywords"),

--- a/src/globus_cli/services/transfer/__init__.py
+++ b/src/globus_cli/services/transfer/__init__.py
@@ -18,15 +18,46 @@ class _NameFormatter(formatters.StrFormatter):
         return str(value[0] or value[1])
 
 
+class _DomainFormatter(formatters.StrFormatter):
+    def parse(self, value: t.Any) -> str:
+        if not isinstance(value, list) or len(value) != 2:
+            raise ValueError("cannot parse domain from malformed data")
+
+        tlsftp_server, gcs_manager_url = value
+
+        # if tlsftp_server is present, this is a GCS collection
+        # parse tlsftp_server in the format tlsftp://{domain}:{port}
+        if tlsftp_server:
+            assert isinstance(tlsftp_server, str)
+            return tlsftp_server[len("tlsftp://") :].split(":")[0]
+
+        # if gcs_manager_url present, but not tlsftp_server, this is a GCS endpoint
+        # parse gcs_manager_url in the format https://{domain}
+        elif gcs_manager_url:
+            assert isinstance(gcs_manager_url, str)
+            return gcs_manager_url[len("https://") :]
+
+        # entity type with no domain
+        else:
+            return str(None)
+
+
+DOMAIN_FIELD = Field(
+    "Domain", "[tlsftp_server, gcs_manager_url]", formatter=_DomainFormatter()
+)
+
+
 ENDPOINT_LIST_FIELDS = [
     Field("ID", "id"),
     Field("Owner", "owner_string"),
     Field("Display Name", "[display_name, canonical_name]", formatter=_NameFormatter()),
+    DOMAIN_FIELD,
 ]
 
 
 __all__ = (
     "ENDPOINT_LIST_FIELDS",
+    "DOMAIN_FIELD",
     "CustomTransferClient",
     "RecursiveLsResponse",
     "iterable_response_to_dict",

--- a/tests/functional/endpoint/test_endpoint_search.py
+++ b/tests/functional/endpoint/test_endpoint_search.py
@@ -15,13 +15,13 @@ def _make_mapped_collection_search_result(
     endpoint_id: str,
     display_name: str,
     owner_string: str,
+    manager_fqdn: str,
+    collection_fqdn: str,
 ) -> dict[str, t.Any]:
     # most of the fields are filled with dummy data
     # some of these values are pulled out here either to ensure their integrity
     # or to make them more visible to a reader
     username = "u_abcdefghijklmnop"  # not a real b32 username
-    manager_fqdn = "a0bc1.23de.data.globus.org"
-    collection_fqdn = f"m-f45678.{manager_fqdn}"
 
     data = {
         "DATA_TYPE": "endpoint",
@@ -123,6 +123,9 @@ def singular_search_response():
     endpoint_id = str(uuid.uuid4())
     display_name = "dummy result"
     owner_string = "globus@globus.org"
+    manager_fqdn = "a0bc1.23de.data.globus.org"
+    collection_fqdn = f"m-f45678.{manager_fqdn}"
+
     return RegisteredResponse(
         service="transfer",
         path="/v0.10/endpoint_search",
@@ -131,11 +134,17 @@ def singular_search_response():
             "endpoint_id": endpoint_id,
             "display_name": display_name,
             "owner_string": owner_string,
+            "collection_fqdn": collection_fqdn,
         },
         json={
             "DATA": [
                 _make_mapped_collection_search_result(
-                    collection_id, endpoint_id, display_name, owner_string
+                    collection_id,
+                    endpoint_id,
+                    display_name,
+                    owner_string,
+                    manager_fqdn,
+                    collection_fqdn,
                 )
             ],
             "DATA_TYPE": "endpoint_list",
@@ -162,20 +171,22 @@ def test_search_shows_collection_id(run_line, singular_search_response):
     header_line, separator_line, data_line = lines
 
     # the header line shows the field names in order
-    header_row = re.split(r"\s+\|\s+", header_line)
-    assert header_row == ["ID", "Owner", "Display Name"]
+    header_row = [header.strip() for header in re.split(r"\s+\|\s+", header_line)]
+    assert header_row == ["ID", "Owner", "Display Name", "Domain"]
     # the separator line is a series of dashes
+
     separator_row = separator_line.split("-+-")
-    assert len(separator_row) == 3
+    assert len(separator_row) == 4
     for separator in separator_row:
         assert set(separator) == {"-"}  # exactly one character is used
 
-    # the data row should have the collection ID, Owner, and Display Name
+    # the data row should have the collection ID, Owner, Display Name, and Domain
     data_row = re.split(r"\s+\|\s+", data_line)
     assert data_row == [
         meta["collection_id"],
         meta["owner_string"],
         meta["display_name"],
+        meta["collection_fqdn"],
     ]
 
     # final sanity check -- the endpoint ID for a mapped collection doesn't


### PR DESCRIPTION
SC: https://app.shortcut.com/globus/story/37370/add-domain-to-cli-output-for-endpoint-search

Adds a `Domain` field to `globus endpoint search` and `globus endpoint show` default output, which parses a GCS endpoint/collection's domain from either `gcs_manager_url` or `tlsftp_server` respectively.

One concern is that this can make search rows quite long, especially when the owner is a client id.
Not sure if we should just accept the longer lines, maybe drop the owner column from default output, or something else? I'll ask in the story.

```
$ globus endpoint search mapped
ID                                   | Owner                                                        | Display Name                            | Domain                              
------------------------------------ | ------------------------------------------------------------ | --------------------------------------- | ------------------------------------
ebf7d0c9-6193-479c-8fef-2b407f9b92be | eliaskhalaf@globusid.org                                     | 20250505 BOEM Test Mapped Collection    | m-ec4de8.fed3c5.0ec8.data.globus.org
80118b8a-1dca-4d22-9ea6-ce3df02964a2 | james@globus.org                                             | 250108-MapApp_TicketTesting-KUBE        | m-63110f.bca83d.0ec8.data.globus.org
9cc36aa9-c7db-4805-9515-5f9ab49ae362 | jkube@globusid.org                                           | 250324-POSIX-Mapped_TT388815            | m-9ce1c2.bca83d.0ec8.data.globus.org
d06f7ce1-1052-4795-9fa3-9f3b61d1850b | james@globus.org                                             | 250324-POSIX-Mapped_TT389145            | m-bdc2f7.bca83d.0ec8.data.globus.org
7e2e9db3-3dd1-452a-bd27-180b2a8215a6 | umn@globusid.org                                             | 3D Maps                                 | m-48d0d1.a7b581.bd7c.data.globus.org
18572f1e-b03a-488b-816d-44b5ca5b0089 | egsadmin@globusid.org                                        | AET Mapped Collection                   | m-48cbfa.250167.8443.gaccess.io     
04c9eeea-3ea0-4d99-852e-b89cb079fd92 | nisthpc@globusid.org                                         | AMBENCH2022-Mapped                      | m-31ded2.38d59.08cc.data.globus.org 
c5526cd9-b640-4ef5-b0e0-b5d620d46d8b | rs1@anl.gov                                                  | APS-Clutch-Mapped-Collection            | m-be7ace.5e4136.03c0.data.globus.org
3fea451d-397d-4ac3-825f-0d0b7a6acf59 | neranjan@gsu.edu                                             | ARCTIC DTN mapped                       | m-10e6ad.1d0f7a.0ec8.data.globus.org
3515a8ae-8754-4215-a66d-dadf576cb3ed | cb3399f0-6788-40cd-bc04-b659e8ff6170@clients.auth.globus.org | Basic mapped Collection                 | m-b0ef78.d872c.bd7c.data.globus.org 
54c3d55c-2ea1-45ba-b879-1e7a9a78f9de | milnes@pitt.edu                                              | BCRF Mapped Data                        | m-c9e925.8d93f.8443.data.globus.org 
38591e4d-4353-429a-a617-41accd7df435 | milnes@pitt.edu                                              | BCRF Mapped Dev Data                    | m-0925e9.8d93f.8443.data.globus.org 
d398373e-ece8-4162-95ad-3dd9686b42f5 | milnes@pitt.edu                                              | BCRF Mapped Example Data                | m-cfef42.8d93f.8443.data.globus.org 
d79dd131-4f87-4ba9-bf8f-8fa6ac9bf60a | 46cbf349-f210-4fa2-ac39-7d3fae5c6900@clients.auth.globus.org | brainmri - Mapped Collection            | m-b5c9c8.1a2d55.6fbd.dn.glob.us     
944a89d9-d648-4eba-a45a-124493cdebef | 9999baf7-947d-45bd-bfe0-28ab474a95c5@clients.auth.globus.org | BRAVE Mapped Collection                 | m-f16438.b0a4c2.bd7c.data.globus.org
d8167c82-8b6d-4755-9cb0-88922a64affa | 3ba902f2-1d0f-4299-a499-391e862ff213@clients.auth.globus.org | Brigitte GCSv5.4 mapped home            | m-d95652.e88e9.5898.data.globus.org 
1c79c9ad-7249-4b77-93c2-cad72154edd6 | 3ba902f2-1d0f-4299-a499-391e862ff213@clients.auth.globus.org | Brigitte GCSv5.4 mapped home HA SL      | m-8309a2.e88e9.5898.data.globus.org 
09939e9e-ac86-4a94-90d9-eb12d4d87a8b | braumann@globus.org                                          | Brigitte mapped S3                      | m-76f33a.e88e9.5898.data.globus.org 
21cfe84d-3b29-467e-94ec-dcfda9f057ac | 453b0f50-d70d-40ab-beb5-65e27341a0ad@clients.auth.globus.org | Canadian Light Source Mapped Collection | m-15995b.bb8eb4.09d9.dn.glob.us     
830329f3-df76-478f-a6b4-bb373bbe51c0 | 873f2fe6-33e1-41ed-b097-7b0f943a106b@clients.auth.globus.org | Cargo-DM-Guest-Mapped                   | m-95c70e.051a7.75bc.data.globus.org 
1ed0a573-315a-434e-936f-ee8fd4ae1092 | kmfernsler@lbl.gov                                           | Catscan Mapped Collection               | m-a5d908.d9cd4d.bd7c.data.globus.org
97410a6e-35fa-468b-968e-3673b4c01742 | kmfernsler@lbl.gov                                           | Catscan Mapped Collection Old           | m-067098.d9cd4d.bd7c.data.globus.org
7f1d684a-92a8-41fa-a342-832b0ec5b9cb | 9ecd26b4-cb93-44d9-a7e6-e25750482e59@clients.auth.globus.org | CFDE_Dev_MapCol                         | m-1132d.f19a4.5898.data.globus.org  
f04a5f55-bf45-4062-adb3-d2851c39a54e | alcf@globusid.org                                            | cfstest2_mapped_sharing                 | m-e16435.22164.03c0.data.globus.org 
090c7c58-d7eb-4acb-b8f3-a4e95b76ac37 | 79237b0f-c0ac-42df-8b28-e2177bb1d1c8@clients.auth.globus.org | Cloudian S3 Mapped Collection           | m-688f23.947b5.0ec8.data.globus.org
```