### PR TITLE
Run 'cov-report' in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
               - "3.13"
             tox-post-environments:
               - "py3.9-mindeps"
-              - "cov-report"
+              - "cov-report-ci"
             cache-key-prefix: "linux"
             cache-key-hash-files:
               - "pyproject.toml"
@@ -35,7 +35,7 @@ jobs:
             cpythons:
               - "3.13"
             tox-post-environments:
-              - "cov-report"
+              - "cov-report-ci"
             tox-environments-from-pythons: true
             cache-key-prefix: "macos"
             cache-key-hash-files:
@@ -46,7 +46,7 @@ jobs:
             cpythons:
               - "3.13"
             tox-post-environments:
-              - "cov-report"
+              - "cov-report-ci"
             tox-environments-from-pythons: true
             cache-key-prefix: "windows"
             cache-key-hash-files:

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,11 @@ base = cov
 commands_pre = coverage html --fail-under=0
 commands = coverage report
 depends = cov-combine
+[testenv:cov-report-ci]
+base = cov
+commands =
+    coverage combine
+    coverage report
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
This reports coverage info in CI output, and importantly checks the
fail-under value.
