### PR TITLE
Remove the legacy 'get_submission_id' mock

### DIFF
--- a/tests/files/api_fixtures/get_submission_id.yaml
+++ b/tests/files/api_fixtures/get_submission_id.yaml
@@ -1,6 +1,0 @@
-metadata:
-  submission_id: "5902daab-ffea-4e83-84f6-f69e5f8b7bb3"
-
-transfer:
-  - path: /v0.10/submission_id
-    json: {"value": "5902daab-ffea-4e83-84f6-f69e5f8b7bb3"}

--- a/tests/functional/task/test_task_submit.py
+++ b/tests/functional/task/test_task_submit.py
@@ -2,7 +2,7 @@ import json
 
 import globus_sdk
 import pytest
-from globus_sdk.testing import get_last_request, load_response, load_response_set
+from globus_sdk.testing import get_last_request, load_response
 
 
 def test_filter_rules(run_line, go_ep1_id, go_ep2_id):
@@ -10,8 +10,7 @@ def test_filter_rules(run_line, go_ep1_id, go_ep2_id):
     Submits two --exclude and two --include options on a transfer, confirms
     they show up the correct order in --dry-run output
     """
-    # put a submission ID and autoactivate response in place
-    load_response_set("cli.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
 
     result = run_line(
         "globus transfer -F json --dry-run -r "
@@ -55,9 +54,6 @@ def test_exclude_recursive(run_line, go_ep1_id, go_ep2_id):
     """
     Confirms using --exclude on non recursive transfers raises errors.
     """
-    # would be better if this could fail before we make any api calls, but
-    # we want to build the transfer_data object before we parse batch input
-    load_response_set("cli.get_submission_id")
     result = run_line(
         f"globus transfer --exclude *.txt {go_ep1_id}:/ {go_ep1_id}:/",
         assert_exit_code=2,
@@ -69,7 +65,6 @@ def test_exclude_recursive(run_line, go_ep1_id, go_ep2_id):
 
 
 def test_exclude_recursive_batch_stdin(run_line, go_ep1_id, go_ep2_id):
-    load_response_set("cli.get_submission_id")
     result = run_line(
         f"globus transfer --exclude *.txt --batch - {go_ep1_id}:/ {go_ep1_id}:/",
         stdin="abc /def\n",
@@ -82,7 +77,6 @@ def test_exclude_recursive_batch_stdin(run_line, go_ep1_id, go_ep2_id):
 
 
 def test_exclude_recursive_batch_file(run_line, go_ep1_id, go_ep2_id, tmp_path):
-    load_response_set("cli.get_submission_id")
     temp = tmp_path / "batch"
     temp.write_text("abc /def\n")
     result = run_line(
@@ -109,7 +103,7 @@ def test_transfer_local_user_opts(run_line, go_ep1_id, go_ep2_id):
     confirms --source-local-user and --destination-local-user are present in
     transfer dry-run output
     """
-    load_response_set("cli.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
 
     result = run_line(
         "globus transfer -F json --dry-run -r "
@@ -126,7 +120,7 @@ def test_delete_local_user(run_line, go_ep1_id):
     """
     Confirms --local-user is present in delete dry-run output.
     """
-    load_response_set("cli.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
 
     result = run_line(
         f"globus delete -F json --dry-run -r --local-user my-user {go_ep1_id}:/"
@@ -140,8 +134,6 @@ def test_rm_local_user(run_line, go_ep1_id):
     """
     Confirms --local-user is present in rm dry-run output.
     """
-    load_response_set("cli.get_submission_id")
-
     result = run_line(
         f"globus rm -F json --dry-run -r --local-user my-user {go_ep1_id}:/"
     )
@@ -155,7 +147,7 @@ def test_transfer_recursive_options(run_line, go_ep1_id, go_ep2_id, tmp_path):
     Confirm --recursive, --no-recursive, and omission of the --recursive option
     result in the expected values in the transfer item
     """
-    load_response_set("cli.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
 
     # --recursive should set the value to True
     result = run_line(

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -2,8 +2,9 @@ import os
 import re
 import uuid
 
+import globus_sdk
 import pytest
-from globus_sdk.testing import RegisteredResponse, load_response, load_response_set
+from globus_sdk.testing import RegisteredResponse, load_response
 
 
 def test_parsing(run_line):
@@ -86,9 +87,6 @@ def test_transfer_batch_stdin_dryrun(run_line, go_ep1_id, go_ep2_id, output_form
     """
     Dry-runs a transfer in batchmode, confirms batchmode inputs received.
     """
-    # put a submission ID response in place
-    load_response_set("cli.get_submission_id")
-
     batch_input = "abc /def\n/xyz p/q/r\n"
     result = run_line(
         f"globus transfer -F {output_format} --batch - "
@@ -107,8 +105,6 @@ def test_transfer_batch_stdin_dryrun(run_line, go_ep1_id, go_ep2_id, output_form
 
 
 def test_transfer_batch_file_dryrun(run_line, go_ep1_id, go_ep2_id, tmp_path):
-    # put a submission ID response in place
-    load_response_set("cli.get_submission_id")
     temp = tmp_path / "batch"
     temp.write_text("abc /def\n/xyz p/q/r\n")
     result = run_line(
@@ -133,9 +129,6 @@ def test_delete_batchmode_dryrun(run_line, go_ep1_id):
     """
     Dry-runs a delete in batchmode.
     """
-    # put a submission ID response in place
-    load_response_set("cli.get_submission_id")
-
     batch_input = "abc/def\n/xyz\nabcdef\nabc/def/../xyz\n"
     result = run_line(
         "globus delete --batch - --dry-run " + go_ep1_id, stdin=batch_input
@@ -226,7 +219,7 @@ def test_no_recursive_and_delete_exclusive(
     recursion_option,
     expected_error,
 ):
-    load_response("transfer.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
     load_response("transfer.submit_transfer")
     ep_meta = load_response("transfer.get_endpoint").metadata
     ep_id = ep_meta["endpoint_id"]

--- a/tests/functional/test_rm.py
+++ b/tests/functional/test_rm.py
@@ -1,7 +1,8 @@
 import json
 
+import globus_sdk
 import responses
-from globus_sdk.testing import load_response_set
+from globus_sdk.testing import load_response, load_response_set
 
 
 def _get_delete_call():
@@ -31,7 +32,7 @@ def test_recursive(run_line, go_ep1_id):
     Makes a dir on ep1, then --recursive rm's it.
     Confirms delete task was successful.
     """
-    load_response_set("cli.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
     load_response_set("cli.submit_delete_success")
 
     result = run_line(f"globus rm -r -F json {go_ep1_id}:/foo")
@@ -43,7 +44,7 @@ def test_no_file(run_line, go_ep1_id):
     """
     Attempts to remove a non-existent file. Confirms exit code 1.
     """
-    load_response_set("cli.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
     load_response_set("cli.submit_delete_failed")
 
     run_line(f"globus rm {go_ep1_id}:/nosuchfile.txt", assert_exit_code=1)
@@ -59,7 +60,7 @@ def test_ignore_missing(run_line, go_ep1_id):
     Attempts to remove a non-existent file path, with --ignore-missing.
     Confirms exit code 0 and silent output.
     """
-    load_response_set("cli.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
     load_response_set("cli.submit_delete_success")
 
     path = "/~/nofilehere.txt"
@@ -75,7 +76,7 @@ def test_timeout(run_line, go_ep1_id):
     """
     If a task is retrying without success, `rm` should wait and eventually time out.
     """
-    load_response_set("cli.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
     load_response_set("cli.submit_delete_queued")
 
     result = run_line(
@@ -91,7 +92,7 @@ def test_timeout_explicit_status(run_line, go_ep1_id):
     Confirms rm exits STATUS after given timeout, where
     STATUS is set via the --timeout-exit-code opt
     """
-    load_response_set("cli.get_submission_id")
+    load_response(globus_sdk.TransferClient.get_submission_id)
     load_response_set("cli.submit_delete_queued")
 
     status = 50


### PR DESCRIPTION
An old mock for `get_submission_id` (as a YAML file) was still in use.
However, `globus_sdk.testing` provides a mock for this API call which can
be switched to trivially.

Additionally, several tests were using the mock which no longer need it
due to changes in SDK behavior to defer the request for a submission ID
until it is actually needed.
