### PR TITLE
Update to use the Flows 'all' scope

### DIFF
--- a/changelog.d/20260108_115929_sirosen_use_the_flows_all_scope.md
+++ b/changelog.d/20260108_115929_sirosen_use_the_flows_all_scope.md
@@ -1,0 +1,3 @@
+### Other
+
+* The scopes used by the CLI for Flows service access have been updated to use the `all` scope.

--- a/src/globus_cli/login_manager/scopes.py
+++ b/src/globus_cli/login_manager/scopes.py
@@ -85,14 +85,11 @@ class _CLIScopeRequirements(t.Dict[ServiceNameLiteral, _ServiceRequirement]):
             ],
         }
         self["flows"] = {
-            "min_contract_version": 0,
+            "min_contract_version": 3,
             "resource_server": FlowsScopes.resource_server,
             "nice_server_name": "Globus Flows",
             "scopes": [
-                FlowsScopes.manage_flows,
-                FlowsScopes.view_flows,
-                FlowsScopes.run_status,
-                FlowsScopes.run_manage,
+                FlowsScopes.all,
             ],
         }
 
@@ -114,4 +111,4 @@ CLI_SCOPE_REQUIREMENTS = _CLIScopeRequirements()
 # version we were at when we got a token
 # it should be the max of the version numbers required by the various different
 # services
-CURRENT_SCOPE_CONTRACT_VERSION: t.Final[int] = 2
+CURRENT_SCOPE_CONTRACT_VERSION: t.Final[int] = 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,14 +127,7 @@ def mock_login_token_response():
             TimersScopes.resource_server, TimersScopes.timer
         ),
         "flows.globus.org": _mock_token_response_data(
-            "flows.globus.org",
-            scope=(
-                "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/manage_flows "  # noqa E501
-                "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/view_flows "  # noqa E501
-                "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run "  # noqa E501
-                "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run_status "  # noqa E501
-                "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run_manage "  # noqa E501
-            ),
+            "flows.globus.org", globus_sdk.FlowsClient.scopes.all
         ),
     }
     return mock_token_res


### PR DESCRIPTION
*I found this old branch of work while cleaning up personal unmerged branches. Opened as a draft to prompt discussion.*

Note: we could let this sit until we have a more significant CLI update to roll out, since it is mildly disruptive for Flows users.

---

This is defined to require a new login (`min_contract_version` is bumped
to 3) in order to ensure that all future interactions with Flows have
scopes matching what is listed in the code.

It would be possible to roll out this change without bumping the
contract-version, since no new permissions are needed in Flows. However,
that would leave us in a degraded state moving forward for development,
in which we wouldn't be able to assert that the tokens used by a CLI
instance really match what's listed in our application.
