### PR TITLE
Update MDDJ usage to v0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ typing = [
     "types-jmespath",
 ]
 check-project-metadata = [
-    "mddj==0.2.0",
+    "mddj==0.4.2",
     {include-group = "yaml"},
     "build",
     "twine",

--- a/scripts/ensure_min_python_is_tested.py
+++ b/scripts/ensure_min_python_is_tested.py
@@ -1,18 +1,16 @@
 # run via `tox r -e check-min-python-is-tested`
 import pathlib
-import subprocess
 import sys
 
+import mddj.api
 import ruamel.yaml
 
+dj = mddj.api.DJ()
 YAML = ruamel.yaml.YAML(typ="safe")
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 
-requires_python_version = subprocess.check_output(
-    ["python", "-m", "mddj", "read", "requires-python", "--lower-bound"],
-    cwd=REPO_ROOT,
-    text=True,
-).strip()
+requires_python_version = dj.read.requires_python(lower_bound=True)
+print("requires-python:", requires_python_version)
 
 with open(REPO_ROOT / ".github/workflows/test.yaml") as f:
     workflow = YAML.load(f)
@@ -40,13 +38,7 @@ if python_version != f"py{requires_python_version}":
     sys.exit(1)
 
 
-proc = subprocess.run(
-    ["python", "-m", "mddj", "read", "tox", "min-version"],
-    check=True,
-    capture_output=True,
-    cwd=REPO_ROOT,
-)
-tox_min_python_version = proc.stdout.decode().strip()
+tox_min_python_version = dj.read.tox.min_python_version()
 if tox_min_python_version != requires_python_version:
     print("ERROR: ensure_min_python_is_tested.py failed!")
     print(


### PR DESCRIPTION
We already applied this update in globus-sdk ; just reflect the improvement here.

---

`mddj.api` allows us to avoid subprocess calls, as it reads data directly in-process.
