### PR TITLE
Remove support for Python 3.9 (fix testing of 3.14)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,13 +18,13 @@ jobs:
           - name: "Linux"
             runner: "ubuntu-latest"
             cpythons:
-              - "3.9"
               - "3.10"
               - "3.11"
               - "3.12"
               - "3.13"
+              - "3.14"
             tox-post-environments:
-              - "py3.9-mindeps"
+              - "py3.10-mindeps"
               - "cov-report-ci"
             cache-key-prefix: "linux"
             cache-key-hash-files:
@@ -33,7 +33,7 @@ jobs:
           - name: "macOS"
             runner: "macos-latest"
             cpythons:
-              - "3.13"
+              - "3.14"
             tox-post-environments:
               - "cov-report-ci"
             tox-environments-from-pythons: true
@@ -44,7 +44,7 @@ jobs:
           - name: "Windows"
             runner: "windows-latest"
             cpythons:
-              - "3.13"
+              - "3.14"
             tox-post-environments:
               - "cov-report-ci"
             tox-environments-from-pythons: true
@@ -56,7 +56,7 @@ jobs:
             runner: "ubuntu-latest"
             cpythons:
               - "3.10"
-              - "3.13"
+              - "3.14"
             tox-environments:
               - "mypy-minpython"
               - "mypy-maxpython"

--- a/changelog.d/20260526_152541_sirosen_update_supported_pythons.md
+++ b/changelog.d/20260526_152541_sirosen_update_supported_pythons.md
@@ -1,0 +1,3 @@
+### Other
+
+* Removed support for Python 3.9 .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: POSIX",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "globus-sdk==4.6.0",
     "click>=8.1.4,<8.4",

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ envlist =
     check-sdist{,-minimum}
     reference
     cov-clean
-    py{3.14,3.13,3.12,3.11,3.10,3.9}
-    py3.9-mindeps
+    py{3.14,3.13,3.12,3.11,3.10}
+    py3.10-mindeps
     cov-combine
     cov-report
     mypy
@@ -27,16 +27,16 @@ dependency_groups = test
 commands = coverage run -m pytest {posargs}
 depends = cov-clean
 
-[testenv:py{3.9,3.10,3.11,3.12,3.13,3.14}]
+[testenv:py{3.10,3.11,3.12,3.13,3.14}]
 base = test_base
 description = Run the testsuite on Python {py_dot_ver}
 
-[testenv:py3.9-mindeps]
+[testenv:py3.10-mindeps]
 base = test_base
 description = Run the testsuite on our minimum dependency versions
 dependency_groups = test-mindeps
 
-[testenv:py{3.9,3.10,3.11,3.12,3.13,3.14}-sdkmain]
+[testenv:py{3.10,3.11,3.12,3.13,3.14}-sdkmain]
 base = test_base
 description = Run the testsuite on Python {py_dot_ver} against the latest globus-sdk pulled from git
 # tox-uv currently has a bug that erases the built wheel environment
@@ -46,7 +46,7 @@ wheel_build_env = build_wheel_sdkmain
 recreate = true
 deps = https://github.com/globus/globus-sdk-python/archive/main.tar.gz
 
-[testenv:py{3.9,3.10,3.11,3.12,3.13,3.14}-localsdk]
+[testenv:py{3.10,3.11,3.12,3.13,3.14}-localsdk]
 base = test_base
 description = Run the testsuite on Python {py_dot_ver} against a local clone of globus-sdk
 passenv = GLOBUS_SDK_PATH
@@ -72,7 +72,7 @@ commands = coverage erase
 base = cov_base
 description = Combine coverage data from parallel tests
 commands = coverage combine
-depends = py{3.13,3.12,3.11,3.10,3.9}{,-mindeps,-localsdk,-sdkmain}
+depends = py{3.14,3.13,3.12,3.11,3.10}{,-mindeps,-localsdk,-sdkmain}
 
 [testenv:cov-report]
 base = cov_base
@@ -111,12 +111,12 @@ description = Type check with mypy
 [testenv:mypy-minpython]
 base = mypy_base
 description = Type check with mypy for our minimum supported Python
-commands = mypy --python-version "3.9" {posargs:src/}
+commands = mypy --python-version "3.10" {posargs:src/}
 
 [testenv:mypy-maxpython]
 base = mypy_base
 description = Type check with mypy for our maximum supported Python
-commands = mypy --python-version "3.13" {posargs:src/}
+commands = mypy --python-version "3.14" {posargs:src/}
 
 
 # --- doc builds
@@ -132,13 +132,10 @@ commands = python ./reference/_generate.py {posargs}
 description = <base env for package and repo metadata checks>
 skip_install = true
 dependency_groups = check-project-metadata
-# NOTE: base_python should be the minimum supported Python for `minimum` envs
-# the tools in `check-project-metadata` require Python 3.10+
-# when we drop 3.9 support, this will become correct
 base_python =
     minimum: python3.10
     !minimum: python
-# Because we have chosen to cntrol the build environment ourselves, we need
+# Because we have chosen to control the build environment ourselves, we need
 # to explicitly install the build backend.
 deps =
     minimum: flit-core==3.11


### PR DESCRIPTION
- Update Requires-Python to '>=3.10'
- Remove 3.9 from all build matrix elements
- Update our "min" bounded builds to use 3.10
- Update build matrices to use 3.14 as our latest Python version -- this  was previously tested in local tox, but not in CI
- Update our classifiers to remove 3.9, add 3.14

---

:robot: _Note_: This PR was made with the assistance of a human brain inside of a gross puppet, moving various physical parts of the puppet by means of electrical impulses. :robot:
