### PR TITLE
Support explicit GLOBUS_CLI_FOLD_TABLES=1

### DIFF
--- a/changelog.d/20260611_125949_sirosen_fix_handling_of_truthy_fold_tables.md
+++ b/changelog.d/20260611_125949_sirosen_fix_handling_of_truthy_fold_tables.md
@@ -1,7 +1,7 @@
 ### Bugfixes
 
-* Fixed a bug in which TTY detection ran even when `GLOBUS_CLI_FOLD_TABLES=1`
-  is set.
+* Fixed a bug in which terminal device (TTY) detection ran even when
+  `GLOBUS_CLI_FOLD_TABLES=1` is set.
   Setting the variable to true now forces use of folded tables.
   Non-TTY output devices will be detected as having a fixed width of 80
   characters.

--- a/changelog.d/20260611_125949_sirosen_fix_handling_of_truthy_fold_tables.md
+++ b/changelog.d/20260611_125949_sirosen_fix_handling_of_truthy_fold_tables.md
@@ -1,0 +1,7 @@
+### Bugfixes
+
+* Fixed a bug in which TTY detection ran even when `GLOBUS_CLI_FOLD_TABLES=1`
+  is set.
+  Setting the variable to true now forces use of folded tables.
+  Non-TTY output devices will be detected as having a fixed width of 80
+  characters.

--- a/src/globus_cli/termio/_display.py
+++ b/src/globus_cli/termio/_display.py
@@ -178,8 +178,8 @@ class Renderer:
 
             _assert_iterable(data)
             if text_mode == self.TABLE:
-                if fold_tables():
-                    return FoldedTablePrinter(fields)
+                if (folding_enabled := fold_tables()) is not False:
+                    return FoldedTablePrinter(fields, folding_enabled=folding_enabled)
                 else:
                     return TablePrinter(fields)
             if text_mode == self.RECORD_LIST:

--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -112,4 +112,4 @@ def term_is_interactive() -> bool:
 
 def fold_tables() -> bool | None:
     val = os.getenv("GLOBUS_CLI_FOLD_TABLES")
-    return val is None or utils.str2bool(val)
+    return val if val is None else utils.str2bool(val)

--- a/src/globus_cli/termio/context.py
+++ b/src/globus_cli/termio/context.py
@@ -112,4 +112,4 @@ def term_is_interactive() -> bool:
 
 def fold_tables() -> bool | None:
     val = os.getenv("GLOBUS_CLI_FOLD_TABLES")
-    return val if val is None else utils.str2bool(val)
+    return None if val is None else utils.str2bool(val)

--- a/src/globus_cli/termio/printers/folded_table_printer.py
+++ b/src/globus_cli/termio/printers/folded_table_printer.py
@@ -82,12 +82,24 @@ class FoldedTablePrinter(Printer[t.Iterable[t.Any]]):
     Rows are folded and stacked only if they won't fit in the output width.
 
     :param fields: a list of Fields with load and render instructions; one per column.
+    :param width: the width to use for display (defaults to terminal width)
+    :param folding_enabled: explicitly force output to be folded or un-folded (defaults
+        to interactive terminal detection)
     """
 
-    def __init__(self, fields: t.Iterable[Field], width: int | None = None) -> None:
+    def __init__(
+        self,
+        fields: t.Iterable[Field],
+        width: int | None = None,
+        folding_enabled: bool | None = None,
+    ) -> None:
         self._fields = tuple(fields)
         self._width = width or _get_terminal_content_width()
-        self._folding_enabled = _detect_folding_enabled()
+        self._folding_enabled: bool = (
+            folding_enabled
+            if folding_enabled is not None
+            else _detect_folding_enabled()
+        )
 
     def echo(self, data: t.Iterable[t.Any], stream: t.IO[str] | None = None) -> None:
         """

--- a/tests/unit/termio/printer/test_folded_table_printer.py
+++ b/tests/unit/termio/printer/test_folded_table_printer.py
@@ -8,6 +8,31 @@ from globus_cli.termio.printers.folded_table_printer import Row, RowTable
 
 
 @pytest.mark.parametrize(
+    "init_setting, detection_result, expect_result",
+    (
+        pytest.param(True, False, True, id="override-true"),
+        pytest.param(False, True, False, id="override-false"),
+        pytest.param(None, True, True, id="detect-true"),
+        pytest.param(None, False, False, id="detect-true"),
+    ),
+)
+def test_folded_table_behavioral_flag_is_externally_controllable(
+    init_setting, detection_result, expect_result, monkeypatch
+):
+    monkeypatch.setattr(
+        "globus_cli.termio.printers.folded_table_printer._detect_folding_enabled",
+        lambda: detection_result,
+    )
+    fields = (
+        Field("Column A", "a"),
+        Field("Column B", "b"),
+    )
+
+    printer = FoldedTablePrinter(fields=fields, folding_enabled=init_setting)
+    assert printer._folding_enabled == expect_result
+
+
+@pytest.mark.parametrize(
     "folding_enabled, width",
     (
         (False, 10),


### PR DESCRIPTION
This is either a missing feature or a bugfix, depending on how you view it.
I can't recall if we thought explicitly about `GLOBUS_CLI_FOLD_TABLES=1` before, but I currently am of the mind that not respecting it is a bug.

I have verified that `GLOBUS_CLI_FOLD_TABLES=1 globus group list | cat` produces a (narrow) folded table.

---

This changeset intentionally does not touch the `GLOBUS_CLI_FOLD_TABLES=0` path, which uses the older/legacy table printer.
This was done to allow some escape-hatch if users' scripts need the old format exactly.
