### PR TITLE
Make table headers in folded tables bold

### DIFF
--- a/changelog.d/20260616_141229_sirosen_bold_table_headers.md
+++ b/changelog.d/20260616_141229_sirosen_bold_table_headers.md
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Folded table output will now have bolded headers in interactive terminals.

--- a/src/globus_cli/termio/printers/folded_table_printer.py
+++ b/src/globus_cli/termio/printers/folded_table_printer.py
@@ -117,7 +117,7 @@ class FoldedTablePrinter(Printer[t.Iterable[t.Any]]):
         if table.folded:
             echo(_separator_line(col_widths, row_type=SeparatorRowType.box_top))
         # print the header row and a separator
-        echo(table.header_row.serialize(col_widths))
+        echo(table.header_row.serialize(col_widths, bold=True))
         echo(
             _separator_line(
                 col_widths,
@@ -288,13 +288,13 @@ class Row:
             0, *(len(subrow[idx]) if idx < len(subrow) else 0 for subrow in self.grid)
         )
 
-    def serialize(self, use_col_widths: tuple[int, ...]) -> str:
+    def serialize(self, use_col_widths: tuple[int, ...], *, bold: bool = False) -> str:
         if len(self.grid) < 1:
             raise ValueError("Invalid state. Cannot serialize an empty row.")
 
         if len(self.grid) == 1:
             # format using ASCII characters (not folded)
-            return _format_subrow(self.grid[0], use_col_widths, "|", "", "")
+            return _format_subrow(self.grid[0], use_col_widths, "|", "", "", bold=bold)
 
         lines: list[str] = []
 
@@ -305,7 +305,9 @@ class Row:
             if i > 0:
                 lines.append(row_separator)
             # format using box drawing characters (part of folded output)
-            lines.append(_format_subrow(subrow, use_col_widths, "╎", "│ ", " │"))
+            lines.append(
+                _format_subrow(subrow, use_col_widths, "╎", "│ ", " │", bold=bold)
+            )
         return "\n".join(lines)
 
 
@@ -315,11 +317,23 @@ def _format_subrow(
     separator: str,
     leader: str,
     trailer: str,
+    bold: bool,
 ) -> str:
     line: list[str] = []
     for idx, width in enumerate(use_col_widths):
-        line.append((subrow[idx] if idx < len(subrow) else "").ljust(width))
+        line.append(
+            _format_element(subrow[idx], width, bold)
+            if idx < len(subrow)
+            else " " * width
+        )
     return leader + f" {separator} ".join(line) + trailer
+
+
+def _format_element(element: str, width: int, bold: bool) -> str:
+    if bold:
+        return f"\033[1m{element.ljust(width)}\033[0m"
+    else:
+        return element.ljust(width)
 
 
 @functools.cache

--- a/src/globus_cli/termio/printers/folded_table_printer.py
+++ b/src/globus_cli/termio/printers/folded_table_printer.py
@@ -331,7 +331,9 @@ def _format_subrow(
 
 def _format_element(element: str, width: int, bold: bool) -> str:
     if bold:
-        return f"\033[1m{element.ljust(width)}\033[0m"
+        start_bold = "\N{ESCAPE}[1m"
+        end_bold = "\N{ESCAPE}[0m"
+        return f"{start_bold}{element.ljust(width)}{end_bold}"
     else:
         return element.ljust(width)
 

--- a/tests/unit/termio/printer/test_folded_table_printer.py
+++ b/tests/unit/termio/printer/test_folded_table_printer.py
@@ -238,3 +238,39 @@ def test_row_table_width_computation_is_pessimal():
     # it should be the max width for each column (1000) + the width of separators (in
     # this case, 3 for the center divider)
     assert table.calculate_width() == 2003
+
+
+@pytest.mark.parametrize("folding_enabled", (False, True))
+def test_folded_table_printer_bolds_headers(monkeypatch, folding_enabled):
+    fields = (
+        Field("Column A", "a"),
+        Field("Column B", "b"),
+        Field("Column C", "c"),
+    )
+    data = ({"a": 1, "b": 2, "c": 3},)
+    printer = FoldedTablePrinter(fields=fields, width=1000)
+    # override detection, set by test
+    printer._folding_enabled = folding_enabled
+
+    capture = []
+
+    def echo_capture(s, file=None):
+        capture.append(s)
+
+    monkeypatch.setattr("click.echo", echo_capture)
+    printer.echo(data, None)
+
+    start_bold = "\N{ESCAPE}[1m"
+    end_bold = "\N{ESCAPE}[0m"
+
+    assert capture == [
+        (
+            f"{start_bold}Column A{end_bold} | "
+            f"{start_bold}Column B{end_bold} | "
+            f"{start_bold}Column C{end_bold}"
+        ),
+        # point of comparison for alignment:
+        # Column A | Column B | Column C
+        "---------+----------+---------",
+        "1        | 2        | 3       ",
+    ]


### PR DESCRIPTION
- rows can be bolded with ANSI escapes
- the header row passes `bold=True`

---

Sample output:
<img width="989" height="224" alt="image" src="https://github.com/user-attachments/assets/7b0c336c-234a-43ad-80c4-eb877beebd73" />