### PR TITLE
Fix a bug in 'get-identities' text output

### DIFF
--- a/changelog.d/20260706_105725_sirosen_fix_get_identities_case_sensitivity.md
+++ b/changelog.d/20260706_105725_sirosen_fix_get_identities_case_sensitivity.md
@@ -1,0 +1,4 @@
+### Bugfixes
+
+* Fixed `globus get-identities` to lowercase usernames and IDs before
+  comparisons for normal text output.

--- a/src/globus_cli/commands/get_identities.py
+++ b/src/globus_cli/commands/get_identities.py
@@ -80,15 +80,25 @@ def get_identities_command(
         Non-verbose text output is customized.
         """
 
-        def resolve_identity(value: dict[str, t.Any]) -> str:
+        def resolve_identity(value: str) -> str:
             """
-            Helper to deal with variable inputs and uncertain response order.
+            Given an input, resolve it to an output:
+
+            - IDs resolve to usernames
+            - Usernames resolve to IDs
+            - Missing values resolve to 'NO_SUCH_IDENTITY'
+            - Comparisons are all done lowercased
             """
+            value = value.lower()
             for identity in identities:
-                if identity["id"] == value:
-                    return t.cast(str, identity["username"])
-                if identity["username"] == value:
-                    return t.cast(str, identity["id"])
+                if identity["id"].lower() == value:
+                    username = identity["username"]
+                    if isinstance(username, str):
+                        return username
+                if identity["username"].lower() == value:
+                    identity_id = identity["id"]
+                    if isinstance(identity_id, str):
+                        return identity_id
             return "NO_SUCH_IDENTITY"
 
         # standard output is one resolved identity per line in the same order

--- a/tests/functional/test_get_identities.py
+++ b/tests/functional/test_get_identities.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 
 def test_get_identities_requires_at_least_one(run_line):
     result = run_line("globus get-identities", assert_exit_code=2)
@@ -87,3 +89,27 @@ def test_json(run_line, get_identities_mocker):
     output = json.loads(run_line("globus get-identities -F json " + user_id).output)
     for key in ["id", "username", "name", "organization", "email"]:
         assert meta[key] == output["identities"][0][key]
+
+
+@pytest.mark.parametrize("input_type", ("id", "username"))
+def test_case_insensitive_resolution(run_line, get_identities_mocker, input_type):
+    """
+    Runs get-identities with id username, duplicate and invalid inputs
+    Confirms order is preserved and all values are as expected
+    """
+    meta = get_identities_mocker.configure_one().metadata
+    username = meta["username"]
+    identity_id = meta["id"]
+
+    if input_type == "id":
+        result_upper = run_line(f"globus get-identities {username.upper()}")
+        result_lower = run_line(f"globus get-identities {username.lower()}")
+        assert result_upper.output == f"{identity_id}\n"
+    elif input_type == "username":
+        result_upper = run_line(f"globus get-identities {identity_id.upper()}")
+        result_lower = run_line(f"globus get-identities {identity_id.lower()}")
+        assert result_upper.output == f"{username}\n"
+    else:
+        raise NotImplementedError(input_type)
+
+    assert result_upper.output == result_lower.output


### PR DESCRIPTION
Globus Auth identity usernames are always lowercase. And identity IDs are
36-char represented UUIDs (meaning they are case insensitive).
However, comparisons for text output printing were done without
lowercasing or casefolding, resulting in incorrect failures to match on
usernames like 'Abc@example.com' vs 'abc@example.com'.

The behavior is fixed both for IDs and usernames, and a new test confirms
simply that uppercased and lowercased inputs result in the same outputs.

Additionally, some small type annotation fixes are made: a `str` was
annotated incorrectly as a dict, and `typing.cast` was used where
`isinstance` can provide a better runtime guarantee.
